### PR TITLE
Removed C++11 features

### DIFF
--- a/test/msgpack_test.cpp
+++ b/test/msgpack_test.cpp
@@ -7,7 +7,7 @@
 #include <deque>
 #include <set>
 #include <list>
-#include <type_traits>
+#include <limits>
 
 #include <gtest/gtest.h>
 
@@ -199,7 +199,7 @@ TYPED_TEST_P(IntegerToFloatingPointTest, simple_buffer)
   vector<integer_type> v;
   v.push_back(0);
   v.push_back(1);
-  if (is_signed<integer_type>::value) v.push_back(-1);
+  if (numeric_limits<integer_type>::is_signed) v.push_back(-1);
   else v.push_back(2);
   v.push_back(numeric_limits<integer_type>::min());
   v.push_back(numeric_limits<integer_type>::max());


### PR DESCRIPTION
C++11 features are used on the following commit:
https://github.com/msgpack/msgpack-c/commit/97a7b7545a529bc29e1cb444b446ccac9883b316
http://www.cplusplus.com/reference/type_traits/is_signed/?kw=is_signed

I got a compile error when I did 'make check' when I configured with CXXFLAGS="-std=c++03".
# include <limits> is not mandatory because other header files include that. But it helps readability of the code.

http://www.cplusplus.com/reference/limits/numeric_limits/?kw=numeric_limits
