### PR TITLE
fix type bool and inline specifier

### DIFF
--- a/src/msgpack.h
+++ b/src/msgpack.h
@@ -20,6 +20,19 @@
  * @{
  * @}
  */
+#if !defined(__cplusplus) && defined(_MSC_VER)
+#if !defined(FALSE)
+#define FALSE (0)
+#endif
+#if !defined(TRUE)
+#define TRUE (!FALSE)
+#endif
+#define bool int
+#define true TRUE
+#define false FALSE
+#define inline __inline
+#endif
+
 #include "msgpack/object.h"
 #include "msgpack/zone.h"
 #include "msgpack/pack.h"


### PR DESCRIPTION
For a pure C compilation with MSVC type bool is not available. Not tested with other targets (Mingw, cygwin). Thats why it is only active if `_MSC_VER` is defined. So not sure if the bool fix should be also applied to other targets.

For MSVC the inline specifier is not valid and must be named __inline (or _inline).
