### PR TITLE
Support std::unordered_map/set even if using libstdc++ from GCC.

### DIFF
--- a/src/msgpack/type/tr1/unordered_map.hpp
+++ b/src/msgpack/type/tr1/unordered_map.hpp
@@ -20,13 +20,16 @@
 
 #include "msgpack/object.hpp"
 
-#if defined(_LIBCPP_VERSION) || (_MSC_VER >= 1700)
+#define LIBSTDCXX_HAS_STD_UNORDERED_MAP defined(__GLIBCXX__) && __GLIBCXX__ >= 20090421 \
+    && (__cplusplus >= 201103L || __GXX_EXPERIMENTAL_CXX0X__)
+
+#if LIBSTDCXX_HAS_STD_UNORDERED_MAP || defined(_LIBCPP_VERSION) || (_MSC_VER >= 1700)
 
 #define MSGPACK_HAS_STD_UNOURDERED_MAP
 #include <unordered_map>
 #define MSGPACK_STD_TR1 std
 
-#else   // defined(_LIBCPP_VERSION) || (_MSC_VER >= 1700)
+#else   // LIBSTDCXX_HAS_STD_UNORDERED_MAP || defined(_LIBCPP_VERSION) || (_MSC_VER >= 1700)
 
 #if __GNUC__ >= 4
 
@@ -37,8 +40,7 @@
 
 #endif // __GNUC__ >= 4
 
-#endif  // defined(_LIBCPP_VERSION) || (_MSC_VER >= 1700)
-
+#endif  // LIBSTDCXX_HAS_STD_UNORDERED_MAP || defined(_LIBCPP_VERSION) || (_MSC_VER >= 1700)
 
 namespace msgpack {
 

--- a/src/msgpack/type/tr1/unordered_set.hpp
+++ b/src/msgpack/type/tr1/unordered_set.hpp
@@ -20,13 +20,16 @@
 
 #include "msgpack/object.hpp"
 
-#if defined(_LIBCPP_VERSION) || (_MSC_VER >= 1700)
+#define LIBSTDCXX_HAS_STD_UNORDERED_SET defined(__GLIBCXX__) && __GLIBCXX__ >= 20090421 \
+    && (__cplusplus >= 201103L || __GXX_EXPERIMENTAL_CXX0X__)
+
+#if LIBSTDCXX_HAS_STD_UNORDERED_SET || defined(_LIBCPP_VERSION) || (_MSC_VER >= 1700)
 
 #define MSGPACK_HAS_STD_UNOURDERED_SET
 #include <unordered_set>
 #define MSGPACK_STD_TR1 std
 
-#else   // defined(_LIBCPP_VERSION) || (_MSC_VER >= 1700)
+#else   // LIBSTDCXX_HAS_STD_UNORDERED_SET || defined(_LIBCPP_VERSION) || (_MSC_VER >= 1700)
 
 #if __GNUC__ >= 4
 
@@ -37,7 +40,7 @@
 
 #endif // __GNUC__ >= 4
 
-#endif  // defined(_LIBCPP_VERSION) || (_MSC_VER >= 1700)
+#endif  // LIBSTDCXX_HAS_STD_UNORDERED_SET || defined(_LIBCPP_VERSION) || (_MSC_VER >= 1700)
 
 namespace msgpack {
 


### PR DESCRIPTION
When passing the appropriate compiler flags, libstdc++ has
supported std::unordered_map and std::unordered_set for a
long time, even without the tr1 namespace. There's no reason to
limit support of non-tr1 containers to libc++ (clang) and MSVC.

(I chose to retain the typo in MSGPACK_HAS_STD_UNOURDERED_MAP as this check is likely going to go away when msgpack-c switches to C++11.)
