### PR TITLE
Fixed #191.

### DIFF
--- a/include/msgpack/adaptor/float.hpp
+++ b/include/msgpack/adaptor/float.hpp
@@ -31,8 +31,8 @@ MSGPACK_API_VERSION_NAMESPACE(v1) {
 
 inline object const& operator>> (object const& o, float& v)
 {
-    if(o.type == type::DOUBLE) {
-        v = static_cast<float>(o.via.dec);
+    if(o.type == type::FLOAT) {
+        v = static_cast<float>(o.via.f64);
     }
     else if (o.type == type::POSITIVE_INTEGER) {
         v = static_cast<float>(o.via.u64);
@@ -56,8 +56,8 @@ inline packer<Stream>& operator<< (packer<Stream>& o, const float& v)
 
 inline object const& operator>> (object const& o, double& v)
 {
-    if(o.type == type::DOUBLE) {
-        v = o.via.dec;
+    if(o.type == type::FLOAT) {
+        v = o.via.f64;
     }
     else if (o.type == type::POSITIVE_INTEGER) {
         v = static_cast<double>(o.via.u64);
@@ -81,14 +81,14 @@ inline packer<Stream>& operator<< (packer<Stream>& o, const double& v)
 
 inline void operator<< (object& o, float v)
 {
-    o.type = type::DOUBLE;
-    o.via.dec = static_cast<double>(v);
+    o.type = type::FLOAT;
+    o.via.f64 = static_cast<double>(v);
 }
 
 inline void operator<< (object& o, double v)
 {
-    o.type = type::DOUBLE;
-    o.via.dec = v;
+    o.type = type::FLOAT;
+    o.via.f64 = v;
 }
 
 inline void operator<< (object::with_zone& o, float v)

--- a/include/msgpack/object.h
+++ b/include/msgpack/object.h
@@ -37,7 +37,10 @@ typedef enum {
     MSGPACK_OBJECT_BOOLEAN              = 0x01,
     MSGPACK_OBJECT_POSITIVE_INTEGER     = 0x02,
     MSGPACK_OBJECT_NEGATIVE_INTEGER     = 0x03,
-    MSGPACK_OBJECT_DOUBLE               = 0x04,
+    MSGPACK_OBJECT_FLOAT                = 0x04,
+#if defined(MSGPACK_USE_LEGACY_NAME_AS_FLOAT)
+    MSGPACK_OBJECT_DOUBLE               = MSGPACK_OBJECT_FLOAT, /* obsolete */
+#endif /* MSGPACK_USE_LEGACY_NAME_AS_FLOAT */
     MSGPACK_OBJECT_STR                  = 0x05,
     MSGPACK_OBJECT_ARRAY                = 0x06,
     MSGPACK_OBJECT_MAP                  = 0x07,
@@ -79,7 +82,10 @@ typedef union {
     bool boolean;
     uint64_t u64;
     int64_t  i64;
-    double   dec;
+#if defined(MSGPACK_USE_LEGACY_NAME_AS_FLOAT)
+    double   dec; /* obsolete*/
+#endif /* MSGPACK_USE_LEGACY_NAME_AS_FLOAT */
+    double   f64;
     msgpack_object_array array;
     msgpack_object_map map;
     msgpack_object_str str;
@@ -111,4 +117,3 @@ bool msgpack_object_equal(const msgpack_object x, const msgpack_object y);
 #endif
 
 #endif /* msgpack/object.h */
-

--- a/include/msgpack/object.hpp
+++ b/include/msgpack/object.hpp
@@ -211,7 +211,7 @@ inline void operator<< (object::with_zone& o, const object& v)
     case type::BOOLEAN:
     case type::POSITIVE_INTEGER:
     case type::NEGATIVE_INTEGER:
-    case type::DOUBLE:
+    case type::FLOAT:
         ::memcpy(&o.via, &v.via, sizeof(v.via));
         return;
 
@@ -342,8 +342,8 @@ inline bool operator==(const object& x, const object& y)
     case type::NEGATIVE_INTEGER:
         return x.via.i64 == y.via.i64;
 
-    case type::DOUBLE:
-        return x.via.dec == y.via.dec;
+    case type::FLOAT:
+        return x.via.f64 == y.via.f64;
 
     case type::STR:
         return x.via.str.size == y.via.str.size &&
@@ -590,8 +590,8 @@ inline packer<Stream>& operator<< (packer<Stream>& o, const object& v)
         o.pack_int64(v.via.i64);
         return o;
 
-    case type::DOUBLE:
-        o.pack_double(v.via.dec);
+    case type::FLOAT:
+        o.pack_double(v.via.f64);
         return o;
 
     case type::STR:
@@ -658,8 +658,8 @@ inline std::ostream& operator<< (std::ostream& s, const object& o)
         s << o.via.i64;
         break;
 
-    case type::DOUBLE:
-        s << o.via.dec;
+    case type::FLOAT:
+        s << o.via.f64;
         break;
 
     case type::STR:

--- a/include/msgpack/object_fwd.hpp
+++ b/include/msgpack/object_fwd.hpp
@@ -36,7 +36,10 @@ namespace type {
         BOOLEAN             = MSGPACK_OBJECT_BOOLEAN,
         POSITIVE_INTEGER    = MSGPACK_OBJECT_POSITIVE_INTEGER,
         NEGATIVE_INTEGER    = MSGPACK_OBJECT_NEGATIVE_INTEGER,
-        DOUBLE              = MSGPACK_OBJECT_DOUBLE,
+        FLOAT               = MSGPACK_OBJECT_FLOAT,
+#if defined(MSGPACK_USE_LEGACY_NAME_AS_FLOAT)
+        DOUBLE              = MSGPACK_OBJECT_DOUBLE, // obsolete
+#endif // MSGPACK_USE_LEGACY_NAME_AS_FLOAT
         STR                 = MSGPACK_OBJECT_STR,
         BIN                 = MSGPACK_OBJECT_BIN,
         ARRAY               = MSGPACK_OBJECT_ARRAY,
@@ -81,7 +84,10 @@ struct object {
         bool boolean;
         uint64_t u64;
         int64_t  i64;
-        double   dec;
+#if defined(MSGPACK_USE_LEGACY_NAME_AS_FLOAT)
+        double   dec; // obsolete
+#endif // MSGPACK_USE_LEGACY_NAME_AS_FLOAT
+        double   f64;
         object_array array;
         object_map map;
         object_str str;

--- a/include/msgpack/unpack.hpp
+++ b/include/msgpack/unpack.hpp
@@ -226,10 +226,10 @@ inline void unpack_int64(int64_t d, object& o)
         else { o.type = type::NEGATIVE_INTEGER; o.via.i64 = d; } }
 
 inline void unpack_float(float d, object& o)
-{ o.type = type::DOUBLE; o.via.dec = d; }
+{ o.type = type::FLOAT; o.via.f64 = d; }
 
 inline void unpack_double(double d, object& o)
-{ o.type = type::DOUBLE; o.via.dec = d; }
+{ o.type = type::FLOAT; o.via.f64 = d; }
 
 inline void unpack_nil(object& o)
 { o.type = type::NIL; }

--- a/src/objectc.c
+++ b/src/objectc.c
@@ -44,8 +44,8 @@ int msgpack_pack_object(msgpack_packer* pk, msgpack_object d)
     case MSGPACK_OBJECT_NEGATIVE_INTEGER:
         return msgpack_pack_int64(pk, d.via.i64);
 
-    case MSGPACK_OBJECT_DOUBLE:
-        return msgpack_pack_double(pk, d.via.dec);
+    case MSGPACK_OBJECT_FLOAT:
+        return msgpack_pack_double(pk, d.via.f64);
 
     case MSGPACK_OBJECT_STR:
         {
@@ -141,8 +141,8 @@ void msgpack_object_print(FILE* out, msgpack_object o)
 #endif
         break;
 
-    case MSGPACK_OBJECT_DOUBLE:
-        fprintf(out, "%f", o.via.dec);
+    case MSGPACK_OBJECT_FLOAT:
+        fprintf(out, "%f", o.via.f64);
         break;
 
     case MSGPACK_OBJECT_STR:
@@ -233,8 +233,8 @@ bool msgpack_object_equal(const msgpack_object x, const msgpack_object y)
     case MSGPACK_OBJECT_NEGATIVE_INTEGER:
         return x.via.i64 == y.via.i64;
 
-    case MSGPACK_OBJECT_DOUBLE:
-        return x.via.dec == y.via.dec;
+    case MSGPACK_OBJECT_FLOAT:
+        return x.via.f64 == y.via.f64;
 
     case MSGPACK_OBJECT_STR:
         return x.via.str.size == y.via.str.size &&

--- a/src/unpack.c
+++ b/src/unpack.c
@@ -159,16 +159,16 @@ static inline int template_callback_int64(unpack_user* u, int64_t d, msgpack_obj
 static inline int template_callback_float(unpack_user* u, float d, msgpack_object* o)
 {
     MSGPACK_UNUSED(u);
-    o->type = MSGPACK_OBJECT_DOUBLE;
-    o->via.dec = d;
+    o->type = MSGPACK_OBJECT_FLOAT;
+    o->via.f64 = d;
     return 0;
 }
 
 static inline int template_callback_double(unpack_user* u, double d, msgpack_object* o)
 {
     MSGPACK_UNUSED(u);
-    o->type = MSGPACK_OBJECT_DOUBLE;
-    o->via.dec = d;
+    o->type = MSGPACK_OBJECT_FLOAT;
+    o->via.f64 = d;
     return 0;
 }
 

--- a/test/msgpack_c.cpp
+++ b/test/msgpack_c.cpp
@@ -223,13 +223,28 @@ TEST(MSGPACKC, simple_buffer_float)
     msgpack_unpack_return ret =
       msgpack_unpack(sbuf.data, sbuf.size, NULL, &z, &obj);
     EXPECT_EQ(MSGPACK_UNPACK_SUCCESS, ret);
+    EXPECT_EQ(MSGPACK_OBJECT_FLOAT, obj.type);
+#if defined(MSGPACK_USE_LEGACY_NAME_AS_FLOAT)
     EXPECT_EQ(MSGPACK_OBJECT_DOUBLE, obj.type);
-    if (isnan(val))
+#endif // MSGPACK_USE_LEGACY_NAME_AS_FLOAT
+    if (isnan(val)) {
+      EXPECT_TRUE(isnan(obj.via.f64));
+#if defined(MSGPACK_USE_LEGACY_NAME_AS_FLOAT)
       EXPECT_TRUE(isnan(obj.via.dec));
-    else if (isinf(val))
+#endif // MSGPACK_USE_LEGACY_NAME_AS_FLOAT
+    }
+    else if (isinf(val)) {
+      EXPECT_TRUE(isinf(obj.via.f64));
+#if defined(MSGPACK_USE_LEGACY_NAME_AS_FLOAT)
       EXPECT_TRUE(isinf(obj.via.dec));
-    else
+#endif // MSGPACK_USE_LEGACY_NAME_AS_FLOAT
+    }
+    else {
+      EXPECT_TRUE(fabs(obj.via.f64 - val) <= kEPS);
+#if defined(MSGPACK_USE_LEGACY_NAME_AS_FLOAT)
       EXPECT_TRUE(fabs(obj.via.dec - val) <= kEPS);
+#endif // MSGPACK_USE_LEGACY_NAME_AS_FLOAT
+    }
     msgpack_zone_destroy(&z);
     msgpack_sbuffer_destroy(&sbuf);
   }
@@ -273,13 +288,28 @@ TEST(MSGPACKC, simple_buffer_double)
     msgpack_unpack_return ret =
       msgpack_unpack(sbuf.data, sbuf.size, NULL, &z, &obj);
     EXPECT_EQ(MSGPACK_UNPACK_SUCCESS, ret);
+    EXPECT_EQ(MSGPACK_OBJECT_FLOAT, obj.type);
+#if defined(MSGPACK_USE_LEGACY_NAME_AS_FLOAT)
     EXPECT_EQ(MSGPACK_OBJECT_DOUBLE, obj.type);
-    if (isnan(val))
+#endif // MSGPACK_USE_LEGACY_NAME_AS_FLOAT
+    if (isnan(val)) {
+      EXPECT_TRUE(isnan(obj.via.f64));
+#if defined(MSGPACK_USE_LEGACY_NAME_AS_FLOAT)
       EXPECT_TRUE(isnan(obj.via.dec));
-    else if (isinf(val))
+#endif // MSGPACK_USE_LEGACY_NAME_AS_FLOAT
+    }
+    else if (isinf(val)) {
+      EXPECT_TRUE(isinf(obj.via.f64));
+#if defined(MSGPACK_USE_LEGACY_NAME_AS_FLOAT)
       EXPECT_TRUE(isinf(obj.via.dec));
-    else
+#endif // MSGPACK_USE_LEGACY_NAME_AS_FLOAT
+    }
+    else {
+      EXPECT_TRUE(fabs(obj.via.f64 - val) <= kEPS);
+#if defined(MSGPACK_USE_LEGACY_NAME_AS_FLOAT)
       EXPECT_TRUE(fabs(obj.via.dec - val) <= kEPS);
+#endif // MSGPACK_USE_LEGACY_NAME_AS_FLOAT
+    }
     msgpack_zone_destroy(&z);
     msgpack_sbuffer_destroy(&sbuf);
   }

--- a/test/object.cpp
+++ b/test/object.cpp
@@ -79,7 +79,10 @@ TEST(object, cross_zone_copy)
 
         obj1 << obj2;
 
+        EXPECT_EQ(obj1.via.array.ptr[2].via.array.ptr[0].via.f64, 1.0);
+#if defined(MSGPACK_USE_LEGACY_NAME_AS_FLOAT)
         EXPECT_EQ(obj1.via.array.ptr[2].via.array.ptr[0].via.dec, 1.0);
+#endif // MSGPACK_USE_LEGACY_NAME_AS_FLOAT
         EXPECT_EQ(obj1.via.array.ptr[3].via.map.ptr[0].key.via.str.ptr[0], 'o');
         EXPECT_EQ(obj1.via.array.ptr[3].via.map.ptr[0].val.via.bin.ptr[0], 't');
         EXPECT_NE(
@@ -117,7 +120,10 @@ TEST(object, cross_zone_copy_construct)
 
     msgpack::object obj1(obj2, z1);
 
+    EXPECT_EQ(obj1.via.array.ptr[2].via.array.ptr[0].via.f64, 1.0);
+#if defined(MSGPACK_USE_LEGACY_NAME_AS_FLOAT)
     EXPECT_EQ(obj1.via.array.ptr[2].via.array.ptr[0].via.dec, 1.0);
+#endif // MSGPACK_USE_LEGACY_NAME_AS_FLOAT
     EXPECT_EQ(obj1.via.array.ptr[3].via.map.ptr[0].key.via.str.ptr[0], 'o');
     EXPECT_EQ(obj1.via.array.ptr[3].via.map.ptr[0].val.via.bin.ptr[0], 't');
     EXPECT_NE(
@@ -215,9 +221,9 @@ TEST(object, equal_primitive)
     EXPECT_EQ(obj_int, msgpack::object(1));
     EXPECT_EQ(obj_int, 1);
 
-    msgpack::object obj_double(1.2);
-    EXPECT_EQ(obj_double, msgpack::object(1.2));
-    EXPECT_EQ(obj_double, 1.2);
+    msgpack::object obj_float(1.2);
+    EXPECT_EQ(obj_float, msgpack::object(1.2));
+    EXPECT_EQ(obj_float, 1.2);
 
     msgpack::object obj_bool(true);
     EXPECT_EQ(obj_bool, msgpack::object(true));
@@ -238,9 +244,13 @@ TEST(object, construct_primitive)
     EXPECT_EQ(msgpack::type::NEGATIVE_INTEGER, obj_int.type);
     EXPECT_EQ(-1, obj_int.via.i64);
 
-    msgpack::object obj_double(1.2);
-    EXPECT_EQ(msgpack::type::DOUBLE, obj_double.type);
-    EXPECT_EQ(1.2, obj_double.via.dec);
+    msgpack::object obj_float(1.2);
+    EXPECT_EQ(msgpack::type::FLOAT, obj_float.type);
+    EXPECT_EQ(1.2, obj_float.via.f64);
+#if defined(MSGPACK_USE_LEGACY_NAME_AS_FLOAT)
+    EXPECT_EQ(msgpack::type::DOUBLE, obj_float.type);
+    EXPECT_EQ(1.2, obj_float.via.dec);
+#endif // MSGPACK_USE_LEGACY_NAME_AS_FLOAT
 
     msgpack::object obj_bool(true);
     EXPECT_EQ(msgpack::type::BOOLEAN, obj_bool.type);

--- a/test/streaming_c.cpp
+++ b/test/streaming_c.cpp
@@ -97,11 +97,19 @@ TEST(streaming, basic)
                     EXPECT_EQ(MSGPACK_OBJECT_MAP, obj.type);
                     EXPECT_EQ(1, obj.via.map.size);
                     e = obj.via.map.ptr[0].key;
+                    EXPECT_EQ(MSGPACK_OBJECT_FLOAT, e.type);
+                    ASSERT_FLOAT_EQ(0.4, static_cast<float>(e.via.f64));
+#if defined(MSGPACK_USE_LEGACY_NAME_AS_FLOAT)
                     EXPECT_EQ(MSGPACK_OBJECT_DOUBLE, e.type);
-                    ASSERT_FLOAT_EQ(0.4, (float)e.via.dec);
+                    ASSERT_FLOAT_EQ(0.4, static_cast<float>(e.via.dec));
+#endif // MSGPACK_USE_LEGACY_NAME_AS_FLOAT
                     e = obj.via.map.ptr[0].val;
+                    EXPECT_EQ(MSGPACK_OBJECT_FLOAT, e.type);
+                    ASSERT_DOUBLE_EQ(0.8, e.via.f64);
+#if defined(MSGPACK_USE_LEGACY_NAME_AS_FLOAT)
                     EXPECT_EQ(MSGPACK_OBJECT_DOUBLE, e.type);
                     ASSERT_DOUBLE_EQ(0.8, e.via.dec);
+#endif // MSGPACK_USE_LEGACY_NAME_AS_FLOAT
                     break;
                 }
             }

--- a/test/zone.cpp
+++ b/test/zone.cpp
@@ -20,7 +20,7 @@ TEST(zone, allocate_align_custom)
         char* start = (char*)z.allocate_align(1, align);
         EXPECT_EQ(reinterpret_cast<std::size_t>(start) % align, 0);
         for (std::size_t s = 1; s < align; ++s) {
-            (char*)z.allocate_no_align(s);
+            z.allocate_no_align(s);
             char* buf_a = (char*)z.allocate_align(1, align);
             EXPECT_EQ(0, reinterpret_cast<std::size_t>(buf_a) % align);
         }


### PR DESCRIPTION
The names of float format family are changed.

old                      new
dec                   -> f64
MSGPACK_OBJECT_DOUBLE -> MSGPACK_OBJECT_FLOAT
msgpack::type::DOUBLE -> msgpack::type::FLOAT

Client codes could have compile errors when it use dec, MSGPACK_OBJECT_DOUBLE or msgpack::type::DOUBLE.
The best way to fix such errors, update client code. If it can't, set MSGPACK_USE_LEGACY_NAME_AS_FLOAT macro.
Then both old names and new names are available.