### PR TITLE
Fixed buffer leak bug.

### DIFF
--- a/src/msgpack/unpack.hpp
+++ b/src/msgpack/unpack.hpp
@@ -226,12 +226,12 @@ inline bool unpacker::next(unpacked* result)
 	}
 
 	if(ret == 0) {
-		if (result->zone().get() != NULL) result->zone().reset();
+		result->zone().reset();
 		result->get() = object();
 		return false;
 
 	} else {
-		if (result->zone().get() != NULL) result->zone().reset( release_zone() );
+		result->zone().reset( release_zone() );
 		result->get() = data();
 		reset();
 		return true;


### PR DESCRIPTION
In the case of the function next() returns true:
  Whichever the argument result is holding the zone or not, the ownership of the zone always should be delegated from 'unpacker' to 'unpacked'.

In the case of the function next() returns false:
  Whichever the argument result is holding the zone or not, the members of 'unpacked' should be reset.
