### PR TITLE
Small typos in quickstarts.

### DIFF
--- a/QUICKSTART-C.md
+++ b/QUICKSTART-C.md
@@ -2,7 +2,7 @@
 
 The serialization library is production-ready.
 
-Currently, no RPC implementation is not available.
+Currently, RPC implementation is not available.
 
 # Install
 

--- a/QUICKSTART-CPP.md
+++ b/QUICKSTART-CPP.md
@@ -2,7 +2,7 @@
 
 The serialization library is production-ready.
 
-Currently, RPC implementation is testing phase. Requires newer kernel, not running on RHEL5/CentOS5.
+Currently, RPC implementation is in testing phase. Requires newer kernel, not running on RHEL5/CentOS5.
 
 # Install
 


### PR DESCRIPTION
Fixed two small typos in descriptions of msgpack in both quickstart documents.