### PR TITLE
Fixed #204, #202.

### DIFF
--- a/erb/cpp03_define.hpp.erb
+++ b/erb/cpp03_define.hpp.erb
@@ -20,6 +20,7 @@
 
 #include "msgpack/versioning.hpp"
 #include "msgpack/adaptor/msgpack_tuple_fwd.hpp"
+#include "msgpack/adaptor/int_fwd.hpp"
 #include "msgpack/object_fwd.hpp"
 
 #define MSGPACK_DEFINE(...) \
@@ -42,7 +43,6 @@
 #define MSGPACK_ADD_ENUM(enum) \
   namespace msgpack { \
   MSGPACK_API_VERSION_NAMESPACE(v1) { \
-    template <> \
     inline object const& operator>> (object const& o, enum& v) \
     { \
       int tmp; \
@@ -50,7 +50,10 @@
       v = static_cast<enum>(tmp); \
       return o; \
     } \
-    template <> \
+    inline void operator<< (object& o, const enum& v) \
+    { \
+      o << static_cast<int>(v); \
+    } \
     inline void operator<< (object::with_zone& o, const enum& v) \
     { \
       o << static_cast<int>(v); \

--- a/include/msgpack/adaptor/detail/cpp03_define.hpp
+++ b/include/msgpack/adaptor/detail/cpp03_define.hpp
@@ -20,6 +20,7 @@
 
 #include "msgpack/versioning.hpp"
 #include "msgpack/adaptor/msgpack_tuple_fwd.hpp"
+#include "msgpack/adaptor/int_fwd.hpp"
 #include "msgpack/object_fwd.hpp"
 
 #define MSGPACK_DEFINE(...) \
@@ -42,7 +43,6 @@
 #define MSGPACK_ADD_ENUM(enum) \
   namespace msgpack { \
   MSGPACK_API_VERSION_NAMESPACE(v1) { \
-    template <> \
     inline object const& operator>> (object const& o, enum& v) \
     { \
       int tmp; \
@@ -50,7 +50,10 @@
       v = static_cast<enum>(tmp); \
       return o; \
     } \
-    template <> \
+    inline void operator<< (object& o, const enum& v) \
+    { \
+      o << static_cast<int>(v); \
+    } \
     inline void operator<< (object::with_zone& o, const enum& v) \
     { \
       o << static_cast<int>(v); \

--- a/include/msgpack/adaptor/detail/cpp11_define.hpp
+++ b/include/msgpack/adaptor/detail/cpp11_define.hpp
@@ -47,18 +47,21 @@
 #define MSGPACK_ADD_ENUM(enum) \
   namespace msgpack { \
   MSGPACK_API_VERSION_NAMESPACE(v1) { \
-    template <> \
     inline object const& operator>> (object const& o, enum& v) \
     { \
-      int tmp; \
+      std::underlying_type<enum>::type tmp; \
       o >> tmp; \
       v = static_cast<enum>(tmp);   \
       return o; \
     } \
-    template <> \
+    inline void operator<< (object& o, const enum& v) \
+    { \
+      auto tmp = static_cast<std::underlying_type<enum>::type>(v); \
+      o << tmp; \
+    } \
     inline void operator<< (object::with_zone& o, const enum& v) \
     { \
-      int tmp = static_cast<std::underlying_type<enum>::type>(v); \
+      auto tmp = static_cast<std::underlying_type<enum>::type>(v); \
       o << tmp; \
     } \
     namespace detail { \

--- a/test/convert.cpp
+++ b/test/convert.cpp
@@ -1,5 +1,23 @@
-#include <msgpack.hpp>
+#include <msgpack_fwd.hpp>
 #include <gtest/gtest.h>
+
+class enum_member {
+public:
+    enum_member() : flag(A) { }
+
+    enum flags_t {
+        A = 0,
+        B = 1
+    };
+
+    flags_t flag;
+
+    MSGPACK_DEFINE(flag);
+};
+
+MSGPACK_ADD_ENUM(enum_member::flags_t);
+
+#include <msgpack.hpp>
 
 class compatibility {
 public:
@@ -43,23 +61,6 @@ TEST(convert, compatibility_more)
     EXPECT_EQ("mpio",   to.str2);
 }
 
-
-class enum_member {
-public:
-    enum_member() : flag(A) { }
-
-    enum flags_t {
-        A = 0,
-        B = 1
-    };
-
-    flags_t flag;
-
-    MSGPACK_DEFINE(flag);
-};
-
-MSGPACK_ADD_ENUM(enum_member::flags_t);
-
 TEST(convert, enum_member)
 {
     enum_member src;
@@ -73,4 +74,3 @@ TEST(convert, enum_member)
 
     EXPECT_EQ(enum_member::B, to.flag);
 }
-

--- a/test/msgpack_container.cpp
+++ b/test/msgpack_container.cpp
@@ -1,4 +1,4 @@
-#include "msgpack.hpp"
+#include <msgpack_fwd.hpp>
 
 #include <cmath>
 #include <string>
@@ -14,6 +14,31 @@
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
+
+
+
+class TestEnumMemberClass
+{
+public:
+  TestEnumMemberClass()
+    : t1(STATE_A), t2(STATE_B), t3(STATE_C) {}
+
+  enum TestEnumType {
+    STATE_INVALID = 0,
+    STATE_A = 1,
+    STATE_B = 2,
+    STATE_C = 3
+  };
+  TestEnumType t1;
+  TestEnumType t2;
+  TestEnumType t3;
+
+  MSGPACK_DEFINE(t1, t2, t3);
+};
+
+MSGPACK_ADD_ENUM(TestEnumMemberClass::TestEnumType);
+
+#include <msgpack.hpp>
 
 using namespace std;
 
@@ -487,27 +512,6 @@ TEST(MSGPACK_USER_DEFINED, simple_buffer_class_new_to_old)
     EXPECT_FALSE(val2.s.empty());
   }
 }
-
-class TestEnumMemberClass
-{
-public:
-  TestEnumMemberClass()
-    : t1(STATE_A), t2(STATE_B), t3(STATE_C) {}
-
-  enum TestEnumType {
-    STATE_INVALID = 0,
-    STATE_A = 1,
-    STATE_B = 2,
-    STATE_C = 3
-  };
-  TestEnumType t1;
-  TestEnumType t2;
-  TestEnumType t3;
-
-  MSGPACK_DEFINE(t1, t2, t3);
-};
-
-MSGPACK_ADD_ENUM(TestEnumMemberClass::TestEnumType);
 
 TEST(MSGPACK_USER_DEFINED, simple_buffer_enum_member)
 {

--- a/test/msgpack_cpp11.cpp
+++ b/test/msgpack_cpp11.cpp
@@ -1,4 +1,4 @@
-#include "msgpack.hpp"
+#include <msgpack_fwd.hpp>
 
 #include <gtest/gtest.h>
 
@@ -6,12 +6,36 @@
 #include "config.h"
 #endif
 
+#if !defined(MSGPACK_USE_CPP03)
+
+class TestEnumClassMemberClass
+{
+public:
+    TestEnumClassMemberClass()
+        : t1(TestEnumClassType::STATE_A), t2(TestEnumClassType::STATE_B), t3(TestEnumClassType::STATE_C) {}
+
+    enum class TestEnumClassType:long {
+        STATE_INVALID = 0,
+            STATE_A = 1,
+            STATE_B = 2,
+            STATE_C = 3
+        };
+    TestEnumClassType t1;
+    TestEnumClassType t2;
+    TestEnumClassType t3;
+
+    MSGPACK_DEFINE(t1, t2, t3);
+};
+
+MSGPACK_ADD_ENUM(TestEnumClassMemberClass::TestEnumClassType);
+
+#include <msgpack.hpp>
+
 using namespace std;
 
 const unsigned int kLoop = 10000;
 const unsigned int kElements = 100;
 
-#if !defined(MSGPACK_USE_CPP03)
 
 // C++11
 
@@ -149,29 +173,6 @@ TEST(MSGPACK_STL, simple_buffer_unordered_multiset)
     EXPECT_EQ(val1, val2);
   }
 }
-
-
-
-class TestEnumClassMemberClass
-{
-public:
-    TestEnumClassMemberClass()
-        : t1(TestEnumClassType::STATE_A), t2(TestEnumClassType::STATE_B), t3(TestEnumClassType::STATE_C) {}
-
-    enum class TestEnumClassType:long {
-        STATE_INVALID = 0,
-            STATE_A = 1,
-            STATE_B = 2,
-            STATE_C = 3
-        };
-    TestEnumClassType t1;
-    TestEnumClassType t2;
-    TestEnumClassType t3;
-
-    MSGPACK_DEFINE(t1, t2, t3);
-};
-
-MSGPACK_ADD_ENUM(TestEnumClassMemberClass::TestEnumClassType);
 
 TEST(MSGPACK_USER_DEFINED, simple_buffer_enum_class_member)
 {

--- a/test/object.cpp
+++ b/test/object.cpp
@@ -1,5 +1,42 @@
-#include <msgpack.hpp>
+#include <msgpack_fwd.hpp>
 #include <gtest/gtest.h>
+
+
+enum enum_test {
+    elem
+};
+
+MSGPACK_ADD_ENUM(enum_test);
+
+struct outer_enum {
+    enum enum_test {
+        elem
+    };
+};
+
+MSGPACK_ADD_ENUM(outer_enum::enum_test);
+
+#if !defined(MSGPACK_USE_CPP03)
+
+enum class enum_class_test {
+    elem
+};
+
+MSGPACK_ADD_ENUM(enum_class_test);
+
+struct outer_enum_class {
+    enum class enum_class_test {
+        elem
+    };
+};
+
+MSGPACK_ADD_ENUM(outer_enum_class::enum_class_test);
+
+#endif // !defined(MSGPACK_USE_CPP03)
+
+
+
+#include <msgpack.hpp>
 
 struct myclass {
     myclass() : num(0), str("default") { }
@@ -256,3 +293,54 @@ TEST(object, construct_primitive)
     EXPECT_EQ(msgpack::type::BOOLEAN, obj_bool.type);
     EXPECT_EQ(true, obj_bool.via.boolean);
 }
+
+TEST(object, construct_enum)
+{
+    msgpack::object obj(elem);
+    EXPECT_EQ(msgpack::type::POSITIVE_INTEGER, obj.type);
+    EXPECT_EQ(elem, obj.via.u64);
+}
+
+#if !defined(MSGPACK_USE_CPP03)
+
+TEST(object, construct_enum_newstyle)
+{
+    msgpack::object obj(enum_test::elem);
+    EXPECT_EQ(msgpack::type::POSITIVE_INTEGER, obj.type);
+    EXPECT_EQ(elem, obj.via.u64);
+}
+
+#endif // !defined(MSGPACK_USE_CPP03)
+
+TEST(object, construct_enum_outer)
+{
+    msgpack::object obj(outer_enum::elem);
+    EXPECT_EQ(msgpack::type::POSITIVE_INTEGER, obj.type);
+    EXPECT_EQ(elem, obj.via.u64);
+}
+
+#if !defined(MSGPACK_USE_CPP03)
+
+TEST(object, construct_enum_outer_newstyle)
+{
+    msgpack::object obj(outer_enum::enum_test::elem);
+    EXPECT_EQ(msgpack::type::POSITIVE_INTEGER, obj.type);
+    EXPECT_EQ(elem, obj.via.u64);
+}
+
+TEST(object, construct_class_enum)
+{
+    msgpack::object obj(enum_class_test::elem);
+    EXPECT_EQ(msgpack::type::POSITIVE_INTEGER, obj.type);
+    EXPECT_EQ(elem, obj.via.u64);
+}
+
+
+TEST(object, construct_class_enum_outer)
+{
+    msgpack::object obj(outer_enum_class::enum_class_test::elem);
+    EXPECT_EQ(msgpack::type::POSITIVE_INTEGER, obj.type);
+    EXPECT_EQ(elem, obj.via.u64);
+}
+
+#endif // !defined(MSGPACK_USE_CPP03)

--- a/test/object_with_zone.cpp
+++ b/test/object_with_zone.cpp
@@ -1,10 +1,47 @@
-#include <msgpack.hpp>
+#include <msgpack_fwd.hpp>
 #include <gtest/gtest.h>
 #include <cmath>
 
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
+
+enum enum_test {
+    elem
+};
+
+MSGPACK_ADD_ENUM(enum_test);
+
+struct outer_enum {
+    enum enum_test {
+        elem
+    };
+};
+
+MSGPACK_ADD_ENUM(outer_enum::enum_test);
+
+#if !defined(MSGPACK_USE_CPP03)
+
+enum class enum_class_test {
+    elem
+};
+
+MSGPACK_ADD_ENUM(enum_class_test);
+
+struct outer_enum_class {
+    enum class enum_class_test {
+        elem
+    };
+};
+
+MSGPACK_ADD_ENUM(outer_enum_class::enum_class_test);
+
+#endif // !defined(MSGPACK_USE_CPP03)
+
+
+
+#include <msgpack.hpp>
+
 
 using namespace std;
 
@@ -615,7 +652,61 @@ TEST(object_with_zone, user_defined)
     EXPECT_EQ(v1.s, v2.s);
 }
 
+TEST(object_with_zone, construct_enum)
+{
+    msgpack::zone z;
+    msgpack::object obj(elem, z);
+    EXPECT_EQ(msgpack::type::POSITIVE_INTEGER, obj.type);
+    EXPECT_EQ(elem, obj.via.u64);
+}
+
 #if !defined(MSGPACK_USE_CPP03)
+
+TEST(object_with_zone, construct_enum_newstyle)
+{
+    msgpack::zone z;
+    msgpack::object obj(enum_test::elem, z);
+    EXPECT_EQ(msgpack::type::POSITIVE_INTEGER, obj.type);
+    EXPECT_EQ(elem, obj.via.u64);
+}
+
+#endif // !defined(MSGPACK_USE_CPP03)
+
+TEST(object_with_zone, construct_enum_outer)
+{
+    msgpack::zone z;
+    msgpack::object obj(outer_enum::elem, z);
+    EXPECT_EQ(msgpack::type::POSITIVE_INTEGER, obj.type);
+    EXPECT_EQ(elem, obj.via.u64);
+}
+
+#if !defined(MSGPACK_USE_CPP03)
+
+TEST(object_with_zone, construct_enum_outer_newstyle)
+{
+    msgpack::zone z;
+    msgpack::object obj(outer_enum::enum_test::elem, z);
+    EXPECT_EQ(msgpack::type::POSITIVE_INTEGER, obj.type);
+    EXPECT_EQ(elem, obj.via.u64);
+}
+
+TEST(object_with_zone, construct_class_enum)
+{
+    msgpack::zone z;
+    msgpack::object obj(enum_class_test::elem, z);
+    EXPECT_EQ(msgpack::type::POSITIVE_INTEGER, obj.type);
+    EXPECT_EQ(elem, obj.via.u64);
+}
+
+
+TEST(object_with_zone, construct_class_enum_outer)
+{
+    msgpack::zone z;
+    msgpack::object obj(outer_enum_class::enum_class_test::elem, z);
+    EXPECT_EQ(msgpack::type::POSITIVE_INTEGER, obj.type);
+    EXPECT_EQ(elem, obj.via.u64);
+}
+
 
 TEST(object_with_zone, array)
 {


### PR DESCRIPTION
enum support had been incomplete.
This fix made enum support complete.

Replaced int with auto on c++11 scoped enum.
Replaced template specializations with function overloads on operator<< and operator>> for enum.

enum can convert to object with or without zone.

When you want to adapt enum, you need to write as follows:

// NOT msgpack.hpp

enum yourenum {
    elem
};

MSGPACK_ADD_ENUM(yourenum);

// msgpack.hpp should be included after MSGPACK_ADD_ENUM(...)

int main() {
    msgpack::object obj(yourenum::elem);
}