### PR TITLE
Recovered a minimal support for Doxygen.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -245,6 +245,8 @@ IF (DOXYGEN_FOUND)
         COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile_c
         COMMAND ${CMAKE_COMMAND} -E echo "FILE_PATTERNS      = *.h" >> ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile_c
         COMMAND ${CMAKE_COMMAND} -E echo "OUTPUT_DIRECTORY   = doc_c" >> ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile_c
+        COMMAND ${CMAKE_COMMAND} -E echo "INPUT              = ${CMAKE_CURRENT_SOURCE_DIR}/include" >> ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile_c
+        COMMAND ${CMAKE_COMMAND} -E echo "EXTRACT_ALL        = YES" >> ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile_c
         COMMAND ${CMAKE_COMMAND} -E echo "PROJECT_NAME       = \"MessagePack for C\"" >> ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile_c
         COMMAND ${DOXYGEN_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile_c
         VERBATIM
@@ -254,6 +256,8 @@ IF (DOXYGEN_FOUND)
         COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile_cpp
         COMMAND ${CMAKE_COMMAND} -E echo "FILE_PATTERNS      = *.hpp" >> ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile_cpp
         COMMAND ${CMAKE_COMMAND} -E echo "OUTPUT_DIRECTORY   = doc_cpp" >> ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile_cpp
+        COMMAND ${CMAKE_COMMAND} -E echo "INPUT              = ${CMAKE_CURRENT_SOURCE_DIR}/include" >> ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile_cpp
+        COMMAND ${CMAKE_COMMAND} -E echo "EXTRACT_ALL        = YES" >> ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile_cpp
         COMMAND ${CMAKE_COMMAND} -E echo "PROJECT_NAME       = \"MessagePack for C++\"" >> ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile_cpp
         COMMAND ${DOXYGEN_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile_cpp
         VERBATIM

--- a/erb/cpp03_define.hpp.erb
+++ b/erb/cpp03_define.hpp.erb
@@ -42,7 +42,9 @@
 // MSGPACK_ADD_ENUM must be used in the global namespace.
 #define MSGPACK_ADD_ENUM(enum) \
   namespace msgpack { \
+  /** @cond */ \
   MSGPACK_API_VERSION_NAMESPACE(v1) { \
+  /** @endcond */ \
     inline msgpack::object const& operator>> (msgpack::object const& o, enum& v) \
     { \
       int tmp; \
@@ -66,18 +68,22 @@
         } \
       }; \
     } \
+  /** @cond */ \
   } \
+  /** @endcond */ \
   }
 
 namespace msgpack {
+/// @cond
 MSGPACK_API_VERSION_NAMESPACE(v1) {
+/// @endcond
 namespace type {
 
-
+/// @cond
 <% GENERATION_LIMIT = 31 %>
 template <typename A0 = void<%1.upto(GENERATION_LIMIT+1) {|i|%>, typename A<%=i%> = void<%}%>>
 struct define;
-
+/// @endcond
 
 template <>
 struct define<> {
@@ -99,6 +105,8 @@ struct define<> {
         o->via.array.size = 0;
     }
 };
+
+/// @cond
 <%0.upto(GENERATION_LIMIT) {|i|%>
 template <typename A0<%1.upto(i) {|j|%>, typename A<%=j%><%}%>>
 struct define<A0<%1.upto(i) {|j|%>, A<%=j%><%}%>> {
@@ -137,11 +145,14 @@ struct define<A0<%1.upto(i) {|j|%>, A<%=j%><%}%>> {
     A<%=j%>& a<%=j%>;<%}%>
 };
 <%}%>
+/// @endcond
 
 inline define<> make_define()
 {
     return define<>();
 }
+
+/// @cond
 <%0.upto(GENERATION_LIMIT) {|i|%>
 template <typename A0<%1.upto(i) {|j|%>, typename A<%=j%><%}%>>
 define<A0<%1.upto(i) {|j|%>, A<%=j%><%}%>> make_define(A0& a0<%1.upto(i) {|j|%>, A<%=j%>& a<%=j%><%}%>)
@@ -149,9 +160,12 @@ define<A0<%1.upto(i) {|j|%>, A<%=j%><%}%>> make_define(A0& a0<%1.upto(i) {|j|%>,
     return define<A0<%1.upto(i) {|j|%>, A<%=j%><%}%>>(a0<%1.upto(i) {|j|%>, a<%=j%><%}%>);
 }
 <%}%>
+/// @endcond
 
 }  // namespace type
+/// @cond
 }  // MSGPACK_API_VERSION_NAMESPACE(v1)
+/// @endcond
 }  // namespace msgpack
 
 

--- a/erb/cpp03_msgpack_tuple.hpp.erb
+++ b/erb/cpp03_msgpack_tuple.hpp.erb
@@ -23,7 +23,9 @@
 
 namespace msgpack {
 
+/// @cond
 MSGPACK_API_VERSION_NAMESPACE(v1) {
+/// @endcond
 
 namespace type {
 
@@ -31,8 +33,10 @@ namespace type {
 // FIXME operator!=
 <% GENERATION_LIMIT = 31 %>
 
+/// @cond
 template <typename A0<%1.upto(GENERATION_LIMIT+1) {|i|%>, typename A<%=i%><%}%>>
 struct tuple;
+/// @endcond
 
 template <typename Tuple, int N>
 struct tuple_element;
@@ -67,6 +71,7 @@ struct tuple_type<const T&> {
     typedef const T& transparent_reference;
 };
 
+/// @cond
 <%0.upto(GENERATION_LIMIT) {|i|%>
 <%0.upto(i) {|j|%>
 template <typename A0<%1.upto(i) {|k|%>, typename A<%=k%><%}%>>
@@ -91,6 +96,7 @@ private:
 };
 <%}%>
 <%}%>
+/// @endcond
 
 template <>
 struct tuple<> {
@@ -98,6 +104,8 @@ struct tuple<> {
     tuple(msgpack::object const& o) { o.convert(*this); }
     typedef tuple<> value_type;
 };
+
+/// @cond
 <%0.upto(GENERATION_LIMIT) {|i|%>
 template <typename A0<%1.upto(i) {|j|%>, typename A<%=j%><%}%>>
 struct tuple<A0<%1.upto(i) {|j|%>, A<%=j%><%}%>> {
@@ -121,11 +129,14 @@ template <int N, typename A0<%1.upto(i) {|j|%>, typename A<%=j%><%}%>>
 inline typename type::const_tuple_element<type::tuple<A0<%1.upto(i) {|j|%>, A<%=j%><%}%>>, N>::const_reference get(type::tuple<A0<%1.upto(i) {|j|%>, A<%=j%><%}%>> const& t)
 { return t.template get<N>(); }
 <%}%>
+/// @endcond
 
 inline tuple<> make_tuple()
 {
     return tuple<>();
 }
+
+/// @cond
 <%0.upto(GENERATION_LIMIT) {|i|%>
 template <typename A0<%1.upto(i) {|j|%>, typename A<%=j%><%}%>>
 inline tuple<A0<%1.upto(i) {|j|%>, A<%=j%><%}%>> make_tuple(typename tuple_type<A0>::transparent_reference a0<%1.upto(i) {|j|%>, typename tuple_type<A<%=j%>>::transparent_reference a<%=j%><%}%>)
@@ -133,6 +144,7 @@ inline tuple<A0<%1.upto(i) {|j|%>, A<%=j%><%}%>> make_tuple(typename tuple_type<
     return tuple<A0<%1.upto(i) {|j|%>, A<%=j%><%}%>>(a0<%1.upto(i) {|j|%>, a<%=j%><%}%>);
 }
 <%}%>
+/// @endcond
 
 }  // namespace type
 
@@ -142,6 +154,8 @@ inline msgpack::object const& operator>> (
     if(o.type != msgpack::type::ARRAY) { throw msgpack::type_error(); }
     return o;
 }
+
+/// @cond
 <%0.upto(GENERATION_LIMIT) {|i|%>
 template <typename A0<%1.upto(i) {|j|%>, typename A<%=j%><%}%>>
 inline msgpack::object const& operator>> (
@@ -154,6 +168,7 @@ inline msgpack::object const& operator>> (
     return o;
 }
 <%}%>
+/// @endcond
 
 template <typename Stream>
 inline const msgpack::packer<Stream>& operator<< (
@@ -162,6 +177,8 @@ inline const msgpack::packer<Stream>& operator<< (
     o.pack_array(0);
     return o;
 }
+
+/// @cond
 <%0.upto(GENERATION_LIMIT) {|i|%>
 template <typename Stream, typename A0<%1.upto(i) {|j|%>, typename A<%=j%><%}%>>
 inline const msgpack::packer<Stream>& operator<< (
@@ -173,6 +190,7 @@ inline const msgpack::packer<Stream>& operator<< (
     return o;
 }
 <%}%>
+/// @endcond
 
 inline void operator<< (
         msgpack::object::with_zone& o,
@@ -181,6 +199,8 @@ inline void operator<< (
     o.via.array.ptr = nullptr;
     o.via.array.size = 0;
 }
+
+/// @cond
 <%0.upto(GENERATION_LIMIT) {|i|%>
 template <typename A0<%1.upto(i) {|j|%>, typename A<%=j%><%}%>>
 inline void operator<< (
@@ -193,8 +213,11 @@ inline void operator<< (
     o.via.array.ptr[<%=j%>] = msgpack::object(v.template get<<%=j%>>(), o.zone);<%}%>
 }
 <%}%>
+/// @endcond
 
+/// @cond
 }  // MSGPACK_API_VERSION_NAMESPACE(v1)
+/// @endcond
 
 }  // namespace msgpack
 

--- a/erb/cpp03_msgpack_tuple_fwd.hpp.erb
+++ b/erb/cpp03_msgpack_tuple_fwd.hpp.erb
@@ -23,7 +23,9 @@
 
 namespace msgpack {
 
+/// @cond
 MSGPACK_API_VERSION_NAMESPACE(v1) {
+/// @endcond
 
 namespace type {
 
@@ -31,8 +33,10 @@ namespace type {
 // FIXME operator!=
 <% GENERATION_LIMIT = 31 %>
 
+/// @cond
 template <typename A0 = void<%1.upto(GENERATION_LIMIT+1) {|i|%>, typename A<%=i%> = void<%}%>>
 struct tuple;
+/// @endcond
 
 template <typename Tuple, int N>
 struct tuple_element;
@@ -43,6 +47,7 @@ struct const_tuple_element;
 template <typename T>
 struct tuple_type;
 
+/// @cond
 <%0.upto(GENERATION_LIMIT) {|i|%>
 <%0.upto(i) {|j|%>
 template <typename A0<%1.upto(i) {|k|%>, typename A<%=k%><%}%>>
@@ -56,9 +61,12 @@ template <typename A0<%1.upto(i) {|k|%>, typename A<%=k%><%}%>>
 struct const_tuple_element<tuple<A0<%1.upto(i) {|k|%>, A<%=k%><%}%>>, <%=j%>>;
 <%}%>
 <%}%>
+/// @endcond
 
 template <>
 struct tuple<>;
+
+/// @cond
 <%0.upto(GENERATION_LIMIT) {|i|%>
 template <typename A0<%1.upto(i) {|j|%>, typename A<%=j%><%}%>>
 struct tuple<A0<%1.upto(i) {|j|%>, A<%=j%><%}%>>;
@@ -74,6 +82,7 @@ tuple<> make_tuple();
 template <typename A0<%1.upto(i) {|j|%>, typename A<%=j%><%}%>>
 tuple<A0<%1.upto(i) {|j|%>, A<%=j%><%}%>> make_tuple(typename tuple_type<A0>::transparent_reference a0<%1.upto(i) {|j|%>, typename tuple_type<A<%=j%>>::transparent_reference a<%=j%><%}%>);
 <%}%>
+/// @endcond
 
 }  // namespace type
 
@@ -81,36 +90,45 @@ msgpack::object const& operator>> (
     msgpack::object const& o,
     type::tuple<>&);
 
+/// @cond
 <%0.upto(GENERATION_LIMIT) {|i|%>
 template <typename A0<%1.upto(i) {|j|%>, typename A<%=j%><%}%>>
 msgpack::object const& operator>> (
     msgpack::object const& o,
     type::tuple<A0<%1.upto(i) {|j|%>, A<%=j%><%}%>>& v);
 <%}%>
+/// @endcond
 
 template <typename Stream>
 const msgpack::packer<Stream>& operator<< (
     msgpack::packer<Stream>& o,
     const type::tuple<>&);
 
+/// @cond
 <%0.upto(GENERATION_LIMIT) {|i|%>
 template <typename Stream, typename A0<%1.upto(i) {|j|%>, typename A<%=j%><%}%>>
 const msgpack::packer<Stream>& operator<< (
     msgpack::packer<Stream>& o,
     const type::tuple<A0<%1.upto(i) {|j|%>, A<%=j%><%}%>>& v);
 <%}%>
+/// @endcond
 
 void operator<< (
     msgpack::object::with_zone& o,
     const type::tuple<>&);
+
+/// @cond
 <%0.upto(GENERATION_LIMIT) {|i|%>
 template <typename A0<%1.upto(i) {|j|%>, typename A<%=j%><%}%>>
 void operator<< (
     msgpack::object::with_zone& o,
     const type::tuple<A0<%1.upto(i) {|j|%>, A<%=j%><%}%>>& v);
 <%}%>
+/// @endcond
 
+/// @cond
 }  // MSGPACK_API_VERSION_NAMESPACE(v1)
+/// @endcond
 
 }  // namespace msgpack
 

--- a/erb/cpp03_zone.hpp.erb
+++ b/erb/cpp03_zone.hpp.erb
@@ -35,7 +35,9 @@
 <% GENERATION_LIMIT = 15 %>
 namespace msgpack {
 
+/// @cond
 MSGPACK_API_VERSION_NAMESPACE(v1) {
+/// @endcond
 
 class zone {
     struct finalizer {
@@ -179,10 +181,12 @@ public:
     {
         ::operator delete(p, place);
     }
+    /// @cond
     <%0.upto(GENERATION_LIMIT) {|i|%>
     template <typename T<%1.upto(i) {|j|%>, typename A<%=j%><%}%>>
     T* allocate(<%=(1..i).map{|j|"A#{j} a#{j}"}.join(', ')%>);
     <%}%>
+    /// @endcond
 
 private:
     void undo_allocate(size_t size);
@@ -304,6 +308,7 @@ inline void zone::undo_allocate(size_t size)
     m_chunk_list.m_free += size;
 }
 
+/// @cond
 <%0.upto(GENERATION_LIMIT) {|i|%>
 template <typename T<%1.upto(i) {|j|%>, typename A<%=j%><%}%>>
 T* zone::allocate(<%=(1..i).map{|j|"A#{j} a#{j}"}.join(', ')%>)
@@ -324,8 +329,11 @@ T* zone::allocate(<%=(1..i).map{|j|"A#{j} a#{j}"}.join(', ')%>)
     }
 }
 <%}%>
+/// @endcond
 
+/// @cond
 }  // MSGPACK_API_VERSION_NAMESPACE(v1)
+/// @endcond
 
 }  // namespace msgpack
 

--- a/include/msgpack/adaptor/bool.hpp
+++ b/include/msgpack/adaptor/bool.hpp
@@ -24,7 +24,9 @@
 
 namespace msgpack {
 
+/// @cond
 MSGPACK_API_VERSION_NAMESPACE(v1) {
+/// @endcond
 
 inline msgpack::object const& operator>> (msgpack::object const& o, bool& v)
 {
@@ -51,7 +53,9 @@ inline void operator<< (msgpack::object::with_zone& o, bool v)
     { static_cast<msgpack::object&>(o) << v; }
 
 
+/// @cond
 }  // MSGPACK_API_VERSION_NAMESPACE(v1)
+/// @endcond
 
 }  // namespace msgpack
 

--- a/include/msgpack/adaptor/bool_fwd.hpp
+++ b/include/msgpack/adaptor/bool_fwd.hpp
@@ -23,7 +23,9 @@
 
 namespace msgpack {
 
+/// @cond
 MSGPACK_API_VERSION_NAMESPACE(v1) {
+/// @endcond
 
 msgpack::object const& operator>> (msgpack::object const& o, bool& v);
 template <typename Stream>
@@ -32,7 +34,9 @@ void operator<< (msgpack::object& o, bool v);
 void operator<< (msgpack::object::with_zone& o, bool v);
 
 
+/// @cond
 }  // MSGPACK_API_VERSION_NAMESPACE(v1)
+/// @endcond
 
 }  // namespace msgpack
 

--- a/include/msgpack/adaptor/char_ptr.hpp
+++ b/include/msgpack/adaptor/char_ptr.hpp
@@ -26,7 +26,9 @@
 
 namespace msgpack {
 
+/// @cond
 MSGPACK_API_VERSION_NAMESPACE(v1) {
+/// @endcond
 
 template <typename Stream>
 inline msgpack::packer<Stream>& operator<< (msgpack::packer<Stream>& o, const char* v)
@@ -71,7 +73,9 @@ inline void operator<< (object& o, char* v)
     msgpack::operator<<(o, static_cast<const char*>(v));
 }
 
+/// @cond
 }  // MSGPACK_API_VERSION_NAMESPACE(v1)
+/// @endcond
 
 }  // namespace msgpack
 

--- a/include/msgpack/adaptor/char_ptr_fwd.hpp
+++ b/include/msgpack/adaptor/char_ptr_fwd.hpp
@@ -24,7 +24,9 @@
 
 namespace msgpack {
 
+/// @cond
 MSGPACK_API_VERSION_NAMESPACE(v1) {
+/// @endcond
 
 template <typename Stream>
 msgpack::packer<Stream>& operator<< (msgpack::packer<Stream>& o, const char* v);
@@ -36,7 +38,9 @@ packer<Stream>& operator<< (packer<Stream>& o, char* v);
 void operator<< (object::with_zone& o, char* v);
 void operator<< (object& o, char* v);
 
+/// @cond
 }  // MSGPACK_API_VERSION_NAMESPACE(v1)
+/// @endcond
 
 }  // namespace msgpack
 

--- a/include/msgpack/adaptor/check_container_size.hpp
+++ b/include/msgpack/adaptor/check_container_size.hpp
@@ -23,7 +23,9 @@
 
 namespace msgpack {
 
+/// @cond
 MSGPACK_API_VERSION_NAMESPACE(v1) {
+/// @endcond
 
 struct container_size_overflow : public std::runtime_error {
     explicit container_size_overflow(const std::string& msg)
@@ -54,7 +56,9 @@ inline uint32_t checked_get_container_size(T size) {
 }
 
 
+/// @cond
 }  // MSGPACK_API_VERSION_NAMESPACE(v1)
+/// @endcond
 
 }  // namespace msgpack
 

--- a/include/msgpack/adaptor/cpp11/array.hpp
+++ b/include/msgpack/adaptor/cpp11/array.hpp
@@ -27,7 +27,9 @@
 
 namespace msgpack {
 
+/// @cond
 MSGPACK_API_VERSION_NAMESPACE(v1) {
+/// @endcond
 
 template <typename T, std::size_t N>
 inline msgpack::object const& operator>> (msgpack::object const& o, std::array<T, N>& v) {
@@ -69,7 +71,9 @@ inline void operator<< (msgpack::object::with_zone& o, const std::array<T, N>& v
     }
 }
 
+/// @cond
 }  // MSGPACK_API_VERSION_NAMESPACE(v1)
+/// @endcond
 
 } // namespace msgpack
 

--- a/include/msgpack/adaptor/cpp11/array_char.hpp
+++ b/include/msgpack/adaptor/cpp11/array_char.hpp
@@ -26,7 +26,9 @@
 
 namespace msgpack {
 
+/// @cond
 MSGPACK_API_VERSION_NAMESPACE(v1) {
+/// @endcond
 
 template <std::size_t N>
 inline msgpack::object const& operator>> (msgpack::object const& o, std::array<char, N>& v)
@@ -77,7 +79,9 @@ inline void operator<< (msgpack::object::with_zone& o, const std::array<char, N>
     std::memcpy(ptr, v.data(), size);
 }
 
+/// @cond
 }  // MSGPACK_API_VERSION_NAMESPACE(v1)
+/// @endcond
 
 }  // namespace msgpack
 

--- a/include/msgpack/adaptor/cpp11/array_char_fwd.hpp
+++ b/include/msgpack/adaptor/cpp11/array_char_fwd.hpp
@@ -24,7 +24,9 @@
 
 namespace msgpack {
 
+/// @cond
 MSGPACK_API_VERSION_NAMESPACE(v1) {
+/// @endcond
 
 template <std::size_t N>
 msgpack::object const& operator>> (msgpack::object const& o, std::array<char, N>& v);
@@ -38,7 +40,9 @@ void operator<< (msgpack::object& o, const std::array<char, N>& v);
 template <std::size_t N>
 void operator<< (msgpack::object::with_zone& o, const std::array<char, N>& v);
 
+/// @cond
 }  // MSGPACK_API_VERSION_NAMESPACE(v1)
+/// @endcond
 
 }  // namespace msgpack
 

--- a/include/msgpack/adaptor/cpp11/array_fwd.hpp
+++ b/include/msgpack/adaptor/cpp11/array_fwd.hpp
@@ -26,7 +26,9 @@
 
 namespace msgpack {
 
+/// @cond
 MSGPACK_API_VERSION_NAMESPACE(v1) {
+/// @endcond
 
 template <typename T, std::size_t N>
 msgpack::object const& operator>> (msgpack::object const& o, std::array<T, N>& v);
@@ -37,7 +39,9 @@ msgpack::packer<Stream>& operator<< (msgpack::packer<Stream>& o, const std::arra
 template <typename T, std::size_t N>
 void operator<< (msgpack::object::with_zone& o, const std::array<T, N>& v);
 
+/// @cond
 }  // MSGPACK_API_VERSION_NAMESPACE(v1)
+/// @endcond
 
 } // namespace msgpack
 

--- a/include/msgpack/adaptor/cpp11/forward_list.hpp
+++ b/include/msgpack/adaptor/cpp11/forward_list.hpp
@@ -27,7 +27,9 @@
 
 namespace msgpack {
 
+/// @cond
 MSGPACK_API_VERSION_NAMESPACE(v1) {
+/// @endcond
 
 template <typename T>
 inline msgpack::object const& operator>> (msgpack::object const& o, std::forward_list<T>& v)
@@ -68,7 +70,9 @@ inline void operator<< (msgpack::object::with_zone& o, const std::forward_list<T
     }
 }
 
+/// @cond
 }  // MSGPACK_API_VERSION_NAMESPACE(v1)
+/// @endcond
 
 } // namespace msgpack
 

--- a/include/msgpack/adaptor/cpp11/forward_list_fwd.hpp
+++ b/include/msgpack/adaptor/cpp11/forward_list_fwd.hpp
@@ -26,7 +26,9 @@
 
 namespace msgpack {
 
+/// @cond
 MSGPACK_API_VERSION_NAMESPACE(v1) {
+/// @endcond
 
 template <typename T>
 msgpack::object const& operator>> (msgpack::object const& o, std::forward_list<T>& v);
@@ -37,7 +39,9 @@ msgpack::packer<Stream>& operator<< (msgpack::packer<Stream>& o, const std::forw
 template <typename T>
 void operator<< (msgpack::object::with_zone& o, const std::forward_list<T>& v);
 
+/// @cond
 }  // MSGPACK_API_VERSION_NAMESPACE(v1)
+/// @endcond
 
 } // namespace msgpack
 

--- a/include/msgpack/adaptor/cpp11/tuple.hpp
+++ b/include/msgpack/adaptor/cpp11/tuple.hpp
@@ -26,7 +26,9 @@
 
 namespace msgpack {
 
+/// @cond
 MSGPACK_API_VERSION_NAMESPACE(v1) {
+/// @endcond
 
 // --- Pack from tuple to packer stream ---
 template <typename Stream, typename Tuple, std::size_t N>
@@ -145,7 +147,9 @@ inline void operator<< (
     StdTupleToObjectWithZone<decltype(v), sizeof...(Args)>::convert(o, v);
 }
 
+/// @cond
 } // MSGPACK_API_VERSION_NAMESPACE(v1)
+/// @endcond
 
 } // namespace msgpack
 

--- a/include/msgpack/adaptor/cpp11/tuple_fwd.hpp
+++ b/include/msgpack/adaptor/cpp11/tuple_fwd.hpp
@@ -25,7 +25,9 @@
 
 namespace msgpack {
 
+/// @cond
 MSGPACK_API_VERSION_NAMESPACE(v1) {
+/// @endcond
 
 // --- Pack from tuple to packer stream ---
 template <typename Stream, typename Tuple, std::size_t N>
@@ -55,7 +57,9 @@ void operator<< (
     msgpack::object::with_zone& o,
     std::tuple<Args...> const& v);
 
+/// @cond
 } // MSGPACK_API_VERSION_NAMESPACE(v1)
+/// @endcond
 
 } // namespace msgpack
 

--- a/include/msgpack/adaptor/cpp11/unordered_map.hpp
+++ b/include/msgpack/adaptor/cpp11/unordered_map.hpp
@@ -26,7 +26,9 @@
 
 namespace msgpack {
 
+/// @cond
 MSGPACK_API_VERSION_NAMESPACE(v1) {
+/// @endcond
 
 template <typename K, typename V>
 inline msgpack::object const& operator>> (msgpack::object const& o, std::unordered_map<K, V>& v)
@@ -134,7 +136,9 @@ inline void operator<< (msgpack::object::with_zone& o, const std::unordered_mult
     }
 }
 
+/// @cond
 }  // MSGPACK_API_VERSION_NAMESPACE(v1)
+/// @endcond
 
 }  // namespace msgpack
 

--- a/include/msgpack/adaptor/cpp11/unordered_map_fwd.hpp
+++ b/include/msgpack/adaptor/cpp11/unordered_map_fwd.hpp
@@ -25,7 +25,9 @@
 
 namespace msgpack {
 
+/// @cond
 MSGPACK_API_VERSION_NAMESPACE(v1) {
+/// @endcond
 
 template <typename K, typename V>
 msgpack::object const& operator>> (msgpack::object const& o, std::unordered_map<K, V>& v);
@@ -45,7 +47,9 @@ msgpack::packer<Stream>& operator<< (msgpack::packer<Stream>& o, const std::unor
 template <typename K, typename V>
 void operator<< (msgpack::object::with_zone& o, const std::unordered_multimap<K,V>& v);
 
+/// @cond
 }  // MSGPACK_API_VERSION_NAMESPACE(v1)
+/// @endcond
 
 }  // namespace msgpack
 

--- a/include/msgpack/adaptor/cpp11/unordered_set.hpp
+++ b/include/msgpack/adaptor/cpp11/unordered_set.hpp
@@ -26,7 +26,9 @@
 
 namespace msgpack {
 
+/// @cond
 MSGPACK_API_VERSION_NAMESPACE(v1) {
+/// @endcond
 
 template <typename T>
 inline msgpack::object const& operator>> (msgpack::object const& o, std::unordered_set<T>& v)
@@ -127,7 +129,9 @@ inline void operator<< (msgpack::object::with_zone& o, const std::unordered_mult
     }
 }
 
+/// @cond
 }  // MSGPACK_API_VERSION_NAMESPACE(v1)
+/// @endcond
 
 }  // namespace msgpack
 

--- a/include/msgpack/adaptor/cpp11/unordered_set_fwd.hpp
+++ b/include/msgpack/adaptor/cpp11/unordered_set_fwd.hpp
@@ -25,7 +25,9 @@
 
 namespace msgpack {
 
+/// @cond
 MSGPACK_API_VERSION_NAMESPACE(v1) {
+/// @endcond
 
 template <typename T>
 msgpack::object const& operator>> (msgpack::object const& o, std::unordered_set<T>& v);
@@ -45,7 +47,9 @@ msgpack::packer<Stream>& operator<< (msgpack::packer<Stream>& o, const std::unor
 template <typename T>
 void operator<< (msgpack::object::with_zone& o, const std::unordered_multiset<T>& v);
 
+/// @cond
 }  // MSGPACK_API_VERSION_NAMESPACE(v1)
+/// @endcond
 
 }  // namespace msgpack
 

--- a/include/msgpack/adaptor/deque.hpp
+++ b/include/msgpack/adaptor/deque.hpp
@@ -26,7 +26,9 @@
 
 namespace msgpack {
 
+/// @cond
 MSGPACK_API_VERSION_NAMESPACE(v1) {
+/// @endcond
 
 template <typename T>
 inline msgpack::object const& operator>> (msgpack::object const& o, std::deque<T>& v)
@@ -76,7 +78,9 @@ inline void operator<< (msgpack::object::with_zone& o, const std::deque<T>& v)
     }
 }
 
+/// @cond
 }  // MSGPACK_API_VERSION_NAMESPACE(v1)
+/// @endcond
 
 }  // namespace msgpack
 

--- a/include/msgpack/adaptor/deque_fwd.hpp
+++ b/include/msgpack/adaptor/deque_fwd.hpp
@@ -24,7 +24,9 @@
 
 namespace msgpack {
 
+/// @cond
 MSGPACK_API_VERSION_NAMESPACE(v1) {
+/// @endcond
 
 template <typename T>
 msgpack::object const& operator>> (msgpack::object const& o, std::deque<T>& v);
@@ -33,7 +35,9 @@ msgpack::packer<Stream>& operator<< (msgpack::packer<Stream>& o, const std::dequ
 template <typename T>
 void operator<< (msgpack::object::with_zone& o, const std::deque<T>& v);
 
+/// @cond
 }  // MSGPACK_API_VERSION_NAMESPACE(v1)
+/// @endcond
 
 }  // namespace msgpack
 

--- a/include/msgpack/adaptor/detail/cpp03_define.hpp
+++ b/include/msgpack/adaptor/detail/cpp03_define.hpp
@@ -42,7 +42,9 @@
 // MSGPACK_ADD_ENUM must be used in the global namespace.
 #define MSGPACK_ADD_ENUM(enum) \
   namespace msgpack { \
+  /** @cond */ \
   MSGPACK_API_VERSION_NAMESPACE(v1) { \
+  /** @endcond */ \
     inline msgpack::object const& operator>> (msgpack::object const& o, enum& v) \
     { \
       int tmp; \
@@ -66,18 +68,22 @@
         } \
       }; \
     } \
+  /** @cond */ \
   } \
+  /** @endcond */ \
   }
 
 namespace msgpack {
+/// @cond
 MSGPACK_API_VERSION_NAMESPACE(v1) {
+/// @endcond
 namespace type {
 
-
+/// @cond
 
 template <typename A0 = void, typename A1 = void, typename A2 = void, typename A3 = void, typename A4 = void, typename A5 = void, typename A6 = void, typename A7 = void, typename A8 = void, typename A9 = void, typename A10 = void, typename A11 = void, typename A12 = void, typename A13 = void, typename A14 = void, typename A15 = void, typename A16 = void, typename A17 = void, typename A18 = void, typename A19 = void, typename A20 = void, typename A21 = void, typename A22 = void, typename A23 = void, typename A24 = void, typename A25 = void, typename A26 = void, typename A27 = void, typename A28 = void, typename A29 = void, typename A30 = void, typename A31 = void, typename A32 = void>
 struct define;
-
+/// @endcond
 
 template <>
 struct define<> {
@@ -99,6 +105,8 @@ struct define<> {
         o->via.array.size = 0;
     }
 };
+
+/// @cond
 
 template <typename A0>
 struct define<A0> {
@@ -3268,11 +3276,14 @@ struct define<A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A
     A31& a31;
 };
 
+/// @endcond
 
 inline define<> make_define()
 {
     return define<>();
 }
+
+/// @cond
 
 template <typename A0>
 define<A0> make_define(A0& a0)
@@ -3466,9 +3477,12 @@ define<A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16
     return define<A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21, A22, A23, A24, A25, A26, A27, A28, A29, A30, A31>(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30, a31);
 }
 
+/// @endcond
 
 }  // namespace type
+/// @cond
 }  // MSGPACK_API_VERSION_NAMESPACE(v1)
+/// @endcond
 }  // namespace msgpack
 
 

--- a/include/msgpack/adaptor/detail/cpp03_msgpack_tuple.hpp
+++ b/include/msgpack/adaptor/detail/cpp03_msgpack_tuple.hpp
@@ -23,7 +23,9 @@
 
 namespace msgpack {
 
+/// @cond
 MSGPACK_API_VERSION_NAMESPACE(v1) {
+/// @endcond
 
 namespace type {
 
@@ -31,8 +33,10 @@ namespace type {
 // FIXME operator!=
 
 
+/// @cond
 template <typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7, typename A8, typename A9, typename A10, typename A11, typename A12, typename A13, typename A14, typename A15, typename A16, typename A17, typename A18, typename A19, typename A20, typename A21, typename A22, typename A23, typename A24, typename A25, typename A26, typename A27, typename A28, typename A29, typename A30, typename A31, typename A32>
 struct tuple;
+/// @endcond
 
 template <typename Tuple, int N>
 struct tuple_element;
@@ -67,6 +71,7 @@ struct tuple_type<const T&> {
     typedef const T& transparent_reference;
 };
 
+/// @cond
 
 
 template <typename A0>
@@ -9174,6 +9179,7 @@ private:
 };
 
 
+/// @endcond
 
 template <>
 struct tuple<> {
@@ -9181,6 +9187,8 @@ struct tuple<> {
     tuple(msgpack::object const& o) { o.convert(*this); }
     typedef tuple<> value_type;
 };
+
+/// @cond
 
 template <typename A0>
 struct tuple<A0> {
@@ -10382,11 +10390,14 @@ template <int N, typename A0, typename A1, typename A2, typename A3, typename A4
 inline typename type::const_tuple_element<type::tuple<A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21, A22, A23, A24, A25, A26, A27, A28, A29, A30, A31>, N>::const_reference get(type::tuple<A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21, A22, A23, A24, A25, A26, A27, A28, A29, A30, A31> const& t)
 { return t.template get<N>(); }
 
+/// @endcond
 
 inline tuple<> make_tuple()
 {
     return tuple<>();
 }
+
+/// @cond
 
 template <typename A0>
 inline tuple<A0> make_tuple(typename tuple_type<A0>::transparent_reference a0)
@@ -10580,6 +10591,7 @@ inline tuple<A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A1
     return tuple<A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21, A22, A23, A24, A25, A26, A27, A28, A29, A30, A31>(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30, a31);
 }
 
+/// @endcond
 
 }  // namespace type
 
@@ -10589,6 +10601,8 @@ inline msgpack::object const& operator>> (
     if(o.type != msgpack::type::ARRAY) { throw msgpack::type_error(); }
     return o;
 }
+
+/// @cond
 
 template <typename A0>
 inline msgpack::object const& operator>> (
@@ -11438,6 +11452,7 @@ inline msgpack::object const& operator>> (
     return o;
 }
 
+/// @endcond
 
 template <typename Stream>
 inline const msgpack::packer<Stream>& operator<< (
@@ -11446,6 +11461,8 @@ inline const msgpack::packer<Stream>& operator<< (
     o.pack_array(0);
     return o;
 }
+
+/// @cond
 
 template <typename Stream, typename A0>
 inline const msgpack::packer<Stream>& operator<< (
@@ -12263,6 +12280,7 @@ inline const msgpack::packer<Stream>& operator<< (
     return o;
 }
 
+/// @endcond
 
 inline void operator<< (
         msgpack::object::with_zone& o,
@@ -12271,6 +12289,8 @@ inline void operator<< (
     o.via.array.ptr = nullptr;
     o.via.array.size = 0;
 }
+
+/// @cond
 
 template <typename A0>
 inline void operator<< (
@@ -13120,8 +13140,11 @@ inline void operator<< (
     o.via.array.ptr[31] = msgpack::object(v.template get<31>(), o.zone);
 }
 
+/// @endcond
 
+/// @cond
 }  // MSGPACK_API_VERSION_NAMESPACE(v1)
+/// @endcond
 
 }  // namespace msgpack
 

--- a/include/msgpack/adaptor/detail/cpp03_msgpack_tuple_fwd.hpp
+++ b/include/msgpack/adaptor/detail/cpp03_msgpack_tuple_fwd.hpp
@@ -23,7 +23,9 @@
 
 namespace msgpack {
 
+/// @cond
 MSGPACK_API_VERSION_NAMESPACE(v1) {
+/// @endcond
 
 namespace type {
 
@@ -31,8 +33,10 @@ namespace type {
 // FIXME operator!=
 
 
+/// @cond
 template <typename A0 = void, typename A1 = void, typename A2 = void, typename A3 = void, typename A4 = void, typename A5 = void, typename A6 = void, typename A7 = void, typename A8 = void, typename A9 = void, typename A10 = void, typename A11 = void, typename A12 = void, typename A13 = void, typename A14 = void, typename A15 = void, typename A16 = void, typename A17 = void, typename A18 = void, typename A19 = void, typename A20 = void, typename A21 = void, typename A22 = void, typename A23 = void, typename A24 = void, typename A25 = void, typename A26 = void, typename A27 = void, typename A28 = void, typename A29 = void, typename A30 = void, typename A31 = void, typename A32 = void>
 struct tuple;
+/// @endcond
 
 template <typename Tuple, int N>
 struct tuple_element;
@@ -43,6 +47,7 @@ struct const_tuple_element;
 template <typename T>
 struct tuple_type;
 
+/// @cond
 
 
 template <typename A0>
@@ -3342,9 +3347,12 @@ template <typename A0, typename A1, typename A2, typename A3, typename A4, typen
 struct const_tuple_element<tuple<A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21, A22, A23, A24, A25, A26, A27, A28, A29, A30, A31>, 31>;
 
 
+/// @endcond
 
 template <>
 struct tuple<>;
+
+/// @cond
 
 template <typename A0>
 struct tuple<A0>;
@@ -3701,6 +3709,7 @@ tuple<A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16,
 template <typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7, typename A8, typename A9, typename A10, typename A11, typename A12, typename A13, typename A14, typename A15, typename A16, typename A17, typename A18, typename A19, typename A20, typename A21, typename A22, typename A23, typename A24, typename A25, typename A26, typename A27, typename A28, typename A29, typename A30, typename A31>
 tuple<A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21, A22, A23, A24, A25, A26, A27, A28, A29, A30, A31> make_tuple(typename tuple_type<A0>::transparent_reference a0, typename tuple_type<A1>::transparent_reference a1, typename tuple_type<A2>::transparent_reference a2, typename tuple_type<A3>::transparent_reference a3, typename tuple_type<A4>::transparent_reference a4, typename tuple_type<A5>::transparent_reference a5, typename tuple_type<A6>::transparent_reference a6, typename tuple_type<A7>::transparent_reference a7, typename tuple_type<A8>::transparent_reference a8, typename tuple_type<A9>::transparent_reference a9, typename tuple_type<A10>::transparent_reference a10, typename tuple_type<A11>::transparent_reference a11, typename tuple_type<A12>::transparent_reference a12, typename tuple_type<A13>::transparent_reference a13, typename tuple_type<A14>::transparent_reference a14, typename tuple_type<A15>::transparent_reference a15, typename tuple_type<A16>::transparent_reference a16, typename tuple_type<A17>::transparent_reference a17, typename tuple_type<A18>::transparent_reference a18, typename tuple_type<A19>::transparent_reference a19, typename tuple_type<A20>::transparent_reference a20, typename tuple_type<A21>::transparent_reference a21, typename tuple_type<A22>::transparent_reference a22, typename tuple_type<A23>::transparent_reference a23, typename tuple_type<A24>::transparent_reference a24, typename tuple_type<A25>::transparent_reference a25, typename tuple_type<A26>::transparent_reference a26, typename tuple_type<A27>::transparent_reference a27, typename tuple_type<A28>::transparent_reference a28, typename tuple_type<A29>::transparent_reference a29, typename tuple_type<A30>::transparent_reference a30, typename tuple_type<A31>::transparent_reference a31);
 
+/// @endcond
 
 }  // namespace type
 
@@ -3708,6 +3717,7 @@ msgpack::object const& operator>> (
     msgpack::object const& o,
     type::tuple<>&);
 
+/// @cond
 
 template <typename A0>
 msgpack::object const& operator>> (
@@ -3869,12 +3879,14 @@ msgpack::object const& operator>> (
     msgpack::object const& o,
     type::tuple<A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21, A22, A23, A24, A25, A26, A27, A28, A29, A30, A31>& v);
 
+/// @endcond
 
 template <typename Stream>
 const msgpack::packer<Stream>& operator<< (
     msgpack::packer<Stream>& o,
     const type::tuple<>&);
 
+/// @cond
 
 template <typename Stream, typename A0>
 const msgpack::packer<Stream>& operator<< (
@@ -4036,10 +4048,13 @@ const msgpack::packer<Stream>& operator<< (
     msgpack::packer<Stream>& o,
     const type::tuple<A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21, A22, A23, A24, A25, A26, A27, A28, A29, A30, A31>& v);
 
+/// @endcond
 
 void operator<< (
     msgpack::object::with_zone& o,
     const type::tuple<>&);
+
+/// @cond
 
 template <typename A0>
 void operator<< (
@@ -4201,8 +4216,11 @@ void operator<< (
     msgpack::object::with_zone& o,
     const type::tuple<A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21, A22, A23, A24, A25, A26, A27, A28, A29, A30, A31>& v);
 
+/// @endcond
 
+/// @cond
 }  // MSGPACK_API_VERSION_NAMESPACE(v1)
+/// @endcond
 
 }  // namespace msgpack
 

--- a/include/msgpack/adaptor/detail/cpp11_define.hpp
+++ b/include/msgpack/adaptor/detail/cpp11_define.hpp
@@ -46,7 +46,9 @@
 // MSGPACK_ADD_ENUM must be used in the global namespace.
 #define MSGPACK_ADD_ENUM(enum) \
   namespace msgpack { \
+  /** @cond */ \
   MSGPACK_API_VERSION_NAMESPACE(v1) { \
+  /** @endcond */ \
     inline msgpack::object const& operator>> (msgpack::object const& o, enum& v) \
     { \
       std::underlying_type<enum>::type tmp; \
@@ -72,11 +74,15 @@
         } \
       }; \
     } \
+  /** @cond */ \
   } \
+  /** @endcond */ \
   }
 
 namespace msgpack {
+/// @cond
 MSGPACK_API_VERSION_NAMESPACE(v1) {
+/// @endcond
 namespace type {
 
 template <typename Tuple, std::size_t N>
@@ -178,7 +184,9 @@ define<Args...> make_define(Args&... args)
 }
 
 }  // namespace type
+/// @cond
 }  // MSGPACK_API_VERSION_NAMESPACE(v1)
+/// @endcond
 }  // namespace msgpack
 
 #endif // MSGPACK_CPP11_DEFINE_HPP

--- a/include/msgpack/adaptor/detail/cpp11_msgpack_tuple.hpp
+++ b/include/msgpack/adaptor/detail/cpp11_msgpack_tuple.hpp
@@ -25,7 +25,9 @@
 
 namespace msgpack {
 
+/// @cond
 MSGPACK_API_VERSION_NAMESPACE(v1) {
+/// @endcond
 
 namespace type {
     // tuple
@@ -205,7 +207,9 @@ inline void operator<< (
     MsgpackTupleToObjectWithZone<decltype(v), sizeof...(Args)>::convert(o, v);
 }
 
+/// @cond
 }  // MSGPACK_API_VERSION_NAMESPACE(v1)
+///@endcond
 
 }  // namespace msgpack
 

--- a/include/msgpack/adaptor/detail/cpp11_msgpack_tuple_fwd.hpp
+++ b/include/msgpack/adaptor/detail/cpp11_msgpack_tuple_fwd.hpp
@@ -25,7 +25,9 @@
 
 namespace msgpack {
 
+/// @cond
 MSGPACK_API_VERSION_NAMESPACE(v1) {
+/// @endcond
 
 namespace type {
     // tuple
@@ -77,7 +79,9 @@ void operator<< (
     msgpack::object::with_zone& o,
     type::tuple<Args...> const& v);
 
+/// @cond
 }  // MSGPACK_API_VERSION_NAMESPACE(v1)
+/// @endcond
 
 }  // namespace msgpack
 

--- a/include/msgpack/adaptor/fixint.hpp
+++ b/include/msgpack/adaptor/fixint.hpp
@@ -24,7 +24,9 @@
 
 namespace msgpack {
 
+/// @cond
 MSGPACK_API_VERSION_NAMESPACE(v1) {
+/// @endcond
 
 namespace type {
 
@@ -205,7 +207,9 @@ inline void operator<< (msgpack::object::with_zone& o, type::fix_uint64 v)
     { static_cast<msgpack::object&>(o) << v; }
 
 
+/// @cond
 }  // MSGPACK_API_VERSION_NAMESPACE(v1)
+/// @endcond
 
 }  // namespace msgpack
 

--- a/include/msgpack/adaptor/fixint_fwd.hpp
+++ b/include/msgpack/adaptor/fixint_fwd.hpp
@@ -23,7 +23,9 @@
 
 namespace msgpack {
 
+/// @cond
 MSGPACK_API_VERSION_NAMESPACE(v1) {
+/// @endcond
 
 namespace type {
 
@@ -93,7 +95,9 @@ void operator<< (msgpack::object::with_zone& o, type::fix_uint16 v);
 void operator<< (msgpack::object::with_zone& o, type::fix_uint32 v);
 void operator<< (msgpack::object::with_zone& o, type::fix_uint64 v);
 
+/// @cond
 }  // MSGPACK_API_VERSION_NAMESPACE(v1)
+/// @endcond
 
 }  // namespace msgpack
 

--- a/include/msgpack/adaptor/float.hpp
+++ b/include/msgpack/adaptor/float.hpp
@@ -24,7 +24,9 @@
 
 namespace msgpack {
 
+/// @cond
 MSGPACK_API_VERSION_NAMESPACE(v1) {
+/// @endcond
 
 // FIXME check overflow, underflow
 
@@ -98,7 +100,9 @@ inline void operator<< (msgpack::object::with_zone& o, double v)
     { static_cast<msgpack::object&>(o) << v; }
 
 
+/// @cond
 }  // MSGPACK_API_VERSION_NAMESPACE(v1)
+/// @endcond
 
 }  // namespace msgpack
 

--- a/include/msgpack/adaptor/float_fwd.hpp
+++ b/include/msgpack/adaptor/float_fwd.hpp
@@ -24,7 +24,9 @@
 
 namespace msgpack {
 
+/// @cond
 MSGPACK_API_VERSION_NAMESPACE(v1) {
+/// @endcond
 
 msgpack::object const& operator>> (msgpack::object const& o, float& v);
 template <typename Stream>
@@ -37,7 +39,9 @@ void operator<< (msgpack::object& o, double v);
 void operator<< (msgpack::object::with_zone& o, float v);
 void operator<< (msgpack::object::with_zone& o, double v);
 
+/// @cond
 }  // MSGPACK_API_VERSION_NAMESPACE(v1)
+/// @endcond
 
 }  // namespace msgpack
 

--- a/include/msgpack/adaptor/int.hpp
+++ b/include/msgpack/adaptor/int.hpp
@@ -24,7 +24,9 @@
 
 namespace msgpack {
 
+/// @cond
 MSGPACK_API_VERSION_NAMESPACE(v1){
+/// @endcond
 
 namespace type {
 namespace detail {
@@ -301,7 +303,9 @@ inline void operator<< (msgpack::object::with_zone& o, const unsigned long long&
     { static_cast<msgpack::object&>(o) << v; }
 
 
+/// @cond
 }  // MSGPACK_API_VERSION_NAMESPACE(v1)
+/// @endcond
 
 }  // namespace msgpack
 

--- a/include/msgpack/adaptor/int_fwd.hpp
+++ b/include/msgpack/adaptor/int_fwd.hpp
@@ -23,7 +23,9 @@
 
 namespace msgpack {
 
+/// @cond
 MSGPACK_API_VERSION_NAMESPACE(v1){
+/// @endcond
 
 msgpack::object const& operator>> (msgpack::object const& o, char& v);
 
@@ -93,7 +95,9 @@ void operator<< (msgpack::object::with_zone& o, unsigned int v);
 void operator<< (msgpack::object::with_zone& o, unsigned long v);
 void operator<< (msgpack::object::with_zone& o, const unsigned long long& v);
 
+/// @cond
 }  // MSGPACK_API_VERSION_NAMESPACE(v1)
+/// @endcond
 
 }  // namespace msgpack
 

--- a/include/msgpack/adaptor/list.hpp
+++ b/include/msgpack/adaptor/list.hpp
@@ -26,7 +26,9 @@
 
 namespace msgpack {
 
+/// @cond
 MSGPACK_API_VERSION_NAMESPACE(v1) {
+/// @endcond
 
 template <typename T>
 inline msgpack::object const& operator>> (msgpack::object const& o, std::list<T>& v)
@@ -76,7 +78,9 @@ inline void operator<< (msgpack::object::with_zone& o, const std::list<T>& v)
     }
 }
 
+/// @cond
 }  // MSGPACK_API_VERSION_NAMESPACE(v1)
+/// @endcond
 
 }  // namespace msgpack
 

--- a/include/msgpack/adaptor/list_fwd.hpp
+++ b/include/msgpack/adaptor/list_fwd.hpp
@@ -24,7 +24,9 @@
 
 namespace msgpack {
 
+/// @cond
 MSGPACK_API_VERSION_NAMESPACE(v1) {
+/// @endcond
 
 template <typename T>
 msgpack::object const& operator>> (msgpack::object const& o, std::list<T>& v);
@@ -33,7 +35,9 @@ msgpack::packer<Stream>& operator<< (msgpack::packer<Stream>& o, const std::list
 template <typename T>
 void operator<< (msgpack::object::with_zone& o, const std::list<T>& v);
 
+/// @cond
 }  // MSGPACK_API_VERSION_NAMESPACE(v1)
+/// @endcond
 
 }  // namespace msgpack
 

--- a/include/msgpack/adaptor/map.hpp
+++ b/include/msgpack/adaptor/map.hpp
@@ -28,7 +28,9 @@
 
 namespace msgpack {
 
+/// @cond
 MSGPACK_API_VERSION_NAMESPACE(v1) {
+/// @endcond
 
 namespace type {
 
@@ -212,7 +214,9 @@ inline void operator<< (msgpack::object::with_zone& o, const std::multimap<K,V>&
     }
 }
 
+/// @cond
 }  // MSGPACK_API_VERSION_NAMESPACE(v1)
+/// @endcond
 
 }  // namespace msgpack
 

--- a/include/msgpack/adaptor/map_fwd.hpp
+++ b/include/msgpack/adaptor/map_fwd.hpp
@@ -26,7 +26,9 @@
 
 namespace msgpack {
 
+/// @cond
 MSGPACK_API_VERSION_NAMESPACE(v1) {
+/// @endcond
 
 namespace type {
 
@@ -62,7 +64,9 @@ msgpack::packer<Stream>& operator<< (msgpack::packer<Stream>& o, const std::mult
 template <typename K, typename V>
 void operator<< (msgpack::object::with_zone& o, const std::multimap<K,V>& v);
 
+/// @cond
 }  // MSGPACK_API_VERSION_NAMESPACE(v1)
+/// @endcond
 
 }  // namespace msgpack
 

--- a/include/msgpack/adaptor/nil.hpp
+++ b/include/msgpack/adaptor/nil.hpp
@@ -23,7 +23,9 @@
 
 namespace msgpack {
 
+/// @cond
 MSGPACK_API_VERSION_NAMESPACE(v1) {
+/// @endcond
 
 namespace type {
 
@@ -61,7 +63,9 @@ inline void msgpack::object::as<void>() const
     convert(v);
 }
 
+/// @cond
 }  // MSGPACK_API_VERSION_NAMESPACE(v1)
+/// @endcond
 
 }  // namespace msgpack
 

--- a/include/msgpack/adaptor/nil_fwd.hpp
+++ b/include/msgpack/adaptor/nil_fwd.hpp
@@ -23,7 +23,9 @@
 
 namespace msgpack {
 
+/// @cond
 MSGPACK_API_VERSION_NAMESPACE(v1) {
+/// @endcond
 
 namespace type {
 
@@ -44,7 +46,9 @@ void operator<< (msgpack::object::with_zone& o, type::nil v);
 template <>
 inline void msgpack::object::as<void>() const;
 
+/// @cond
 }  // MSGPACK_API_VERSION_NAMESPACE(v1)
+/// @endcond
 
 }  // namespace msgpack
 

--- a/include/msgpack/adaptor/pair.hpp
+++ b/include/msgpack/adaptor/pair.hpp
@@ -24,7 +24,9 @@
 
 namespace msgpack {
 
+/// @cond
 MSGPACK_API_VERSION_NAMESPACE(v1) {
+/// @endcond
 
 template <typename T1, typename T2>
 inline msgpack::object const& operator>> (msgpack::object const& o, std::pair<T1, T2>& v)
@@ -56,7 +58,9 @@ inline void operator<< (msgpack::object::with_zone& o, const std::pair<T1, T2>& 
     p[1] = msgpack::object(v.second, o.zone);
 }
 
+/// @cond
 }  // MSGPACK_API_VERSION_NAMESPACE(v1)
+/// @endcond
 
 }  // namespace msgpack
 

--- a/include/msgpack/adaptor/pair_fwd.hpp
+++ b/include/msgpack/adaptor/pair_fwd.hpp
@@ -24,7 +24,9 @@
 
 namespace msgpack {
 
+/// @cond
 MSGPACK_API_VERSION_NAMESPACE(v1) {
+/// @endcond
 
 template <typename T1, typename T2>
 msgpack::object const& operator>> (msgpack::object const& o, std::pair<T1, T2>& v);
@@ -35,7 +37,9 @@ msgpack::packer<Stream>& operator<< (msgpack::packer<Stream>& o, const std::pair
 template <typename T1, typename T2>
 void operator<< (msgpack::object::with_zone& o, const std::pair<T1, T2>& v);
 
+/// @cond
 }  // MSGPACK_API_VERSION_NAMESPACE(v1)
+/// @endcond
 
 }  // namespace msgpack
 

--- a/include/msgpack/adaptor/raw.hpp
+++ b/include/msgpack/adaptor/raw.hpp
@@ -25,7 +25,9 @@
 
 namespace msgpack {
 
+/// @cond
 MSGPACK_API_VERSION_NAMESPACE(v1) {
+/// @endcond
 
 namespace type {
 
@@ -91,7 +93,9 @@ inline void operator<< (msgpack::object::with_zone& o, const msgpack::type::raw_
     { static_cast<msgpack::object&>(o) << v; }
 
 
+/// @cond
 }  // MSGPACK_API_VERSION_NAMESPACE(v1)
+/// @endcond
 
 }  // namespace msgpack
 

--- a/include/msgpack/adaptor/raw_fwd.hpp
+++ b/include/msgpack/adaptor/raw_fwd.hpp
@@ -25,7 +25,9 @@
 
 namespace msgpack {
 
+/// @cond
 MSGPACK_API_VERSION_NAMESPACE(v1) {
+/// @endcond
 
 namespace type {
 
@@ -43,7 +45,9 @@ void operator<< (msgpack::object& o, const type::raw_ref& v);
 
 void operator<< (msgpack::object::with_zone& o, const type::raw_ref& v);
 
+/// @cond
 }  // MSGPACK_API_VERSION_NAMESPACE(v1)
+/// @endcond
 
 }  // namespace msgpack
 

--- a/include/msgpack/adaptor/set.hpp
+++ b/include/msgpack/adaptor/set.hpp
@@ -26,7 +26,9 @@
 
 namespace msgpack {
 
+/// @cond
 MSGPACK_API_VERSION_NAMESPACE(v1) {
+/// @endcond
 
 template <typename T>
 inline msgpack::object const& operator>> (msgpack::object const& o, std::set<T>& v)
@@ -127,7 +129,9 @@ inline void operator<< (msgpack::object::with_zone& o, const std::multiset<T>& v
     }
 }
 
+/// @cond
 }  // MSGPACK_API_VERSION_NAMESPACE(v1)
+/// @endcond
 
 }  // namespace msgpack
 

--- a/include/msgpack/adaptor/set_fwd.hpp
+++ b/include/msgpack/adaptor/set_fwd.hpp
@@ -25,7 +25,9 @@
 
 namespace msgpack {
 
+/// @cond
 MSGPACK_API_VERSION_NAMESPACE(v1) {
+/// @endcond
 
 template <typename T>
 msgpack::object const& operator>> (msgpack::object const& o, std::set<T>& v);
@@ -45,7 +47,9 @@ msgpack::packer<Stream>& operator<< (msgpack::packer<Stream>& o, const std::mult
 template <typename T>
 void operator<< (msgpack::object::with_zone& o, const std::multiset<T>& v);
 
+/// @cond
 }  // MSGPACK_API_VERSION_NAMESPACE(v1)
+/// @endcond
 
 }  // namespace msgpack
 

--- a/include/msgpack/adaptor/string.hpp
+++ b/include/msgpack/adaptor/string.hpp
@@ -26,7 +26,9 @@
 
 namespace msgpack {
 
+/// @cond
 MSGPACK_API_VERSION_NAMESPACE(v1) {
+/// @endcond
 
 inline msgpack::object const& operator>> (msgpack::object const& o, std::string& v)
 {
@@ -71,7 +73,9 @@ inline void operator<< (msgpack::object& o, const std::string& v)
     o.via.str.size = size;
 }
 
+/// @cond
 }  // MSGPACK_API_VERSION_NAMESPACE(v1)
+/// @endcond
 
 }  // namespace msgpack
 

--- a/include/msgpack/adaptor/string_fwd.hpp
+++ b/include/msgpack/adaptor/string_fwd.hpp
@@ -24,7 +24,9 @@
 
 namespace msgpack {
 
+/// @cond
 MSGPACK_API_VERSION_NAMESPACE(v1) {
+/// @endcond
 
 msgpack::object const& operator>> (msgpack::object const& o, std::string& v);
 
@@ -35,7 +37,9 @@ void operator<< (msgpack::object::with_zone& o, const std::string& v);
 
 void operator<< (msgpack::object& o, const std::string& v);
 
+/// @cond
 }  // MSGPACK_API_VERSION_NAMESPACE(v1)
+/// @endcond
 
 }  // namespace msgpack
 

--- a/include/msgpack/adaptor/tr1/unordered_map.hpp
+++ b/include/msgpack/adaptor/tr1/unordered_map.hpp
@@ -45,7 +45,9 @@
 
 namespace msgpack {
 
+/// @cond
 MSGPACK_API_VERSION_NAMESPACE(v1) {
+/// @endcond
 
 template <typename K, typename V>
 inline msgpack::object const& operator>> (msgpack::object const& o, MSGPACK_STD_TR1::unordered_map<K, V>& v)
@@ -153,7 +155,9 @@ inline void operator<< (msgpack::object::with_zone& o, const MSGPACK_STD_TR1::un
     }
 }
 
+/// @cond
 }  // MSGPACK_API_VERSION_NAMESPACE(v1)
+/// @endcond
 
 }  // namespace msgpack
 

--- a/include/msgpack/adaptor/tr1/unordered_map_fwd.hpp
+++ b/include/msgpack/adaptor/tr1/unordered_map_fwd.hpp
@@ -44,7 +44,9 @@
 
 namespace msgpack {
 
+/// @cond
 MSGPACK_API_VERSION_NAMESPACE(v1) {
+/// @endcond
 
 template <typename K, typename V>
 msgpack::object const& operator>> (msgpack::object const& o, MSGPACK_STD_TR1::unordered_map<K, V>& v);
@@ -64,7 +66,9 @@ msgpack::packer<Stream>& operator<< (msgpack::packer<Stream>& o, const MSGPACK_S
 template <typename K, typename V>
 void operator<< (msgpack::object::with_zone& o, const MSGPACK_STD_TR1::unordered_multimap<K,V>& v);
 
+/// @cond
 }  // MSGPACK_API_VERSION_NAMESPACE(v1)
+/// @endcond
 
 }  // namespace msgpack
 

--- a/include/msgpack/adaptor/tr1/unordered_set.hpp
+++ b/include/msgpack/adaptor/tr1/unordered_set.hpp
@@ -45,7 +45,9 @@
 
 namespace msgpack {
 
+/// @cond
 MSGPACK_API_VERSION_NAMESPACE(v1) {
+/// @endcond
 
 template <typename T>
 inline msgpack::object const& operator>> (msgpack::object const& o, MSGPACK_STD_TR1::unordered_set<T>& v)
@@ -146,7 +148,9 @@ inline void operator<< (msgpack::object::with_zone& o, const MSGPACK_STD_TR1::un
     }
 }
 
+/// @cond
 }  // MSGPACK_API_VERSION_NAMESPACE(v1)
+/// @endcond
 
 }  // namespace msgpack
 

--- a/include/msgpack/adaptor/tr1/unordered_set_fwd.hpp
+++ b/include/msgpack/adaptor/tr1/unordered_set_fwd.hpp
@@ -44,7 +44,9 @@
 
 namespace msgpack {
 
+/// @cond
 MSGPACK_API_VERSION_NAMESPACE(v1) {
+/// @endcond
 
 template <typename T>
 msgpack::object const& operator>> (msgpack::object const& o, MSGPACK_STD_TR1::unordered_set<T>& v);
@@ -64,7 +66,9 @@ msgpack::packer<Stream>& operator<< (msgpack::packer<Stream>& o, const MSGPACK_S
 template <typename T>
 void operator<< (msgpack::object::with_zone& o, const MSGPACK_STD_TR1::unordered_multiset<T>& v);
 
+/// @cond
 }  // MSGPACK_API_VERSION_NAMESPACE(v1)
+/// @endcond
 
 }  // namespace msgpack
 

--- a/include/msgpack/adaptor/vector.hpp
+++ b/include/msgpack/adaptor/vector.hpp
@@ -26,7 +26,9 @@
 
 namespace msgpack {
 
+/// @cond
 MSGPACK_API_VERSION_NAMESPACE(v1) {
+/// @endcond
 
 template <typename T>
 inline msgpack::object const& operator>> (msgpack::object const& o, std::vector<T>& v)
@@ -80,7 +82,9 @@ inline void operator<< (msgpack::object::with_zone& o, const std::vector<T>& v)
     }
 }
 
+/// @cond
 }  // MSGPACK_API_VERSION_NAMESPACE(v1)
+/// @endcond
 
 }  // namespace msgpack
 

--- a/include/msgpack/adaptor/vector_bool.hpp
+++ b/include/msgpack/adaptor/vector_bool.hpp
@@ -24,7 +24,9 @@
 
 namespace msgpack {
 
+/// @cond
 MSGPACK_API_VERSION_NAMESPACE(v1) {
+/// @endcond
 
 inline msgpack::object const& operator>> (msgpack::object const& o, std::vector<bool>& v)
 {
@@ -73,7 +75,9 @@ inline void operator<< (msgpack::object::with_zone& o, const std::vector<bool>& 
     }
 }
 
+/// @cond
 }  // MSGPACK_API_VERSION_NAMESPACE(v1)
+/// @endcond
 
 }  // namespace msgpack
 

--- a/include/msgpack/adaptor/vector_bool_fwd.hpp
+++ b/include/msgpack/adaptor/vector_bool_fwd.hpp
@@ -24,7 +24,9 @@
 
 namespace msgpack {
 
+/// @cond
 MSGPACK_API_VERSION_NAMESPACE(v1) {
+/// @endcond
 
 object const& operator>> (object const& o, std::vector<bool>& v);
 
@@ -33,7 +35,9 @@ packer<Stream>& operator<< (packer<Stream>& o, const std::vector<bool>& v);
 
 void operator<< (object::with_zone& o, const std::vector<bool>& v);
 
+/// @cond
 }  // MSGPACK_API_VERSION_NAMESPACE(v1)
+/// @endcond
 
 }  // namespace msgpack
 

--- a/include/msgpack/adaptor/vector_char.hpp
+++ b/include/msgpack/adaptor/vector_char.hpp
@@ -26,7 +26,9 @@
 
 namespace msgpack {
 
+/// @cond
 MSGPACK_API_VERSION_NAMESPACE(v1) {
+/// @endcond
 
 inline msgpack::object const& operator>> (msgpack::object const& o, std::vector<char>& v)
 {
@@ -74,7 +76,9 @@ inline void operator<< (msgpack::object::with_zone& o, const std::vector<char>& 
     std::memcpy(ptr, &v.front(), size);
 }
 
+/// @cond
 }  // MSGPACK_API_VERSION_NAMESPACE(v1)
+/// @endcond
 
 }  // namespace msgpack
 

--- a/include/msgpack/adaptor/vector_char_fwd.hpp
+++ b/include/msgpack/adaptor/vector_char_fwd.hpp
@@ -24,7 +24,9 @@
 
 namespace msgpack {
 
+/// @cond
 MSGPACK_API_VERSION_NAMESPACE(v1) {
+/// @endcond
 
 msgpack::object const& operator>> (msgpack::object const& o, std::vector<char>& v);
 
@@ -35,7 +37,9 @@ void operator<< (msgpack::object& o, const std::vector<char>& v);
 
 void operator<< (msgpack::object::with_zone& o, const std::vector<char>& v);
 
+/// @cond
 }  // MSGPACK_API_VERSION_NAMESPACE(v1)
+/// @endcond
 
 }  // namespace msgpack
 

--- a/include/msgpack/adaptor/vector_fwd.hpp
+++ b/include/msgpack/adaptor/vector_fwd.hpp
@@ -24,7 +24,9 @@
 
 namespace msgpack {
 
+/// @cond
 MSGPACK_API_VERSION_NAMESPACE(v1) {
+/// @endcond
 
 template <typename T>
 msgpack::object const& operator>> (msgpack::object const& o, std::vector<T>& v);
@@ -35,7 +37,9 @@ msgpack::packer<Stream>& operator<< (msgpack::packer<Stream>& o, const std::vect
 template <typename T>
 void operator<< (msgpack::object::with_zone& o, const std::vector<T>& v);
 
+/// @cond
 }  // MSGPACK_API_VERSION_NAMESPACE(v1)
+/// @endcond
 
 }  // namespace msgpack
 

--- a/include/msgpack/cpp_config.hpp
+++ b/include/msgpack/cpp_config.hpp
@@ -44,7 +44,9 @@
 
 namespace msgpack {
 
+/// @cond
 MSGPACK_API_VERSION_NAMESPACE(v1) {
+/// @endcond
 
 template <typename T>
 struct unique_ptr : std::auto_ptr<T> {
@@ -75,7 +77,9 @@ template <typename T>
 struct enable_if<false, T> {
 };
 
+/// @cond
 }  // MSGPACK_API_VERSION_NAMESPACE(v1)
+/// @endcond
 
 }  // namespace msgpack
 
@@ -86,7 +90,9 @@ struct enable_if<false, T> {
 #include <tuple>
 
 namespace msgpack {
+/// @cond
 MSGPACK_API_VERSION_NAMESPACE(v1) {
+/// @endcond
 
     // unique_ptr
     using std::unique_ptr;
@@ -98,7 +104,9 @@ MSGPACK_API_VERSION_NAMESPACE(v1) {
     using std::swap;
     using std::enable_if;
 
+/// @cond
 }  // MSGPACK_API_VERSION_NAMESPACE(v1)
+/// @endcond
 }  // namespace msgpack
 
 

--- a/include/msgpack/detail/cpp03_zone.hpp
+++ b/include/msgpack/detail/cpp03_zone.hpp
@@ -35,7 +35,9 @@
 
 namespace msgpack {
 
+/// @cond
 MSGPACK_API_VERSION_NAMESPACE(v1) {
+/// @endcond
 
 class zone {
     struct finalizer {
@@ -179,6 +181,7 @@ public:
     {
         ::operator delete(p, place);
     }
+    /// @cond
     
     template <typename T>
     T* allocate();
@@ -228,6 +231,7 @@ public:
     template <typename T, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7, typename A8, typename A9, typename A10, typename A11, typename A12, typename A13, typename A14, typename A15>
     T* allocate(A1 a1, A2 a2, A3 a3, A4 a4, A5 a5, A6 a6, A7 a7, A8 a8, A9 a9, A10 a10, A11 a11, A12 a12, A13 a13, A14 a14, A15 a15);
     
+    /// @endcond
 
 private:
     void undo_allocate(size_t size);
@@ -349,6 +353,7 @@ inline void zone::undo_allocate(size_t size)
     m_chunk_list.m_free += size;
 }
 
+/// @cond
 
 template <typename T>
 T* zone::allocate()
@@ -654,8 +659,11 @@ T* zone::allocate(A1 a1, A2 a2, A3 a3, A4 a4, A5 a5, A6 a6, A7 a7, A8 a8, A9 a9,
     }
 }
 
+/// @endcond
 
+/// @cond
 }  // MSGPACK_API_VERSION_NAMESPACE(v1)
+/// @endcond
 
 }  // namespace msgpack
 

--- a/include/msgpack/detail/cpp11_zone.hpp
+++ b/include/msgpack/detail/cpp11_zone.hpp
@@ -36,7 +36,9 @@
 
 namespace msgpack {
 
+/// @cond
 MSGPACK_API_VERSION_NAMESPACE(v1) {
+/// @endcond
 
 class zone {
 private:
@@ -361,7 +363,9 @@ T* zone::allocate(Args... args)
     }
 }
 
+/// @cond
 }  // MSGPACK_API_VERSION_NAMESPACE(v1)
+/// @endcond
 
 }  // namespace msgpack
 

--- a/include/msgpack/fbuffer.hpp
+++ b/include/msgpack/fbuffer.hpp
@@ -25,7 +25,9 @@
 
 namespace msgpack {
 
+/// @cond
 MSGPACK_API_VERSION_NAMESPACE(v1) {
+/// @endcond
 
 class fbuffer {
 public:
@@ -57,7 +59,9 @@ private:
     FILE* m_file;
 };
 
+/// @cond
 }  // MSGPACK_API_VERSION_NAMESPACE(v1)
+/// @endcond
 
 }  // namespace msgpack
 

--- a/include/msgpack/iterator.hpp
+++ b/include/msgpack/iterator.hpp
@@ -24,8 +24,10 @@
 
 namespace msgpack
 {
+    /// @cond
     MSGPACK_API_VERSION_NAMESPACE(MSGPACK_DEFAULT_API_NS)
     {
+    /// @endcond
         inline object_kv* begin(object_map &map) { return map.ptr; }
         inline const object_kv* begin(const object_map &map) { return map.ptr; }
         inline object_kv* end(object_map &map) { return map.ptr + map.size; }
@@ -35,7 +37,9 @@ namespace msgpack
         inline const object* begin(const object_array &array) { return array.ptr; }
         inline object* end(object_array &array) { return array.ptr + array.size; }
         inline const object* end(const object_array &array) { return array.ptr + array.size; }
+    /// @cond
     }
+    /// @endcond
 }
 
 #endif // !defined(MSGPACK_USE_CPP03)

--- a/include/msgpack/object.hpp
+++ b/include/msgpack/object.hpp
@@ -65,7 +65,9 @@
 
 namespace msgpack {
 
+/// @cond
 MSGPACK_API_VERSION_NAMESPACE(v1) {
+/// @endcond
 
 struct object::with_zone : object {
     with_zone(msgpack::zone& zone) : zone(zone) { }
@@ -703,7 +705,9 @@ inline std::ostream& operator<< (std::ostream& s, const msgpack::object& o)
     return s;
 }
 
+/// @cond
 }  // MSGPACK_API_VERSION_NAMESPACE(v1)
+/// @endcond
 
 }  // namespace msgpack
 

--- a/include/msgpack/object_fwd.hpp
+++ b/include/msgpack/object_fwd.hpp
@@ -27,7 +27,9 @@
 
 namespace msgpack {
 
+/// @cond
 MSGPACK_API_VERSION_NAMESPACE(v1) {
+/// @endcond
 
 
 namespace type {
@@ -175,7 +177,9 @@ msgpack::packer<Stream>& operator<< (msgpack::packer<Stream>& o, const T& v);
 template <typename T>
 void operator<< (msgpack::object::with_zone& o, const T& v);
 
+/// @cond
 } // MSGPACK_API_VERSION_NAMESPACE(v1)
+/// @endcond
 
 } // namespace msgpack
 

--- a/include/msgpack/pack.hpp
+++ b/include/msgpack/pack.hpp
@@ -29,7 +29,9 @@
 
 namespace msgpack {
 
+/// @cond
 MSGPACK_API_VERSION_NAMESPACE(v1) {
+/// @endcond
 
 template <typename Stream>
 class packer {
@@ -1055,7 +1057,9 @@ inline void packer<Stream>::pack_imp_int64(T d)
     }
 }
 
+/// @cond
 }  // MSGPACK_API_VERSION_NAMESPACE(v1)
+/// @endcond
 
 }  // namespace msgpack
 

--- a/include/msgpack/sbuffer.hpp
+++ b/include/msgpack/sbuffer.hpp
@@ -28,7 +28,9 @@
 
 namespace msgpack {
 
+/// @cond
 MSGPACK_API_VERSION_NAMESPACE(v1) {
+/// @endcond
 
 class sbuffer {
 public:
@@ -127,7 +129,9 @@ private:
     size_t m_alloc;
 };
 
+/// @cond
 }  // MSGPACK_API_VERSION_NAMESPACE(v1)
+/// @endcond
 
 }  // namespace msgpack
 

--- a/include/msgpack/unpack.hpp
+++ b/include/msgpack/unpack.hpp
@@ -64,7 +64,9 @@ const size_t COUNTER_SIZE = sizeof(_msgpack_atomic_counter_t);
 
 namespace msgpack {
 
+/// @cond
 MSGPACK_API_VERSION_NAMESPACE(v1) {
+/// @endcond
 
 typedef bool (*unpack_reference_func)(msgpack::type::object_type, std::size_t, void*);
 
@@ -1727,7 +1729,9 @@ inline bool unpacker::default_reference_func(msgpack::type::object_type /*type*/
     return true;
 }
 
+/// @cond
 }  // MSGPACK_API_VERSION_NAMESPACE(v1)
+/// @endcond
 
 }  // namespace msgpack
 

--- a/include/msgpack/vrefbuffer.hpp
+++ b/include/msgpack/vrefbuffer.hpp
@@ -41,7 +41,9 @@ struct iovec {
 
 namespace msgpack {
 
+/// @cond
 MSGPACK_API_VERSION_NAMESPACE(v1) {
+/// @endcond
 
 namespace detail {
     // int64, uint64, double
@@ -289,7 +291,9 @@ private:
 
 };
 
+/// @cond
 }  // MSGPACK_API_VERSION_NAMESPACE(v1)
+/// @endcond
 
 }  // namespace msgpack
 

--- a/include/msgpack/zbuffer.hpp
+++ b/include/msgpack/zbuffer.hpp
@@ -33,7 +33,9 @@
 
 namespace msgpack {
 
+/// @cond
 MSGPACK_API_VERSION_NAMESPACE(v1) {
+/// @endcond
 
 class zbuffer {
 public:
@@ -164,7 +166,9 @@ private:
     size_t m_init_size;
 };
 
+/// @cond
 }  // MSGPACK_API_VERSION_NAMESPACE(v1)
+/// @endcond
 
 }  // namespace msgpack
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -141,6 +141,8 @@ doxygen_c:
 	cat ../Doxyfile > Doxyfile_c
 	echo "FILE_PATTERNS      = *.h" >> Doxyfile_c
 	echo "OUTPUT_DIRECTORY   = doc_c" >> Doxyfile_c
+	echo "INPUT              = ../include" >> Doxyfile_c
+	echo "EXTRACT_ALL        = YES" >> Doxyfile_c
 	echo "PROJECT_NAME       = \"MessagePack for C\"" >> Doxyfile_c
 	doxygen Doxyfile_c
 
@@ -148,6 +150,8 @@ doxygen_cpp:
 	cat ../Doxyfile > Doxyfile_cpp
 	echo "FILE_PATTERNS      = *.hpp" >> Doxyfile_cpp
 	echo "OUTPUT_DIRECTORY   = doc_cpp" >> Doxyfile_cpp
+	echo "INPUT              = ../include" >> Doxyfile_cpp
+	echo "EXTRACT_ALL        = YES" >> Doxyfile_cpp
 	echo "PROJECT_NAME       = \"MessagePack for C++\"" >> Doxyfile_cpp
 	doxygen Doxyfile_cpp
 


### PR DESCRIPTION
Removed MSGPACK_API_VERSION_NAMESPACE(v1) from doxygen build.
It seems that Doxygen cannot parse a complicated macro such as MSGPACK_API_VERSION_NAMESPACE.

Added EXTRACT_ALL=YES to Doxyfle.
Added INPUT configuration variable that is point to include directory to Doxyfile.