### PR TITLE
Added additional unpack() APIs to support C++11 style programming.

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -33,6 +33,7 @@ LIST (APPEND check_PROGRAMS
 IF (MSGPACK_CXX11)
     LIST (APPEND check_PROGRAMS
         msgpack_cpp11.cpp
+        reference_cpp11.cpp
     )
 ENDIF ()
 

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -23,6 +23,7 @@ check_PROGRAMS = \
 		msgpack_stream \
 		msgpack_vref \
 		msgpack_cpp11 \
+		reference_cpp11 \
 		reference
 
 TESTS = $(check_PROGRAMS)
@@ -69,5 +70,7 @@ msgpack_vref_SOURCES = msgpack_vref.cpp
 msgpack_cpp11_SOURCES = msgpack_cpp11.cpp
 
 reference_SOURCES = reference.cpp
+
+reference_cpp11_SOURCES = reference_cpp11.cpp
 
 EXTRA_DIST = cases.mpac cases_compact.mpac

--- a/test/pack_unpack.cpp
+++ b/test/pack_unpack.cpp
@@ -49,7 +49,58 @@ TEST(pack, myclass)
     msgpack::pack(sbuf, m);
 }
 
-TEST(unpack, int_no_offset)
+
+#if !defined(MSGPACK_USE_CPP03)
+
+TEST(unpack, int_ret_no_offset_no_ref)
+{
+    msgpack::sbuffer sbuf;
+    msgpack::pack(sbuf, 1);
+
+    msgpack::unpacked msg = msgpack::unpack(sbuf.data(), sbuf.size());
+    EXPECT_EQ(1, msg.get().as<int>());
+}
+
+TEST(unpack, int_ret_offset_no_ref)
+{
+    msgpack::sbuffer sbuf;
+    msgpack::pack(sbuf, 1);
+
+    std::size_t off = 0;
+
+    msgpack::unpacked msg = msgpack::unpack(sbuf.data(), sbuf.size(), off);
+    EXPECT_EQ(1, msg.get().as<int>());
+    EXPECT_EQ(off, sbuf.size());
+}
+
+TEST(unpack, int_ret_no_offset_ref)
+{
+    msgpack::sbuffer sbuf;
+    msgpack::pack(sbuf, 1);
+    bool referenced;
+
+    msgpack::unpacked msg = msgpack::unpack(sbuf.data(), sbuf.size(), referenced);
+    EXPECT_EQ(1, msg.get().as<int>());
+    EXPECT_EQ(false, referenced);
+}
+
+TEST(unpack, int_ret_offset_ref)
+{
+    msgpack::sbuffer sbuf;
+    msgpack::pack(sbuf, 1);
+    std::size_t off = 0;
+    bool referenced;
+
+    msgpack::unpacked msg = msgpack::unpack(sbuf.data(), sbuf.size(), off, referenced);
+    EXPECT_EQ(1, msg.get().as<int>());
+    EXPECT_EQ(false, referenced);
+    EXPECT_EQ(off, sbuf.size());
+}
+
+#endif // !defined(MSGPACK_USE_CPP03)
+
+
+TEST(unpack, int_no_offset_no_ref)
 {
     msgpack::sbuffer sbuf;
     msgpack::pack(sbuf, 1);
@@ -59,7 +110,7 @@ TEST(unpack, int_no_offset)
     EXPECT_EQ(1, msg.get().as<int>());
 }
 
-TEST(unpack, int_offset)
+TEST(unpack, int_offset_no_ref)
 {
     msgpack::sbuffer sbuf;
     msgpack::pack(sbuf, 1);
@@ -72,7 +123,34 @@ TEST(unpack, int_offset)
     EXPECT_EQ(off, sbuf.size());
 }
 
