### PR TITLE
Modified the default value of MSGPACK_ZONE_ALIGN from sizeof(int) to siz...

### DIFF
--- a/erb/cpp03_zone.hpp.erb
+++ b/erb/cpp03_zone.hpp.erb
@@ -29,7 +29,7 @@
 #endif
 
 #ifndef MSGPACK_ZONE_ALIGN
-#define MSGPACK_ZONE_ALIGN sizeof(int)
+#define MSGPACK_ZONE_ALIGN sizeof(void*)
 #endif
 
 <% GENERATION_LIMIT = 15 %>

--- a/include/msgpack/detail/cpp03_zone.hpp
+++ b/include/msgpack/detail/cpp03_zone.hpp
@@ -29,7 +29,7 @@
 #endif
 
 #ifndef MSGPACK_ZONE_ALIGN
-#define MSGPACK_ZONE_ALIGN sizeof(int)
+#define MSGPACK_ZONE_ALIGN sizeof(void*)
 #endif
 
 

--- a/include/msgpack/detail/cpp11_zone.hpp
+++ b/include/msgpack/detail/cpp11_zone.hpp
@@ -31,7 +31,7 @@
 #endif
 
 #ifndef MSGPACK_ZONE_ALIGN
-#define MSGPACK_ZONE_ALIGN sizeof(int)
+#define MSGPACK_ZONE_ALIGN sizeof(void*)
 #endif
 
 namespace msgpack {

--- a/include/msgpack/zone.h
+++ b/include/msgpack/zone.h
@@ -89,7 +89,7 @@ void msgpack_zone_clear(msgpack_zone* zone);
 
 
 #ifndef MSGPACK_ZONE_ALIGN
-#define MSGPACK_ZONE_ALIGN sizeof(int)
+#define MSGPACK_ZONE_ALIGN sizeof(void*)
 #endif
 
 MSGPACK_DLLEXPORT


### PR DESCRIPTION
...eof(void*).

On the x64 environment, sizeof(int) == 4 but pointer size is 8. The latter is suitable for the default value.