### PR TITLE
I've moved msgpack::packer<Stream>& operator<< (msgpack::packer<Stream>&...

### DIFF
--- a/include/msgpack/object.hpp
+++ b/include/msgpack/object.hpp
@@ -196,6 +196,14 @@ struct packer_serializer {
 };
 }
 
+// serialize operator
+template <typename Stream, typename T>
+inline msgpack::packer<Stream>& operator<< (msgpack::packer<Stream>& o, const T& v)
+{
+    return detail::packer_serializer<Stream, T>::pack(o, v);
+}
+
+
 inline void operator<< (msgpack::object::with_zone& o, const msgpack::object& v)
 {
     o.type = v.type;

--- a/include/msgpack/pack.hpp
+++ b/include/msgpack/pack.hpp
@@ -139,14 +139,6 @@ inline void pack(Stream& s, const T& v)
     packer<Stream>(s).pack(v);
 }
 
-// serialize operator
-template <typename Stream, typename T>
-inline msgpack::packer<Stream>& operator<< (msgpack::packer<Stream>& o, const T& v)
-{
-    return detail::packer_serializer<Stream, T>::pack(o, v);
-}
-
-
 
 #if defined(__LITTLE_ENDIAN__)
 template <typename T>


### PR DESCRIPTION
... o, const T& v) from object.hpp to pack.hpp. (#238) At that time, I thought it is a part of pack APIs. But now, I realized that it is a part of object implementation. So, I reverted #238.