-TEST(unpack, int_pointer)
+TEST(unpack, int_no_offset_ref)
+{
+    msgpack::sbuffer sbuf;
+    msgpack::pack(sbuf, 1);
+    msgpack::unpacked msg;
+    bool referenced;
+
+    msgpack::unpack(msg, sbuf.data(), sbuf.size(), referenced);
+    EXPECT_EQ(1, msg.get().as<int>());
+    EXPECT_EQ(false, referenced);
+}
+
+TEST(unpack, int_offset_ref)
+{
+    msgpack::sbuffer sbuf;
+    msgpack::pack(sbuf, 1);
+    msgpack::unpacked msg;
+    std::size_t off = 0;
+    bool referenced;
+
+    msgpack::unpack(msg, sbuf.data(), sbuf.size(), off, referenced);
+    EXPECT_EQ(1, msg.get().as<int>());
+    EXPECT_EQ(false, referenced);
+    EXPECT_EQ(off, sbuf.size());
+}
+
+
+TEST(unpack, int_pointer_off_no_ref)
 {
     msgpack::sbuffer sbuf;
     msgpack::pack(sbuf, 1);
@@ -86,16 +164,48 @@ TEST(unpack, int_pointer)
     EXPECT_EQ(off, sbuf.size());
 }
 
-TEST(unpack, int_null_pointer)
+TEST(unpack, int_pointer_off_no_ref_explicit)
 {
     msgpack::sbuffer sbuf;
     msgpack::pack(sbuf, 1);
     msgpack::unpacked msg;
 
+    std::size_t off = 0;
+
     // obsolete
-    msgpack::unpack(&msg, sbuf.data(), sbuf.size(), nullptr);
+    msgpack::unpack(&msg, sbuf.data(), sbuf.size(), &off, nullptr);
     EXPECT_EQ(1, msg.get().as<int>());
+    EXPECT_EQ(off, sbuf.size());
 }
