### PR TITLE
Object conversions return the specific type that was converted.

### DIFF
--- a/include/msgpack/object.hpp
+++ b/include/msgpack/object.hpp
@@ -386,15 +386,17 @@ inline msgpack::object::implicit_type object::convert() const
 }
 
 template <typename T>
-inline void object::convert(T& v) const
+inline T& object::convert(T& v) const
 {
     msgpack::operator>>(*this, v);
+    return v;
 }
 
 template <typename T>
-inline void object::convert(T* v) const
+inline T* object::convert(T* v) const
 {
     convert(*v);
+    return v;
 }
 
 template <typename T>

--- a/include/msgpack/object_fwd.hpp
+++ b/include/msgpack/object_fwd.hpp
@@ -106,9 +106,9 @@ struct object {
     T as() const;
 
     template <typename T>
-    void convert(T& v) const;
+    T& convert(T& v) const;
     template <typename T>
-    void convert(T* v) const;
+    T* convert(T* v) const;
 
     object();
 


### PR DESCRIPTION
This allows us to easily make function calls that have parameters that are dependent
upon converting from msgpack objects to concrete types. For example:

    void process_args(std::tuple<int,std::string>& args)
    {
        ...
    }

    process_args(obj.convert(std::make_tuple(100,"hello")))

You can get similar behavior by using obj.as<...>() but its performance is highly
dependent upon the specific compiler and whether or not r-value references are
supported.