### PR TITLE
Allowing msgpack to build on FreeBSD

### DIFF
--- a/include/msgpack/sysdep.h
+++ b/include/msgpack/sysdep.h
@@ -76,7 +76,7 @@ typedef unsigned int _msgpack_atomic_counter_t;
 #else
 
 #include <arpa/inet.h>  /* __BYTE_ORDER */
-#  if !defined(__APPLE__) && !(defined(__sun) && defined(__SVR4))
+#  if !defined(__APPLE__) && !(defined(__sun) && !defined(__FreeBSD__) && defined(__SVR4))
 #    include <byteswap.h>
 #  endif
 


### PR DESCRIPTION
FreeBSD doesn't have the byteswap header but __SVR4 is defined.