+
+TEST(unpack, int_pointer_no_off_ref)
+{
+    msgpack::sbuffer sbuf;
+    msgpack::pack(sbuf, 1);
+    msgpack::unpacked msg;
+    bool referenced;
+
+    // obsolete
+    msgpack::unpack(&msg, sbuf.data(), sbuf.size(), nullptr, &referenced);
+    EXPECT_EQ(1, msg.get().as<int>());
+    EXPECT_EQ(false, referenced);
+}
+
+TEST(unpack, int_pointer_off_ref)
+{
+    msgpack::sbuffer sbuf;
+    msgpack::pack(sbuf, 1);
+    msgpack::unpacked msg;
+    bool referenced;
+    std::size_t off = 0;
+
+    // obsolete
+    msgpack::unpack(&msg, sbuf.data(), sbuf.size(), &off, &referenced);
+    EXPECT_EQ(1, msg.get().as<int>());
+    EXPECT_EQ(off, sbuf.size());
+    EXPECT_EQ(false, referenced);
+}
+
 
 TEST(unpack, int_default_null_pointer)
 {

--- a/test/reference_cpp11.cpp
+++ b/test/reference_cpp11.cpp
@@ -1,0 +1,232 @@
+#include <msgpack.hpp>
+#include <gtest/gtest.h>
+
+#if !defined(MSGPACK_USE_CPP03)
+
+TEST(reference, unpack_int)
+{
+    msgpack::sbuffer sbuf;
+    msgpack::pack(sbuf, 1);
+    bool referenced;
+
+    msgpack::unpacked ret = msgpack::unpack(sbuf.data(), sbuf.size(), referenced);
+    EXPECT_FALSE(referenced);
+}
+
+TEST(reference, unpack_string)
+{
+    msgpack::sbuffer sbuf;
+    msgpack::pack(sbuf, std::string("abcdefg"));
+    bool referenced;
+
+    msgpack::unpacked ret = msgpack::unpack(sbuf.data(), sbuf.size(), referenced);
+    EXPECT_FALSE(referenced);
+}
+
+TEST(reference, unpack_bin)
+{
+    msgpack::sbuffer sbuf;
+    msgpack::packer<msgpack::sbuffer> packer(sbuf);
+    char c[] = { 1, 2, 3, 4, 5, 6 };
+    packer.pack_bin(sizeof(c));
+    packer.pack_bin_body(c, sizeof(c));
+
+    bool referenced;
+    msgpack::unpacked ret = msgpack::unpack(sbuf.data(), sbuf.size(), referenced);
+    EXPECT_FALSE(referenced);
+}
+
+TEST(reference, unpack_ext)
+{
+    msgpack::sbuffer sbuf;
+    msgpack::packer<msgpack::sbuffer> packer(sbuf);
+    char const buf [] = { 2 };
+
+    packer.pack_ext(sizeof(buf), 1);
+    packer.pack_ext_body(buf, sizeof(buf));
+    bool referenced;
+    msgpack::unpacked ret = msgpack::unpack(sbuf.data(), sbuf.size(), referenced);
+    EXPECT_FALSE(referenced);
+}
+
+bool never_called(msgpack::type::object_type, std::size_t, void*)
+{
+    EXPECT_TRUE(false);
+    return false;
+}
+
+bool always_reference(msgpack::type::object_type, std::size_t, void*)
+{
+    return true;
+}
+
+TEST(reference, unpack_int_ref)
+{
+    msgpack::sbuffer sbuf;
+    msgpack::pack(sbuf, 1);
+    bool referenced;
+
+    msgpack::unpacked ret = msgpack::unpack(sbuf.data(), sbuf.size(), referenced, never_called);
+    EXPECT_FALSE(referenced);
+}
+
+TEST(reference, unpack_string_ref)
+{
+    msgpack::sbuffer sbuf;
+    msgpack::pack(sbuf, std::string("abcdefg"));
+    bool referenced;
+
+    msgpack::unpacked ret = msgpack::unpack(sbuf.data(), sbuf.size(), referenced, always_reference);
+    EXPECT_TRUE(referenced);
+}
+
+TEST(reference, unpack_bin_ref)
+{
+    msgpack::sbuffer sbuf;
+    msgpack::packer<msgpack::sbuffer> packer(sbuf);
+    char c[] = { 1, 2, 3, 4, 5, 6 };
+    packer.pack_bin(sizeof(c));
+    packer.pack_bin_body(c, sizeof(c));
+
+    bool referenced;
+    msgpack::unpacked ret = msgpack::unpack(sbuf.data(), sbuf.size(), referenced, always_reference);
+    EXPECT_TRUE(referenced);
+}
+
+TEST(reference, unpack_ext_ref)
+{
+    msgpack::sbuffer sbuf;
+    msgpack::packer<msgpack::sbuffer> packer(sbuf);
+    char const buf [] = { 2 };
+
+    packer.pack_ext(sizeof(buf), 1);
+    packer.pack_ext_body(buf, sizeof(buf));
+    bool referenced;
+    msgpack::unpacked ret = msgpack::unpack(sbuf.data(), sbuf.size(), referenced, always_reference);
+    EXPECT_TRUE(referenced);
+}
+
+static void* s_p;
+
+bool sized_reference(msgpack::type::object_type t, std::size_t s, void* p)
+{
+    s_p = p;
+    switch (t) {
+    case msgpack::type::STR:
+        if (s >= 5) return true;
+        break;
+    case msgpack::type::BIN:
+        if (s >= 6) return true;
+        break;
+    case msgpack::type::EXT:
+        if (s >= 7) return true;
+        break;
+    default:
+        EXPECT_TRUE(false);
+    }
+    return false;
+}
+
+TEST(reference, unpack_int_sized_ref)
+{
+    msgpack::sbuffer sbuf;
+    msgpack::pack(sbuf, 1);
+
+    bool referenced;
+    s_p = nullptr;
+    msgpack::unpacked ret = msgpack::unpack(sbuf.data(), sbuf.size(), referenced, never_called, &sbuf);
+    EXPECT_FALSE(referenced);
+    EXPECT_EQ(nullptr, s_p);
+}
+
+TEST(reference, unpack_string_sized_ref_4)
+{
+    msgpack::sbuffer sbuf;
+    msgpack::pack(sbuf, std::string("1234"));
+
+    bool referenced;
+    s_p = nullptr;
+    // the last argument sbuf is any pointer as a user data.
+    // That is stored to s_p in sized_reference
+    msgpack::unpacked ret = msgpack::unpack(sbuf.data(), sbuf.size(), referenced, sized_reference, &sbuf);
+    EXPECT_FALSE(referenced);
+    // compare the passed argument with stored s_p.
+    EXPECT_EQ(&sbuf, s_p);
+}
+
+TEST(reference, unpack_string_sized_ref_5)
+{
+    msgpack::sbuffer sbuf;
+    msgpack::pack(sbuf, std::string("12345"));
+
+    bool referenced;
+    s_p = nullptr;
+    msgpack::unpacked ret = msgpack::unpack(sbuf.data(), sbuf.size(), referenced, sized_reference, &sbuf);
+    EXPECT_TRUE(referenced);
+    EXPECT_EQ(&sbuf, s_p);
+}
+
+
+TEST(reference, unpack_bin_sized_ref_5)
+{
+    msgpack::sbuffer sbuf;
+    msgpack::packer<msgpack::sbuffer> packer(sbuf);
+    char c[] = { 1, 2, 3, 4, 5 };
+    packer.pack_bin(sizeof(c));
+    packer.pack_bin_body(c, sizeof(c));
+
+    bool referenced;
+    s_p = nullptr;
+    msgpack::unpacked ret = msgpack::unpack(sbuf.data(), sbuf.size(), referenced, sized_reference, &sbuf);
+    EXPECT_FALSE(referenced);
+    EXPECT_EQ(&sbuf, s_p);
+}
+
+TEST(reference, unpack_bin_sized_ref_6)
+{
+    msgpack::sbuffer sbuf;
+    msgpack::packer<msgpack::sbuffer> packer(sbuf);
+    char c[] = { 1, 2, 3, 4, 5, 6 };
+    packer.pack_bin(sizeof(c));
+    packer.pack_bin_body(c, sizeof(c));
+
+    bool referenced;
+    s_p = nullptr;
+    msgpack::unpacked ret = msgpack::unpack(sbuf.data(), sbuf.size(), referenced, sized_reference, &sbuf);
+    EXPECT_TRUE(referenced);
+    EXPECT_EQ(&sbuf, s_p);
+}
+
+TEST(reference, unpack_ext_sized_ref_6)
+{
+    msgpack::sbuffer sbuf;
+    msgpack::packer<msgpack::sbuffer> packer(sbuf);
+    char const buf [] = { 1, 2, 3, 4, 5 };
+
+    packer.pack_ext(sizeof(buf), 1); // 5 + 1(type) = 6
+    packer.pack_ext_body(buf, sizeof(buf));
+
+    bool referenced;
+    s_p = nullptr;
+    msgpack::unpacked ret = msgpack::unpack(sbuf.data(), sbuf.size(), referenced, sized_reference, &sbuf);
+    EXPECT_FALSE(referenced);
+    EXPECT_EQ(&sbuf, s_p);
+}
+
+TEST(reference, unpack_ext_sized_ref_7)
+{
+    msgpack::sbuffer sbuf;
+    msgpack::packer<msgpack::sbuffer> packer(sbuf);
+    char const buf [] = { 1, 2, 3, 4, 5, 6 };
+
+    packer.pack_ext(sizeof(buf), 1); // 6 + 1(type) = 7
+    packer.pack_ext_body(buf, sizeof(buf));
+
+    bool referenced;
+    s_p = nullptr;
+    msgpack::unpacked ret = msgpack::unpack(sbuf.data(), sbuf.size(), referenced, sized_reference, &sbuf);
+    EXPECT_TRUE(referenced);
+    EXPECT_EQ(&sbuf, s_p);
+}
+
+#endif // !defined(MSGPACK_USE_CPP03)


### PR DESCRIPTION
I heard a request that unpack() should return msgpack::unpacked instead of void from some users. So I considered. It's good way to support C++11 style programming. msgpack::unpacked moves well. 

However, it's not good for C++03. msgpack::unpacked has msgpack::unique_ptrmsgpack::zone. msgpack::unique_ptr is implemented by std::auto_ptr on C++03. 
https://github.com/msgpack/msgpack-c/blob/poc/0.6/include/msgpack/cpp_config.hpp#L44

std::auto_ptr requires the copy constructor that have non const reference type, unpacked(unpacked&). It cannot receive a rvalue such as function return value.

``` C++
unpacked unp = unpack(...); // NG
```

Finally, I've decided to support unpack() that returns msgpack::unpacked only C++11.
