### PR TITLE
Fix up README, include accurate instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,73 +1,134 @@
-MessagePack for C/C++
-=====================
+# Msgpack for C/C++
+It's like JSON but small and fast.
+
+## Overview
+
+MessagePack is an efficient binary serialization format. It lets you exchange data among multiple languages like JSON. But it's faster and smaller. Small integers are encoded into a single byte, and typical short strings require only one extra byte in addition to the strings themselves.
 Binary-based efficient object serialization library.
 
 
-## Installation
+## License
 
-Download latest package from [releases of MessagePack](http://sourceforge.net/projects/msgpack/files/) and extract it.
-
-On UNIX-like platform, run ./configure && make && sudo make install:
-
-    $ ./configure
-    $ make
-    $ sudo make install
-
-On Windows, open msgpack_vc8.vcproj or msgpack_vc2008 file and build it using batch build. DLLs are built on lib folder,
-and the headers are built on include folder.
-
-To use the library in your program, include msgpack.hpp header and link "msgpack" library.
+Msgpack is Copyright (C) 2008-2010 FURUHASHI Sadayuki and licensed under the Apache License, Version 2.0 (the "License"). For details see the `COPYING` file in this directory.
 
 
-## Example
+## Contributing
+
+The source for msgpack-c is held at [msgpack-c](https://github.com/msgpack/msgpack-c) github.com site.
+
+To report an issue, use the [msgpack-c issue tracker](https://github.com/msgpack/msgpack-c/issues) at github.com.
+
+
+## Using Msgpack
+
+### Building and Installing
+
+#### Install from git repository
+
+You will need gcc (4.1.0 or higher), autotools.
+
+```
+$ git clone https://github.com/msgpack/msgpack-c.git
+$ cd msgpack-c
+$ ./bootstrap
+$ ./configure
+$ make
+$ sudo make install
+```
+
+#### Install from package
+
+##### UNIX-like platform with ./configure
+
+On typical UNIX-like platforms, download source package from [Releases|http://msgpack.org/releases/cpp/] and run `./configure && make && make install`. Example:
+
+```
+$ wget http://msgpack.org/releases/cpp/msgpack-0.5.5.tar.gz
+$ tar zxvf msgpack-0.5.5.tar.gz
+$ cd msgpack-0.5.5
+$ ./configure
+$ make
+$ sudo make install
+```
+
+##### FreeBSD with Ports Collection
+
+On FreeBSD, you can use Ports Collection. Install [net/msgpack|http://www.freebsd.org/cgi/cvsweb.cgi/ports/devel/msgpack/] package.
+
+
+##### Gentoo Linux with Portage
+
+On Gentoo Linux, you can use emerge. Install [dev-libs/msgpack|http://gentoo-portage.com/dev-libs/msgpack] package.
+
+
+##### Mac OS X with MacPorts
+
+On Mac OS X, you can install MessagePack for C using MacPorts.
+
+```
+$ sudo port install msgpack
+```
+
+You might need to run `sudo port selfupdate` before installing to update the package repository.
+
+You can also install via Homebrew.
+
+```
+$ sudo brew install msgpack
+```
+
+
+##### Windows
+
+On Windows, download source package from [here|https://sourceforge.net/projects/msgpack/files/] and extract it. Open `msgpack_vc8.vcproj` or msgpack_vc2008 file and build it using batch build. It builds libraries in `lib/` folder and header files in `include/` folder.
+
+You can build using command line as follows:
+
+```
+> vcbuild msgpack_vc2008.vcproj
+> dir lib       % DLL files are here
+> dir include   % header files are here
+```
+
+
+### Linking with an Application
+
+Include `msgpack.hpp` (or `msgpack.h` for C) in your application and link with libmsgpack. Here is a typical gcc link command:
+
+    gcc -lmsgpack myapp.c -o myapp
+
+
+### Code Example
 ```CPP
 #include <msgpack.hpp>
 #include <vector>
-    
+
 int main(void) {
     // This is target object.
     std::vector<std::string> target;
     target.push_back("Hello,");
     target.push_back("World!");
-    
+
     // Serialize it.
     msgpack::sbuffer sbuf;  // simple buffer
     msgpack::pack(&sbuf, target);
-    
+
     // Deserialize the serialized data.
     msgpack::unpacked msg;    // includes memory pool and deserialized object
     msgpack::unpack(&msg, sbuf.data(), sbuf.size());
     msgpack::object obj = msg.get();
-    
+
     // Print the deserialized object to stdout.
     std::cout << obj << std::endl;    // ["Hello," "World!"]
-    
+
     // Convert the deserialized object to staticaly typed object.
     std::vector<std::string> result;
     obj.convert(&result);
-    
+
     // If the type is mismatched, it throws msgpack::type_error.
     obj.as<int>();  // type is mismatched, msgpack::type_error is thrown
 }
 ```
+### Quickstart Guides
 
-See [QuickStart for C](QUICKSTART-C.md) and [QuickStart for C++](QUICKSTART-CPP.md) for other example codes.
-
-## License
-
-    Copyright (C) 2008-2010 FURUHASHI Sadayuki
-    
-       Licensed under the Apache License, Version 2.0 (the "License");
-       you may not use this file except in compliance with the License.
-       You may obtain a copy of the License at
-    
-           http://www.apache.org/licenses/LICENSE-2.0
-    
-       Unless required by applicable law or agreed to in writing, software
-       distributed under the License is distributed on an "AS IS" BASIS,
-       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-       See the License for the specific language governing permissions and
-       limitations under the License.
-
-See also NOTICE file.
-
+For more detailed examples see [QuickStart for C](QUICKSTART-C.md) and [QuickStart for C++](QUICKSTART-CPP.md).


### PR DESCRIPTION
The instructions in the current github landing page (README.md) cause problems for people trying to install msgpack. The instructions are missing the call out to run the `bootstrap` script. This is highlighted in #16 about 6 months ago.

This pull request generally cleans up the README.md file and includes accurate installation instructions.
