### PR TITLE
Comment unused variable name

### DIFF
--- a/include/msgpack/unpack.hpp
+++ b/include/msgpack/unpack.hpp
@@ -541,7 +541,7 @@ private:
     }
 
     template <std::size_t N>
-    static void check_ext_size(std::size_t size) {
+    static void check_ext_size(std::size_t /*size*/) {
     }
 
 private:


### PR DESCRIPTION
Prevents unused parameter error from gcc when compiled with -Wextra.