### PR TITLE
Add inline for ODR compliance.

### DIFF
--- a/include/msgpack/object.hpp
+++ b/include/msgpack/object.hpp
@@ -468,7 +468,7 @@ packer<Stream>& operator<< (packer<Stream>& o, const object& v)
     }
 }
 
-std::ostream& operator<< (std::ostream& s, const object& o)
+inline std::ostream& operator<< (std::ostream& s, const object& o)
 {
     switch(o.type) {
     case type::NIL:


### PR DESCRIPTION
> libSocket.a(Socket.cpp.o): In function `std::iterator_traits<char*>::iterator_category std::__iterator_category<char*>(char* const&)`:
> **/usr/local/include/msgpack/object.hpp:472**: multiple definition of `msgpack::operator<<(std::ostream&, msgpack::object const&)`
> CMakeFiles/cvim.dir/main.cpp.o:**/usr/local/include/msgpack/object.hpp:472**: first defined here
> collect2: error: ld returned 1 exit status

^ Fixes this bug from my project ^
