### PR TITLE
Moved include byteswap.h to sysdep.h.

### DIFF
--- a/include/msgpack/sysdep.h
+++ b/include/msgpack/sysdep.h
@@ -68,7 +68,12 @@ typedef unsigned int _msgpack_atomic_counter_t;
 #endif
 
 #else
+
 #include <arpa/inet.h>  /* __BYTE_ORDER */
+#  if !defined(__APPLE__)
+#    include <byteswap.h>
+#  endif
+
 #endif
 
 #if !defined(__LITTLE_ENDIAN__) && !defined(__BIG_ENDIAN__)
@@ -185,4 +190,3 @@ typedef unsigned int _msgpack_atomic_counter_t;
 #endif
 
 #endif /* msgpack/sysdep.h */
-

--- a/include/msgpack/unpack.hpp
+++ b/include/msgpack/unpack.hpp
@@ -21,10 +21,10 @@
 #include "zone.hpp"
 #include "unpack_define.h"
 #include "cpp_config.hpp"
+#include "sysdep.h"
 
 #include <memory>
 #include <stdexcept>
-#include <byteswap.h>
 
 
 


### PR DESCRIPTION
When compiling on Mac, byteswap.h is not included.
