### PR TITLE
Fixed an unused function warning.

### DIFF
--- a/src/unpack.c
+++ b/src/unpack.c
@@ -462,7 +462,9 @@ bool msgpack_unpack_next(msgpack_unpacked* result,
 	return true;
 }
 
+#if defined(MSGPACK_OLD_COMPILER_BUS_ERROR_WORKAROUND)
 // FIXME: Dirty hack to avoid a bus error caused by OS X's old gcc.
 static void dummy_function_to_avoid_bus_error()
 {
 }
+#endif


### PR DESCRIPTION
This fix is a part of issue #33.
https://github.com/snej/msgpack-c/commit/35ba41c24503ec934b1cb181a979459644242a01
