### PR TITLE
Fixed dereferencing type-punned pointer will break strict-aliasing rules warning

### DIFF
--- a/test/msgpack_test.cpp
+++ b/test/msgpack_test.cpp
@@ -843,8 +843,10 @@ public:
   TestEnumType t2;
   TestEnumType t3;
 
-  MSGPACK_DEFINE((int&)t1, (int&)t2, (int&)t3);
+  MSGPACK_DEFINE(t1, t2, t3);
 };
+
+MSGPACK_ADD_ENUM(TestEnumMemberClass::TestEnumType);
 
 TEST(MSGPACK_USER_DEFINED, simple_buffer_enum_member)
 {


### PR DESCRIPTION
When I did 'make check' on gcc, I got the following warning:

```
msgpack_test.cpp: メンバ関数 ‘void TestEnumMemberClass::msgpack_unpack(const msgpack::object&)’ 内:
msgpack_test.cpp:846:24: 警告: dereferencing type-punned pointer will break strict-aliasing rules [-Wstrict-aliasing]
   MSGPACK_DEFINE((int&)t1, (int&)t2, (int&)t3);
                        ^
../src/msgpack/type/define.hpp:29:30: 備考: in definition of macro ‘MSGPACK_DEFINE’
   msgpack::type::make_define(__VA_ARGS__).msgpack_unpack(o); \
```

I believe that we should use MSGPACK_ADD_ENUM macro instead of casting to int&.
