### PR TITLE
Fix compiler warning C4309 in Visual C++ 2013

### DIFF
--- a/include/msgpack/pack.hpp
+++ b/include/msgpack/pack.hpp
@@ -27,6 +27,11 @@
 
 #include "sysdep.h"
 
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable: 4309)
+#endif
+
 namespace msgpack {
 
 MSGPACK_API_VERSION_NAMESPACE(v1) {
@@ -1049,5 +1054,9 @@ inline void packer<Stream>::pack_imp_int64(T d)
 }  // MSGPACK_API_VERSION_NAMESPACE(v1)
 
 }  // namespace msgpack
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 
 #endif /* msgpack/pack.hpp */


### PR DESCRIPTION
Code in pack.hpp like `static_cast<char>` will issue [C4309](http://msdn.microsoft.com/en-us/library/sz5z1byt.aspx)

Suppress this with pragma directive to local warning level state.
