### PR TITLE
This patch fixes a type conversion warning in clang 5 when compiling for arm64 targets

### DIFF
--- a/src/msgpack/pack.h
+++ b/src/msgpack/pack.h
@@ -40,7 +40,7 @@ extern "C" {
  * @{
  */
 
-typedef int (*msgpack_packer_write)(void* data, const char* buf, unsigned int len);
+typedef int (*msgpack_packer_write)(void* data, const char* buf, size_t len);
 
 typedef struct msgpack_packer {
 	void* data;


### PR DESCRIPTION
```
$ clang --version
Apple LLVM version 5.0 (clang-500.2.79) (based on LLVM 3.3svn)
Target: x86_64-apple-darwin13.0.0
Thread model: posix

```

```

In file included from /Users/drew/Dropbox/Code/caffeine-ios/ext/msgpack/src/msgpack/pack.h:120:
/Users/drew/Dropbox/Code/caffeine-ios/ext/msgpack/src/msgpack/pack_template.h:773:57: warning: implicit conversion loses integer precision: 'size_t' (aka 'unsigned long') to 'unsigned int' [-Wshorten-64-to-32]
        msgpack_pack_append_buffer(x, (const unsigned char*)b, l);
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
In file included from /Users/drew/Dropbox/Code/caffeine-ios/ext/msgpack/src/objectc.c:19:
/Users/drew/Dropbox/Code/caffeine-ios/ext/msgpack/src/msgpack/pack.h:118:61: note: expanded from macro 'msgpack_pack_append_buffer'
        return (*(user)->callback)((user)->data, (const char*)buf, len)
                                                                   ^
1 warning generated.
```

This patch is provided under the Apache License version 2.
