### PR TITLE
Don't include byteswap.h and FreeBSD and OpenBSD.

### DIFF
--- a/include/msgpack/sysdep.h
+++ b/include/msgpack/sysdep.h
@@ -76,7 +76,8 @@ typedef unsigned int _msgpack_atomic_counter_t;
 #else
 
 #include <arpa/inet.h>  /* __BYTE_ORDER */
-#  if !defined(__APPLE__) && !(defined(__sun) && defined(__SVR4))
+#  if !defined(__APPLE__) && !defined(__FreeBSD__) && !defined(__OpenBSD__) && \
+       !(defined(__sun) && defined(__SVR4))
 #    include <byteswap.h>
 #  endif
 


### PR DESCRIPTION
This builds on #221 to include FreeBSD.  At the moment, we have to patch msgpack to work for FreeBSD and OpenBSD for Neovim.