### PR TITLE
Fix to allow projects to compile with -Wconversion

### DIFF
--- a/src/msgpack/vrefbuffer.h
+++ b/src/msgpack/vrefbuffer.h
@@ -131,7 +131,7 @@ static inline const struct iovec* msgpack_vrefbuffer_vec(const msgpack_vrefbuffe
 
 static inline size_t msgpack_vrefbuffer_veclen(const msgpack_vrefbuffer* vref)
 {
-	return vref->tail - vref->array;
+	return (size_t)(vref->tail - vref->array);
 }
 
 

--- a/src/unpack.c
+++ b/src/unpack.c
@@ -71,19 +71,19 @@ static inline int template_callback_uint64(unpack_user* u, uint64_t d, msgpack_o
 { o->type = MSGPACK_OBJECT_POSITIVE_INTEGER; o->via.u64 = d; return 0; }
 
 static inline int template_callback_int8(unpack_user* u, int8_t d, msgpack_object* o)
-{ if(d >= 0) { o->type = MSGPACK_OBJECT_POSITIVE_INTEGER; o->via.u64 = d; return 0; }
+{ if(d >= 0) { o->type = MSGPACK_OBJECT_POSITIVE_INTEGER; o->via.u64 = (uint64_t)d; return 0; }
 		else { o->type = MSGPACK_OBJECT_NEGATIVE_INTEGER; o->via.i64 = d; return 0; } }
 
 static inline int template_callback_int16(unpack_user* u, int16_t d, msgpack_object* o)
-{ if(d >= 0) { o->type = MSGPACK_OBJECT_POSITIVE_INTEGER; o->via.u64 = d; return 0; }
+{ if(d >= 0) { o->type = MSGPACK_OBJECT_POSITIVE_INTEGER; o->via.u64 = (uint64_t)d; return 0; }
 		else { o->type = MSGPACK_OBJECT_NEGATIVE_INTEGER; o->via.i64 = d; return 0; } }
 
 static inline int template_callback_int32(unpack_user* u, int32_t d, msgpack_object* o)
-{ if(d >= 0) { o->type = MSGPACK_OBJECT_POSITIVE_INTEGER; o->via.u64 = d; return 0; }
+{ if(d >= 0) { o->type = MSGPACK_OBJECT_POSITIVE_INTEGER; o->via.u64 = (uint64_t)d; return 0; }
 		else { o->type = MSGPACK_OBJECT_NEGATIVE_INTEGER; o->via.i64 = d; return 0; } }
 
 static inline int template_callback_int64(unpack_user* u, int64_t d, msgpack_object* o)
-{ if(d >= 0) { o->type = MSGPACK_OBJECT_POSITIVE_INTEGER; o->via.u64 = d; return 0; }
+{ if(d >= 0) { o->type = MSGPACK_OBJECT_POSITIVE_INTEGER; o->via.u64 = (uint64_t)d; return 0; }
 		else { o->type = MSGPACK_OBJECT_NEGATIVE_INTEGER; o->via.i64 = d; return 0; } }
 
 static inline int template_callback_float(unpack_user* u, float d, msgpack_object* o)

--- a/src/vrefbuffer.c
+++ b/src/vrefbuffer.c
@@ -98,7 +98,7 @@ int msgpack_vrefbuffer_append_ref(msgpack_vrefbuffer* vbuf,
 		const char* buf, size_t len)
 {
 	if(vbuf->tail == vbuf->end) {
-		const size_t nused = vbuf->tail - vbuf->array;
+		const size_t nused = (size_t)(vbuf->tail - vbuf->array);
 		const size_t nnext = nused * 2;
 
 		struct iovec* nvec = (struct iovec*)realloc(
@@ -169,11 +169,11 @@ int msgpack_vrefbuffer_migrate(msgpack_vrefbuffer* vbuf, msgpack_vrefbuffer* to)
 	empty->next = NULL;
 
 
-	const size_t nused = vbuf->tail - vbuf->array;
+	const size_t nused = (size_t)(vbuf->tail - vbuf->array);
 	if(to->tail + nused < vbuf->end) {
-		const size_t tosize = to->tail - to->array;
+		const size_t tosize = (size_t)(to->tail - to->array);
 		const size_t reqsize = nused + tosize;
-		size_t nnext = (to->end - to->array) * 2;
+		size_t nnext = (size_t)(to->end - to->array) * 2;
 		while(nnext < reqsize) {
 			nnext *= 2;
 		}

--- a/src/zone.c
+++ b/src/zone.c
@@ -127,7 +127,7 @@ bool msgpack_zone_push_finalizer_expand(msgpack_zone* zone,
 {
 	msgpack_zone_finalizer_array* const fa = &zone->finalizer_array;
 
-	const size_t nused = fa->end - fa->array;
+	const size_t nused = (size_t)(fa->end - fa->array);
 
 	size_t nnext;
 	if(nused == 0) {


### PR DESCRIPTION
Projects that use `-Wconversion` don't compile due to errors in msgpack header
files. This commit fixes all the errors in msgpack-c for when `-Wconversion` is
enabled.

Now I can even compile msgpack-c itself with `-Wconversion` and all my projects:

```
CFLAGS=-Wconversion ./configure
make
```
