### PR TITLE
Use std::move (C++11) in map and set adaptors where possible.

### DIFF
--- a/include/msgpack/adaptor/cpp11/unordered_map.hpp
+++ b/include/msgpack/adaptor/cpp11/unordered_map.hpp
@@ -42,9 +42,9 @@ struct convert<std::unordered_map<K, V>> {
         for(; p != pend; ++p) {
             K key;
             p->key.convert(key);
-            p->val.convert(tmp[key]);
+            p->val.convert(tmp[std::move(key)]);
         }
-        tmp.swap(v);
+        v = std::move(tmp);
         return o;
     }
 };
@@ -100,9 +100,9 @@ struct convert<std::unordered_multimap<K, V>> {
             std::pair<K, V> value;
             p->key.convert(value.first);
             p->val.convert(value.second);
-            tmp.insert(value);
+            tmp.insert(std::move(value));
         }
-        tmp.swap(v);
+        v = std::move(tmp);
         return o;
     }
 };

--- a/include/msgpack/adaptor/cpp11/unordered_set.hpp
+++ b/include/msgpack/adaptor/cpp11/unordered_set.hpp
@@ -43,7 +43,7 @@ struct convert<std::unordered_set<T>> {
             --p;
             tmp.insert(p->as<T>());
         }
-        tmp.swap(v);
+        v = std::move(tmp);
         return o;
     }
 };
@@ -97,7 +97,7 @@ struct convert<std::unordered_multiset<T>> {
             --p;
             tmp.insert(p->as<T>());
         }
-        tmp.swap(v);
+        v = std::move(tmp);
         return o;
     }
 };

--- a/include/msgpack/adaptor/map.hpp
+++ b/include/msgpack/adaptor/map.hpp
@@ -115,16 +115,17 @@ struct convert<std::map<K, V> > {
         for(; p != pend; ++p) {
             K key;
             p->key.convert(key);
-            typename std::map<K,V>::iterator it(tmp.lower_bound(key));
-            if(it != tmp.end() && !(key < it->first)) {
-                p->val.convert(it->second);
-            } else {
-                V val;
-                p->val.convert(val);
-                tmp.insert(it, std::pair<K,V>(key, val));
-            }
+#if __cplusplus >= 201103L
+            p->val.convert(tmp[std::move(key)]);
+#else
+            p->val.convert(tmp[key]);
+#endif
         }
+#if __cplusplus >= 201103L
+        v = std::move(tmp);
+#else
         tmp.swap(v);
+#endif
         return o;
     }
 };
@@ -180,9 +181,17 @@ struct convert<std::multimap<K, V> > {
             std::pair<K, V> value;
             p->key.convert(value.first);
             p->val.convert(value.second);
+#if __cplusplus >= 201103L
+            tmp.insert(std::move(value));
+#else
             tmp.insert(value);
+#endif
         }
+#if __cplusplus >= 201103L
+        v = std::move(tmp);
+#else
         tmp.swap(v);
+#endif
         return o;
     }
 };

--- a/include/msgpack/adaptor/set.hpp
+++ b/include/msgpack/adaptor/set.hpp
@@ -43,7 +43,11 @@ struct convert<std::set<T> > {
             --p;
             tmp.insert(p->as<T>());
         }
+#if __cplusplus >= 201103L
+        v = std::move(tmp);
+#else
         tmp.swap(v);
+#endif
         return o;
     }
 };
@@ -96,7 +100,11 @@ struct convert<std::multiset<T> > {
             --p;
             tmp.insert(p->as<T>());
         }
+#if __cplusplus >= 201103L
+        v = std::move(tmp);
+#else
         tmp.swap(v);
+#endif
         return o;
     }
 };


### PR DESCRIPTION
Using std::move for map/set is potentially more efficient (depending on the type), but also allows converting to move-only types where previously the types had to have a copy constructor.

For insert(), moving will actually prevent the copy if possible. This is the important part of the patch.

swap() is very similar to a move assignment, but needs to ensure that the `tmp` variable will afterwards contain the original contents of the target `v` variable, which we don't care about but requires a temporary variable for three-way swapping anyway, so it's a bit less optimal.

I made the moves dependent on the standard macro for C++11 since there's no need to depend on any msgpack defines in these cases, and in the cpp11/ directory there are no #ifdefs. I did not adapt any code in the tr1/ directory since the TR1 types did not have move constructors or move assignment operators anyway (move got introduced very late in the standardization process).