### PR TITLE
Do not interleave code and declarations in C files

### DIFF
--- a/include/msgpack/sysdep.h
+++ b/include/msgpack/sysdep.h
@@ -36,7 +36,7 @@ typedef unsigned __int64 uint64_t;
 #include <stdbool.h>
 #endif
 
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) && !defined(_LIB)
 #define MSGPACK_DLLEXPORT __declspec(dllexport)
 #else  /* _MSC_VER */
 #define MSGPACK_DLLEXPORT
@@ -92,7 +92,6 @@ typedef unsigned int _msgpack_atomic_counter_t;
 #define __LITTLE_ENDIAN__
 #endif
 #endif
-
 
 #ifdef __LITTLE_ENDIAN__
 
@@ -181,7 +180,6 @@ typedef unsigned int _msgpack_atomic_counter_t;
 #define _msgpack_load64(cast, from) \
     ({ cast val; memcpy(&val, (char*)from, 8); _msgpack_be64(val); })
 */
-
 
 #if !defined(__cplusplus) && defined(_MSC_VER)
 #  if !defined(FALSE)

--- a/include/msgpack/unpack_template.h
+++ b/include/msgpack/unpack_template.h
@@ -66,7 +66,6 @@ msgpack_unpack_struct_decl(_context) {
     msgpack_unpack_struct(_stack) stack[MSGPACK_EMBED_STACK_SIZE];
 };
 
