### PR TITLE
Fixed https://github.com/msgpack/msgpack-c/issues/76

### DIFF
--- a/include/msgpack/adaptor/map.hpp
+++ b/include/msgpack/adaptor/map.hpp
@@ -99,18 +99,20 @@ inline object const& operator>> (object const& o, std::map<K, V>& v)
     if(o.type != type::MAP) { throw type_error(); }
     object_kv* p(o.via.map.ptr);
     object_kv* const pend(o.via.map.ptr + o.via.map.size);
+    std::map<K, V> tmp;
     for(; p != pend; ++p) {
         K key;
         p->key.convert(key);
-        typename std::map<K,V>::iterator it(v.lower_bound(key));
-        if(it != v.end() && !(key < it->first)) {
+        typename std::map<K,V>::iterator it(tmp.lower_bound(key));
+        if(it != tmp.end() && !(key < it->first)) {
             p->val.convert(it->second);
         } else {
             V val;
             p->val.convert(val);
-            v.insert(it, std::pair<K,V>(key, val));
+            tmp.insert(it, std::pair<K,V>(key, val));
         }
     }
+    tmp.swap(v);
     return o;
 }
 
@@ -155,12 +157,14 @@ inline object const& operator>> (object const& o, std::multimap<K, V>& v)
     if(o.type != type::MAP) { throw type_error(); }
     object_kv* p(o.via.map.ptr);
     object_kv* const pend(o.via.map.ptr + o.via.map.size);
+    std::multimap<K, V> tmp;
     for(; p != pend; ++p) {
         std::pair<K, V> value;
         p->key.convert(value.first);
         p->val.convert(value.second);
-        v.insert(value);
+        tmp.insert(value);
     }
+    tmp.swap(v);
     return o;
 }
 

--- a/include/msgpack/adaptor/set.hpp
+++ b/include/msgpack/adaptor/set.hpp
@@ -30,10 +30,12 @@ inline object const& operator>> (object const& o, std::set<T>& v)
     if(o.type != type::ARRAY) { throw type_error(); }
     object* p = o.via.array.ptr + o.via.array.size;
     object* const pbegin = o.via.array.ptr;
+    std::set<T> tmp;
     while(p > pbegin) {
         --p;
-        v.insert(p->as<T>());
+        tmp.insert(p->as<T>());
     }
+    tmp.swap(v);
     return o;
 }
 
@@ -76,10 +78,12 @@ inline object const& operator>> (object const& o, std::multiset<T>& v)
     if(o.type != type::ARRAY) { throw type_error(); }
     object* p = o.via.array.ptr + o.via.array.size;
     object* const pbegin = o.via.array.ptr;
+    std::multiset<T> tmp;
     while(p > pbegin) {
         --p;
-        v.insert(p->as<T>());
+        tmp.insert(p->as<T>());
     }
+    tmp.swap(v);
     return o;
 }
 

--- a/include/msgpack/adaptor/tr1/unordered_map.hpp
+++ b/include/msgpack/adaptor/tr1/unordered_map.hpp
@@ -49,11 +49,13 @@ inline object const& operator>> (object const& o, MSGPACK_STD_TR1::unordered_map
     if(o.type != type::MAP) { throw type_error(); }
     object_kv* p(o.via.map.ptr);
     object_kv* const pend(o.via.map.ptr + o.via.map.size);
+    MSGPACK_STD_TR1::unordered_map<K, V> tmp;
     for(; p != pend; ++p) {
         K key;
         p->key.convert(key);
-        p->val.convert(v[key]);
+        p->val.convert(tmp[key]);
     }
+    tmp.swap(v);
     return o;
 }
 
@@ -98,12 +100,14 @@ inline object const& operator>> (object const& o, MSGPACK_STD_TR1::unordered_mul
     if(o.type != type::MAP) { throw type_error(); }
     object_kv* p(o.via.map.ptr);
     object_kv* const pend(o.via.map.ptr + o.via.map.size);
+    MSGPACK_STD_TR1::unordered_multimap<K, V> tmp;
     for(; p != pend; ++p) {
         std::pair<K, V> value;
         p->key.convert(value.first);
         p->val.convert(value.second);
-        v.insert(value);
+        tmp.insert(value);
     }
+    tmp.swap(v);
     return o;
 }
 

--- a/include/msgpack/adaptor/tr1/unordered_set.hpp
+++ b/include/msgpack/adaptor/tr1/unordered_set.hpp
@@ -48,10 +48,12 @@ inline object const& operator>> (object const& o, MSGPACK_STD_TR1::unordered_set
     if(o.type != type::ARRAY) { throw type_error(); }
     object* p = o.via.array.ptr + o.via.array.size;
     object* const pbegin = o.via.array.ptr;
+    MSGPACK_STD_TR1::unordered_set<T> tmp;
     while(p > pbegin) {
         --p;
-        v.insert(p->as<T>());
+        tmp.insert(p->as<T>());
     }
+    tmp.swap(v);
     return o;
 }
 
@@ -94,10 +96,12 @@ inline object const& operator>> (object const& o, MSGPACK_STD_TR1::unordered_mul
     if(o.type != type::ARRAY) { throw type_error(); }
     object* p = o.via.array.ptr + o.via.array.size;
     object* const pbegin = o.via.array.ptr;
+    MSGPACK_STD_TR1::unordered_multiset<T> tmp;
     while(p > pbegin) {
         --p;
-        v.insert(p->as<T>());
+        tmp.insert(p->as<T>());
     }
+    tmp.swap(v);
     return o;
 }
 


### PR DESCRIPTION
Clear deserialized target containers.
As the result of this fix, all containers' deserialized behaviors become consistent.
