### PR TITLE
Support OS X's sed in configure.in

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -1,4 +1,4 @@
-AC_INIT(msgpack, m4_esyscmd([cat include/msgpack/version_master.h | tr -d "\n" | sed -e 's/#define MSGPACK_VERSION_MAJOR\s*\(\w*\)/\1./g' -e 's/#define MSGPACK_VERSION_MINOR\s*\(\w*\)/\1./g' -e 's/#define MSGPACK_VERSION_REVISION\s*\(\w*\)/\1/g']))
+AC_INIT(msgpack, m4_esyscmd([cat include/msgpack/version_master.h | tr -d "\n" | sed -e 's/#define MSGPACK_VERSION_MAJOR[[:space:]]*\([[:alnum:]]*\)/\1./g' -e 's/#define MSGPACK_VERSION_MINOR[[:space:]]*\([[:alnum:]]*\)/\1./g' -e 's/#define MSGPACK_VERSION_REVISION[[:space:]]*\([[:alnum:]]*\)/\1/g' | tr -d "\n"]))
 AC_CONFIG_AUX_DIR(ac)
 AM_INIT_AUTOMAKE
 AC_CONFIG_HEADER(config.h)


### PR DESCRIPTION
configure.in extracts version string for AC_INIT using sed. However, sed in OS X behaves differently from the one in Linux. `\s` and `\w` cannot be used and it appends `\n` to the output. So, I slightly modified the command to support OS X's sed.