### PR TITLE
Make use of MSVC specific macros for format specifiers

### DIFF
--- a/src/objectc.c
+++ b/src/objectc.c
@@ -20,7 +20,15 @@
 #include <stdio.h>
 #include <string.h>
 
-#if !defined(_MSC_VER) || _MSC_VER >= 1800
+#if defined(_MSC_VER)
+#if _MSC_VER >= 1800
+#include <inttypes.h>
+#else
+#define PRIu64 "I64u"
+#define PRIi64 "I64i"
+#define PRIi8 "i"
+#endif
+#else
 #include <inttypes.h>
 #endif
 


### PR DESCRIPTION
 * Where inttypes.h is not availabale for VS<=2012 the MSVC specific macros still can be used.
 * Tested with VS2010.
 * See msgpack/msgpack-c#257