### PR TITLE
Added check for already defined NOMINMAX

### DIFF
--- a/include/msgpack/unpack.hpp
+++ b/include/msgpack/unpack.hpp
@@ -30,7 +30,9 @@
 
 #if defined(_MSC_VER)
 // avoiding confliction std::max, std::min, and macro in windows.h
+#ifndef NOMINMAX
 #define NOMINMAX
+#endif
 #endif // defined(_MSC_VER)
 
 #ifdef _msgpack_atomic_counter_header


### PR DESCRIPTION
If NOMINMAX is already defined I get a warning in Visual Studio. The fix is to define it only if not already defined.
