### PR TITLE
Fix test failure regarding int->float conversion

### DIFF
--- a/test/msgpack_test.cpp
+++ b/test/msgpack_test.cpp
@@ -201,10 +201,8 @@ TYPED_TEST_P(IntegerToFloatingPointTest, simple_buffer)
   v.push_back(1);
   if (numeric_limits<integer_type>::is_signed) v.push_back(-1);
   else v.push_back(2);
-  v.push_back(numeric_limits<integer_type>::min());
-  v.push_back(numeric_limits<integer_type>::max());
   for (unsigned int i = 0; i < kLoop; i++) {
-    v.push_back(rand());
+    v.push_back(rand() % 0x7FFFFF);
   }
   for (unsigned int i = 0; i < v.size() ; i++) {
     msgpack::sbuffer sbuf;


### PR DESCRIPTION
Supply only small integers (< 1^24) to int->float conversion tests,
so they can roundtrip without error.

I got a failure building 0.5.9 in Fedora:
http://koji.fedoraproject.org/koji/buildinfo?buildID=543205
.
[----------] 1 test from IntegerToFloatingPointTestInstance/IntegerToFloatingPointTest/0, where TypeParam = (anonymous namespace)::TypePair<float, long long>
[ RUN      ] IntegerToFloatingPointTestInstance/IntegerToFloatingPointTest/0.simple_buffer
msgpack_test.cpp:220: Failure
Value of: fabs(val2 - val1) <= kEPS
  Actual: false
Expected: true

The test supplies large integers which do not fit in the float significand and thus cause rounding error.  How about limiting the input values to 0 < x < 1^24?
