### PR TITLE
Fixed out of source cmake builds to work correctly.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,7 +158,7 @@ ENDIF ()
 INSTALL (TARGETS msgpack msgpack-static DESTINATION lib)
 INSTALL (DIRECTORY src/msgpack DESTINATION include)
 INSTALL (FILES src/msgpack.h src/msgpack.hpp DESTINATION include)
-INSTALL (FILES msgpack.pc DESTINATION lib/pkgconfig)
+INSTALL (FILES ${CMAKE_CURRENT_BINARY_DIR}/msgpack.pc DESTINATION lib/pkgconfig)
 
 # Doxygen
 FIND_PACKAGE (Doxygen)


### PR DESCRIPTION
The out of source cmake build was not working correctly. In particular,
the main CMakeLists.txt was not installing from the correct location.
In the case of msgpack.pc, it was trying to install from the top repo
directory instead of from the cmake build directory. So you can now
build as follows:

```
$ cd msgpack-c
$ mkdir build
$ cd build
$ cmake ../
$ make
$ make install
```
