### PR TITLE
Add missing break to prevent segfault

### DIFF
--- a/include/msgpack/object.hpp
+++ b/include/msgpack/object.hpp
@@ -672,6 +672,7 @@ inline std::ostream& operator<< (std::ostream& s, const object& o)
 
     case type::EXT:
         s << "EXT";
+        break;
 
     case type::ARRAY:
         s << "[";


### PR DESCRIPTION
When printing objects with extension, falling through to type ARRAY may cause segmentation fault.