-
 msgpack_unpack_func(void, _init)(msgpack_unpack_struct(_context)* ctx)
 {
     ctx->cs = MSGPACK_CS_HEADER;
@@ -93,10 +92,9 @@ msgpack_unpack_func(msgpack_unpack_object, _data)(msgpack_unpack_struct(_context
     return (ctx)->stack[0].obj;
 }
 
-
 msgpack_unpack_func(int, _execute)(msgpack_unpack_struct(_context)* ctx, const char* data, size_t len, size_t* off)
 {
-    assert(len >= *off);
+    /* assert(len >= *off); */
 
     const unsigned char* p = (unsigned char*)data + *off;
     const unsigned char* const pe = (unsigned char*)data + len;
@@ -252,7 +250,6 @@ msgpack_unpack_func(int, _execute)(msgpack_unpack_struct(_context)* ctx, const c
                 goto _failed;
             SWITCH_RANGE_END
             // end MSGPACK_CS_HEADER
-
 
         _fixed_trail_again:
             ++p;
@@ -432,7 +429,6 @@ _header_again:
     } while(p != pe);
     goto _out;
 
-
 _finish:
     stack[0].obj = obj;
     ++p;
@@ -457,7 +453,6 @@ _end:
 
     return ret;
 }
-
 
 #undef msgpack_unpack_func
 #undef msgpack_unpack_callback

--- a/src/objectc.c
+++ b/src/objectc.c
@@ -24,7 +24,6 @@
 #include <inttypes.h>
 #endif
 
-
 int msgpack_pack_object(msgpack_packer* pk, msgpack_object d)
 {
     switch(d.type) {
@@ -71,40 +70,45 @@ int msgpack_pack_object(msgpack_packer* pk, msgpack_object d)
     case MSGPACK_OBJECT_ARRAY:
         {
             int ret = msgpack_pack_array(pk, d.via.array.size);
-            if(ret < 0) { return ret; }
-
-            msgpack_object* o = d.via.array.ptr;
-            msgpack_object* const oend = d.via.array.ptr + d.via.array.size;
-            for(; o != oend; ++o) {
-                ret = msgpack_pack_object(pk, *o);
-                if(ret < 0) { return ret; }
+            if(ret < 0) {
+                return ret;
             }
+            else {
+                msgpack_object* o = d.via.array.ptr;
+                msgpack_object* const oend = d.via.array.ptr + d.via.array.size;
+                for(; o != oend; ++o) {
+                    ret = msgpack_pack_object(pk, *o);
+                    if(ret < 0) { return ret; }
+                }
 
-            return 0;
+                return 0;
+            }
         }
 
     case MSGPACK_OBJECT_MAP:
         {
             int ret = msgpack_pack_map(pk, d.via.map.size);
-            if(ret < 0) { return ret; }
-
-            msgpack_object_kv* kv = d.via.map.ptr;
-            msgpack_object_kv* const kvend = d.via.map.ptr + d.via.map.size;
-            for(; kv != kvend; ++kv) {
-                ret = msgpack_pack_object(pk, kv->key);
-                if(ret < 0) { return ret; }
-                ret = msgpack_pack_object(pk, kv->val);
-                if(ret < 0) { return ret; }
+            if(ret < 0) {
+                return ret;
             }
+            else {
+                msgpack_object_kv* kv = d.via.map.ptr;
+                msgpack_object_kv* const kvend = d.via.map.ptr + d.via.map.size;
+                for(; kv != kvend; ++kv) {
+                    ret = msgpack_pack_object(pk, kv->key);
+                    if(ret < 0) { return ret; }
+                    ret = msgpack_pack_object(pk, kv->val);
+                    if(ret < 0) { return ret; }
+                }
 
-            return 0;
+                return 0;
+            }
         }
 
     default:
         return -1;
     }
 }
-
 
 void msgpack_object_print(FILE* out, msgpack_object o)
 {
@@ -172,9 +176,9 @@ void msgpack_object_print(FILE* out, msgpack_object o)
         fprintf(out, "[");
         if(o.via.array.size != 0) {
             msgpack_object* p = o.via.array.ptr;
+            msgpack_object* const pend = o.via.array.ptr + o.via.array.size;
             msgpack_object_print(out, *p);
             ++p;
-            msgpack_object* const pend = o.via.array.ptr + o.via.array.size;
             for(; p < pend; ++p) {
                 fprintf(out, ", ");
                 msgpack_object_print(out, *p);
@@ -187,11 +191,11 @@ void msgpack_object_print(FILE* out, msgpack_object o)
         fprintf(out, "{");
         if(o.via.map.size != 0) {
             msgpack_object_kv* p = o.via.map.ptr;
+            msgpack_object_kv* const pend = o.via.map.ptr + o.via.map.size;
             msgpack_object_print(out, p->key);
             fprintf(out, "=>");
             msgpack_object_print(out, p->val);
             ++p;
-            msgpack_object_kv* const pend = o.via.map.ptr + o.via.map.size;
             for(; p < pend; ++p) {
                 fprintf(out, ", ");
                 msgpack_object_print(out, p->key);

--- a/src/unpack.c
+++ b/src/unpack.c
@@ -24,12 +24,10 @@
 #include _msgpack_atomic_counter_header
 #endif
 
-
 typedef struct {
     msgpack_zone* z;
     bool referenced;
 } unpack_user;
-
 
 #define msgpack_unpack_struct(name) \
     struct template ## name
@@ -44,7 +42,6 @@ typedef struct {
 
 #define msgpack_unpack_user unpack_user
 
-
 struct template_context;
 typedef struct template_context template_context;
 
@@ -55,11 +52,10 @@ static msgpack_object template_data(template_context* ctx);
 static int template_execute(
     template_context* ctx, const char* data, size_t len, size_t* off);
 
-
 static inline msgpack_object template_callback_root(unpack_user* u)
 {
-    MSGPACK_UNUSED(u);
     msgpack_object o;
+    MSGPACK_UNUSED(u);
     o.type = MSGPACK_OBJECT_NIL;
     return o;
 }
@@ -275,12 +271,10 @@ static inline int template_callback_ext(unpack_user* u, const char* b, const cha
 
 #include "msgpack/unpack_template.h"
 
-
 #define CTX_CAST(m) ((template_context*)(m))
 #define CTX_REFERENCED(mpac) CTX_CAST((mpac)->ctx)->user.referenced
 
 #define COUNTER_SIZE (sizeof(_msgpack_atomic_counter_t))
-
 
 static inline void init_count(void* buffer)
 {
@@ -306,26 +300,28 @@ static inline _msgpack_atomic_counter_t get_count(void* buffer)
     return *(volatile _msgpack_atomic_counter_t*)buffer;
 }
 
-
-
 bool msgpack_unpacker_init(msgpack_unpacker* mpac, size_t initial_buffer_size)
 {
+    char* buffer;
+    void* ctx;
+    msgpack_zone* z;
+
     if(initial_buffer_size < COUNTER_SIZE) {
         initial_buffer_size = COUNTER_SIZE;
     }
 
-    char* buffer = (char*)malloc(initial_buffer_size);
+    buffer = (char*)malloc(initial_buffer_size);
     if(buffer == NULL) {
         return false;
     }
 
-    void* ctx = malloc(sizeof(template_context));
+    ctx = malloc(sizeof(template_context));
     if(ctx == NULL) {
         free(buffer);
         return false;
     }
 
-    msgpack_zone* z = msgpack_zone_new(MSGPACK_ZONE_CHUNK_SIZE);
+    z = msgpack_zone_new(MSGPACK_ZONE_CHUNK_SIZE);
     if(z == NULL) {
         free(ctx);
         free(buffer);
@@ -356,7 +352,6 @@ void msgpack_unpacker_destroy(msgpack_unpacker* mpac)
     free(mpac->ctx);
     decr_count(mpac->buffer);
 }
-
 
 msgpack_unpacker* msgpack_unpacker_new(size_t initial_buffer_size)
 {
@@ -394,6 +389,7 @@ bool msgpack_unpacker_expand_buffer(msgpack_unpacker* mpac, size_t size)
     }
 
     if(mpac->off == COUNTER_SIZE) {
+        char* tmp;
         size_t next_size = (mpac->used + mpac->free) * 2;  // include COUNTER_SIZE
         while(next_size < size + mpac->used) {
             size_t tmp_next_size = next_size * 2;
@@ -404,7 +400,7 @@ bool msgpack_unpacker_expand_buffer(msgpack_unpacker* mpac, size_t size)
             next_size = tmp_next_size;
         }
 
-        char* tmp = (char*)realloc(mpac->buffer, next_size);
+        tmp = (char*)realloc(mpac->buffer, next_size);
         if(tmp == NULL) {
             return false;
         }
@@ -413,6 +409,7 @@ bool msgpack_unpacker_expand_buffer(msgpack_unpacker* mpac, size_t size)
         mpac->free = next_size - mpac->used;
 
     } else {
+        char* tmp;
         size_t next_size = mpac->initial_buffer_size;  // include COUNTER_SIZE
         size_t not_parsed = mpac->used - mpac->off;
         while(next_size < size + not_parsed + COUNTER_SIZE) {
@@ -424,7 +421,7 @@ bool msgpack_unpacker_expand_buffer(msgpack_unpacker* mpac, size_t size)
             next_size = tmp_next_size;
         }
 
-        char* tmp = (char*)malloc(next_size);
+        tmp = (char*)malloc(next_size);
         if(tmp == NULL) {
             return false;
         }
@@ -470,16 +467,19 @@ msgpack_object msgpack_unpacker_data(msgpack_unpacker* mpac)
 
 msgpack_zone* msgpack_unpacker_release_zone(msgpack_unpacker* mpac)
 {
+    msgpack_zone* r;
+    msgpack_zone* old;
+
     if(!msgpack_unpacker_flush_zone(mpac)) {
         return NULL;
     }
 
-    msgpack_zone* r = msgpack_zone_new(MSGPACK_ZONE_CHUNK_SIZE);
+    r = msgpack_zone_new(MSGPACK_ZONE_CHUNK_SIZE);
     if(r == NULL) {
         return NULL;
     }
 
-    msgpack_zone* old = mpac->z;
+    old = mpac->z;
     mpac->z = r;
     CTX_CAST(mpac->ctx)->user.z = mpac->z;
 
@@ -514,9 +514,11 @@ void msgpack_unpacker_reset(msgpack_unpacker* mpac)
 
 msgpack_unpack_return msgpack_unpacker_next(msgpack_unpacker* mpac, msgpack_unpacked* result)
 {
+    int ret;
+
     msgpack_unpacked_destroy(result);
 
-    int ret = msgpack_unpacker_execute(mpac);
+    ret = msgpack_unpacker_execute(mpac);
 
     if(ret < 0) {
         result->zone = NULL;
@@ -534,7 +536,6 @@ msgpack_unpack_return msgpack_unpacker_next(msgpack_unpacker* mpac, msgpack_unpa
     return MSGPACK_UNPACK_SUCCESS;
 }
 
-
 msgpack_unpack_return
 msgpack_unpack(const char* data, size_t len, size_t* off,
         msgpack_zone* result_zone, msgpack_object* result)
@@ -546,40 +547,42 @@ msgpack_unpack(const char* data, size_t len, size_t* off,
         // FIXME
         return MSGPACK_UNPACK_CONTINUE;
     }
+    else {
+        int e;
+        template_context ctx;
+        template_init(&ctx);
 
-    template_context ctx;
-    template_init(&ctx);
+        ctx.user.z = result_zone;
+        ctx.user.referenced = false;
 
-    ctx.user.z = result_zone;
-    ctx.user.referenced = false;
+        e = template_execute(&ctx, data, len, &noff);
+        if(e < 0) {
+            return MSGPACK_UNPACK_PARSE_ERROR;
+        }
 
-    int e = template_execute(&ctx, data, len, &noff);
-    if(e < 0) {
-        return MSGPACK_UNPACK_PARSE_ERROR;
+        if(off != NULL) { *off = noff; }
+
+        if(e == 0) {
+            return MSGPACK_UNPACK_CONTINUE;
+        }
+
+        *result = template_data(&ctx);
+
+        if(noff < len) {
+            return MSGPACK_UNPACK_EXTRA_BYTES;
+        }
+
+        return MSGPACK_UNPACK_SUCCESS;
     }
-
-    if(off != NULL) { *off = noff; }
-
-    if(e == 0) {
-        return MSGPACK_UNPACK_CONTINUE;
-    }
-
-    *result = template_data(&ctx);
-
-    if(noff < len) {
-        return MSGPACK_UNPACK_EXTRA_BYTES;
-    }
-
-    return MSGPACK_UNPACK_SUCCESS;
 }
 
 msgpack_unpack_return
 msgpack_unpack_next(msgpack_unpacked* result,
         const char* data, size_t len, size_t* off)
 {
+    size_t noff = 0;
     msgpack_unpacked_destroy(result);
 
-    size_t noff = 0;
     if(off != NULL) { noff = *off; }
 
     if(len <= noff) {
@@ -593,29 +596,31 @@ msgpack_unpack_next(msgpack_unpacked* result,
     if (!result->zone) {
         return MSGPACK_UNPACK_NOMEM_ERROR;
     }
+    else {
+        int e;
+        template_context ctx;
+        template_init(&ctx);
 
-    template_context ctx;
-    template_init(&ctx);
+        ctx.user.z = result->zone;
+        ctx.user.referenced = false;
 
-    ctx.user.z = result->zone;
-    ctx.user.referenced = false;
+        e = template_execute(&ctx, data, len, &noff);
+        if(e < 0) {
+            msgpack_zone_free(result->zone);
+            result->zone = NULL;
+            return MSGPACK_UNPACK_PARSE_ERROR;
+        }
 
-    int e = template_execute(&ctx, data, len, &noff);
-    if(e < 0) {
-        msgpack_zone_free(result->zone);
-        result->zone = NULL;
-        return MSGPACK_UNPACK_PARSE_ERROR;
+        if(off != NULL) { *off = noff; }
+
+        if(e == 0) {
+            return MSGPACK_UNPACK_CONTINUE;
+        }
+
+        result->data = template_data(&ctx);
+
+        return MSGPACK_UNPACK_SUCCESS;
     }
-
-    if(off != NULL) { *off = noff; }
-
-    if(e == 0) {
-        return MSGPACK_UNPACK_CONTINUE;
-    }
-
-    result->data = template_data(&ctx);
-
-    return MSGPACK_UNPACK_SUCCESS;
 }
 
 #if defined(MSGPACK_OLD_COMPILER_BUS_ERROR_WORKAROUND)

--- a/src/zone.c
+++ b/src/zone.c
@@ -75,6 +75,7 @@ static inline void clear_chunk_list(msgpack_zone_chunk_list* cl, size_t chunk_si
 void* msgpack_zone_malloc_expand(msgpack_zone* zone, size_t size)
 {
     msgpack_zone_chunk_list* const cl = &zone->chunk_list;
+    msgpack_zone_chunk* chunk;
 
     size_t sz = zone->chunk_size;
 
@@ -87,18 +88,21 @@ void* msgpack_zone_malloc_expand(msgpack_zone* zone, size_t size)
         sz = tmp_sz;
     }
 
-    msgpack_zone_chunk* chunk = (msgpack_zone_chunk*)malloc(
+    chunk = (msgpack_zone_chunk*)malloc(
             sizeof(msgpack_zone_chunk) + sz);
-    if (chunk == NULL)  return NULL;
-    char* ptr = ((char*)chunk) + sizeof(msgpack_zone_chunk);
-    chunk->next = cl->head;
-    cl->head = chunk;
-    cl->free = sz - size;
-    cl->ptr  = ptr + size;
+    if (chunk == NULL) {
+        return NULL;
+    }
+    else {
+        char* ptr = ((char*)chunk) + sizeof(msgpack_zone_chunk);
+        chunk->next = cl->head;
+        cl->head = chunk;
+        cl->free = sz - size;
+        cl->ptr  = ptr + size;
 
-    return ptr;
+        return ptr;
+    }
 }
-
 
 static inline void init_finalizer_array(msgpack_zone_finalizer_array* fa)
 {
@@ -131,6 +135,7 @@ bool msgpack_zone_push_finalizer_expand(msgpack_zone* zone,
         void (*func)(void* data), void* data)
 {
     msgpack_zone_finalizer_array* const fa = &zone->finalizer_array;
+    msgpack_zone_finalizer* tmp;
 
     const size_t nused = (size_t)(fa->end - fa->array);
 
@@ -143,8 +148,7 @@ bool msgpack_zone_push_finalizer_expand(msgpack_zone* zone,
         nnext = nused * 2;
     }
 
-    msgpack_zone_finalizer* tmp =
-        (msgpack_zone_finalizer*)realloc(fa->array,
+    tmp = (msgpack_zone_finalizer*)realloc(fa->array,
                 sizeof(msgpack_zone_finalizer) * nnext);
     if(tmp == NULL) {
         return false;
@@ -162,7 +166,6 @@ bool msgpack_zone_push_finalizer_expand(msgpack_zone* zone,
     return true;
 }
 
-
 bool msgpack_zone_is_empty(msgpack_zone* zone)
 {
     msgpack_zone_chunk_list* const cl = &zone->chunk_list;
@@ -170,7 +173,6 @@ bool msgpack_zone_is_empty(msgpack_zone* zone)
     return cl->free == zone->chunk_size && cl->head->next == NULL &&
         fa->tail == fa->array;
 }
-
 
 void msgpack_zone_destroy(msgpack_zone* zone)
 {


### PR DESCRIPTION
Avoid C99 style to interleave code and declarations in order to compile msgpackc with MSVC