### PR TITLE
vector<char> is mapped to BIN

### DIFF
--- a/include/msgpack/adaptor/vector_char.hpp
+++ b/include/msgpack/adaptor/vector_char.hpp
@@ -1,0 +1,72 @@
+//
+// MessagePack for C++ static resolution routine
+//
+// Copyright (C) 2014 KONDO Takatoshi
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+#ifndef MSGPACK_TYPE_VECTOR_CHAR_HPP
+#define MSGPACK_TYPE_VECTOR_CHAR_HPP
+
+#include "msgpack/object.hpp"
+#include <vector>
+
+namespace msgpack {
+
+inline std::vector<char>& operator>> (object const& o, std::vector<char>& v)
+{
+    switch (o.type) {
+    case type::BIN:
+        v.resize(o.via.bin.size);
+        std::memcpy(v.data(), o.via.bin.ptr, o.via.bin.size);
+        break;
+    case type::STR:
+        v.resize(o.via.str.size);
+        std::memcpy(v.data(), o.via.str.ptr, o.via.str.size);
+        break;
+    default:
+        throw type_error();
+        break;
+    }
+    return v;
+}
+
+template <typename Stream>
+inline packer<Stream>& operator<< (packer<Stream>& o, const std::vector<char>& v)
+{
+    o.pack_bin(v.size());
+    o.pack_bin_body(v.data(), v.size());
+
+    return o;
+}
+
+inline void operator<< (object& o, const std::vector<char>& v)
+{
+    o.type = type::BIN;
+    o.via.bin.ptr = v.data();
+    o.via.bin.size = static_cast<uint32_t>(v.size());
+}
+
+inline void operator<< (object::with_zone& o, const std::vector<char>& v)
+{
+    o.type = type::BIN;
+    char* ptr = static_cast<char*>(o.zone->allocate_align(v.size()));
+    o.via.bin.ptr = ptr;
+    o.via.bin.size = static_cast<uint32_t>(v.size());
+    std::memcpy(ptr, v.data(), v.size());
+}
+
+}  // namespace msgpack
+
+#endif // MSGPACK_TYPE_VECTOR_CHAR_HPP
+

--- a/include/msgpack/type.hpp
+++ b/include/msgpack/type.hpp
@@ -12,6 +12,7 @@
 #include "adaptor/set.hpp"
 #include "adaptor/string.hpp"
 #include "adaptor/vector.hpp"
+#include "adaptor/vector_char.hpp"
 #include "adaptor/msgpack_tuple.hpp"
 #include "adaptor/define.hpp"
 #include "adaptor/tr1/unordered_map.hpp"

--- a/test/msgpack_test.cpp
+++ b/test/msgpack_test.cpp
@@ -288,6 +288,7 @@ TEST(MSGPACK_STL, simple_buffer_string)
     msgpack::pack(sbuf, val1);
     msgpack::unpacked ret;
     msgpack::unpack(ret, sbuf.data(), sbuf.size());
+    EXPECT_EQ(ret.get().type, msgpack::type::STR);
     string val2 = ret.get().as<string>();
     EXPECT_EQ(val1.size(), val2.size());
     EXPECT_EQ(val1, val2);
@@ -304,7 +305,25 @@ TEST(MSGPACK_STL, simple_buffer_vector)
     msgpack::pack(sbuf, val1);
     msgpack::unpacked ret;
     msgpack::unpack(ret, sbuf.data(), sbuf.size());
+    EXPECT_EQ(ret.get().type, msgpack::type::ARRAY);
     vector<int> val2 = ret.get().as<vector<int> >();
+    EXPECT_EQ(val1.size(), val2.size());
+    EXPECT_TRUE(equal(val1.begin(), val1.end(), val2.begin()));
+  }
+}
+
+TEST(MSGPACK_STL, simple_buffer_vector_char)
+{
+  for (unsigned int k = 0; k < kLoop; k++) {
+    vector<char> val1;
+    for (unsigned int i = 0; i < kElements; i++)
+      val1.push_back(rand());
+    msgpack::sbuffer sbuf;
+    msgpack::pack(sbuf, val1);
+    msgpack::unpacked ret;
+    msgpack::unpack(ret, sbuf.data(), sbuf.size());
+    EXPECT_EQ(ret.get().type, msgpack::type::BIN);
+    vector<char> val2 = ret.get().as<vector<char> >();
     EXPECT_EQ(val1.size(), val2.size());
     EXPECT_TRUE(equal(val1.begin(), val1.end(), val2.begin()));
   }


### PR DESCRIPTION
Added the new mapping:
  std::vector<char> is mapped to BIN.

So, currently BIN, STR, and ARRAY mappings are as follows:
  std::vector<char> is mapped to BIN
  std::string       is mapped to STR
  std::vector<T>    is mapped to ARRAY // T is not char

This is a PR for poc/0.6. It is a breaking change so I'd like to have a discussion. The new msgpack format supports BIN and STR. BIN is binary. STR is UTF-8 string. https://github.com/msgpack/msgpack/blob/master/spec.md

C++ doesn't have UTF-8 string type. When users pack std::string, there are two design choice. Those are BIN or STR. I've chosen STR. This is not a part of this PR. That have already committed. 

How about BIN? I believe that std::vector<char> is suitable type to map to BIN. So I created the PR. Someone might consider that std::vectorstd::uint8_t is good. However, I don't think so. C++ uses char as binary byte data like as ostream::write:
http://www.cplusplus.com/reference/ostream/ostream/write/?kw=write

There is another design choice. That is, no direct type mapping to BIN. Users always call the following functions when they want to map tp BIN:

``` C++
    o.pack_bin(v.size());
    o.pack_bin_body(v.data(), v.size());
```

I think that it is convenient providing some direct mapped type to BIN, and that is std::vector<char>.

Any ideas?

If there is no strong against opinion, I will merge the PR.
