### PR TITLE
Fix zbuffer empty string writes

### DIFF
--- a/include/msgpack/zbuffer.h
+++ b/include/msgpack/zbuffer.h
@@ -131,7 +131,7 @@ int msgpack_zbuffer_write(void* data, const char* buf, size_t len)
     zbuf->stream.next_in = (Bytef*)buf;
     zbuf->stream.avail_in = len;
 
-    do {
+    while(zbuf->stream.avail_in > 0) {
         if(zbuf->stream.avail_out < MSGPACK_ZBUFFER_RESERVE_SIZE) {
             if(!msgpack_zbuffer_expand(zbuf)) {
                 return -1;
@@ -141,7 +141,7 @@ int msgpack_zbuffer_write(void* data, const char* buf, size_t len)
         if(deflate(&zbuf->stream, Z_NO_FLUSH) != Z_OK) {
             return -1;
         }
-    } while(zbuf->stream.avail_in > 0);
+    }
 
     return 0;
 }

--- a/include/msgpack/zbuffer.h
+++ b/include/msgpack/zbuffer.h
@@ -70,7 +70,7 @@ static inline int msgpack_zbuffer_write(void* data, const char* buf, size_t len)
 static inline bool msgpack_zbuffer_expand(msgpack_zbuffer* zbuf);
 
 
-bool msgpack_zbuffer_init(msgpack_zbuffer* zbuf,
+static inline bool msgpack_zbuffer_init(msgpack_zbuffer* zbuf,
         int level, size_t init_size)
 {
     memset(zbuf, 0, sizeof(msgpack_zbuffer));
@@ -82,13 +82,13 @@ bool msgpack_zbuffer_init(msgpack_zbuffer* zbuf,
     return true;
 }
 
-void msgpack_zbuffer_destroy(msgpack_zbuffer* zbuf)
+static inline void msgpack_zbuffer_destroy(msgpack_zbuffer* zbuf)
 {
     deflateEnd(&zbuf->stream);
     free(zbuf->data);
 }
 
-msgpack_zbuffer* msgpack_zbuffer_new(int level, size_t init_size)
+static inline msgpack_zbuffer* msgpack_zbuffer_new(int level, size_t init_size)
 {
     msgpack_zbuffer* zbuf = (msgpack_zbuffer*)malloc(sizeof(msgpack_zbuffer));
     if (zbuf == NULL) return NULL;
@@ -99,14 +99,14 @@ msgpack_zbuffer* msgpack_zbuffer_new(int level, size_t init_size)
     return zbuf;
 }
 
-void msgpack_zbuffer_free(msgpack_zbuffer* zbuf)
+static inline void msgpack_zbuffer_free(msgpack_zbuffer* zbuf)
 {
     if(zbuf == NULL) { return; }
     msgpack_zbuffer_destroy(zbuf);
     free(zbuf);
 }
 
-bool msgpack_zbuffer_expand(msgpack_zbuffer* zbuf)
+static inline bool msgpack_zbuffer_expand(msgpack_zbuffer* zbuf)
 {
     size_t used = (char*)zbuf->stream.next_out - zbuf->data;
     size_t csize = used + zbuf->stream.avail_out;
@@ -124,7 +124,7 @@ bool msgpack_zbuffer_expand(msgpack_zbuffer* zbuf)
     return true;
 }
 
-int msgpack_zbuffer_write(void* data, const char* buf, size_t len)
+static inline int msgpack_zbuffer_write(void* data, const char* buf, size_t len)
 {
     msgpack_zbuffer* zbuf = (msgpack_zbuffer*)data;
 
@@ -146,7 +146,7 @@ int msgpack_zbuffer_write(void* data, const char* buf, size_t len)
     return 0;
 }
 
-char* msgpack_zbuffer_flush(msgpack_zbuffer* zbuf)
+static inline char* msgpack_zbuffer_flush(msgpack_zbuffer* zbuf)
 {
     while(true) {
         switch(deflate(&zbuf->stream, Z_FINISH)) {
@@ -163,23 +163,23 @@ char* msgpack_zbuffer_flush(msgpack_zbuffer* zbuf)
     }
 }
 
-const char* msgpack_zbuffer_data(const msgpack_zbuffer* zbuf)
+static inline const char* msgpack_zbuffer_data(const msgpack_zbuffer* zbuf)
 {
     return zbuf->data;
 }
 
-size_t msgpack_zbuffer_size(const msgpack_zbuffer* zbuf)
+static inline size_t msgpack_zbuffer_size(const msgpack_zbuffer* zbuf)
 {
     return (char*)zbuf->stream.next_out - zbuf->data;
 }
 
-void msgpack_zbuffer_reset_buffer(msgpack_zbuffer* zbuf)
+static inline void msgpack_zbuffer_reset_buffer(msgpack_zbuffer* zbuf)
 {
     zbuf->stream.avail_out += (char*)zbuf->stream.next_out - zbuf->data;
     zbuf->stream.next_out = (Bytef*)zbuf->data;
 }
 
-bool msgpack_zbuffer_reset(msgpack_zbuffer* zbuf)
+static inline bool msgpack_zbuffer_reset(msgpack_zbuffer* zbuf)
 {
     if(deflateReset(&zbuf->stream) != Z_OK) {
         return false;
@@ -188,7 +188,7 @@ bool msgpack_zbuffer_reset(msgpack_zbuffer* zbuf)
     return true;
 }
 
-char* msgpack_zbuffer_release_buffer(msgpack_zbuffer* zbuf)
+static inline char* msgpack_zbuffer_release_buffer(msgpack_zbuffer* zbuf)
 {
     char* tmp = zbuf->data;
     zbuf->data = NULL;

--- a/include/msgpack/zbuffer.hpp
+++ b/include/msgpack/zbuffer.hpp
@@ -65,7 +65,7 @@ public:
         m_stream.next_in = reinterpret_cast<Bytef*>(const_cast<char*>(buf));
         m_stream.avail_in = len;
 
-        do {
+        while(m_stream.avail_in > 0) {
             if(m_stream.avail_out < MSGPACK_ZBUFFER_RESERVE_SIZE) {
                 if(!expand()) {
                     throw std::bad_alloc();
@@ -75,7 +75,7 @@ public:
             if(deflate(&m_stream, Z_NO_FLUSH) != Z_OK) {
                 throw std::bad_alloc();
             }
-        } while(m_stream.avail_in > 0);
+        }
     }
 
     char* flush()

--- a/test/buffer.cpp
+++ b/test/buffer.cpp
@@ -2,6 +2,7 @@
 #include <msgpack/fbuffer.hpp>
 #include <msgpack/fbuffer.h>
 #include <msgpack/zbuffer.hpp>
+#include <msgpack/zbuffer.h>
 #include <gtest/gtest.h>
 #include <string.h>
 
@@ -68,8 +69,22 @@ TEST(buffer, zbuffer)
     zbuf.write("a", 1);
     zbuf.write("a", 1);
     zbuf.write("a", 1);
+    zbuf.write("", 0);
 
     zbuf.flush();
+}
+
+
+TEST(buffer, zbuffer_c)
+{
+    msgpack_zbuffer zbuf;
+    EXPECT_TRUE(msgpack_zbuffer_init(&zbuf, 1, MSGPACK_ZBUFFER_INIT_SIZE));
+    EXPECT_EQ(0, msgpack_zbuffer_write(&zbuf, "a", 1));
+    EXPECT_EQ(0, msgpack_zbuffer_write(&zbuf, "a", 1));
+    EXPECT_EQ(0, msgpack_zbuffer_write(&zbuf, "a", 1));
+    EXPECT_EQ(0, msgpack_zbuffer_write(&zbuf, "", 0));
+
+    EXPECT_TRUE(msgpack_zbuffer_flush(&zbuf) != NULL);
 }
 
 

--- a/test/buffer.cpp
+++ b/test/buffer.cpp
@@ -85,6 +85,8 @@ TEST(buffer, zbuffer_c)
     EXPECT_EQ(0, msgpack_zbuffer_write(&zbuf, "", 0));
 
     EXPECT_TRUE(msgpack_zbuffer_flush(&zbuf) != NULL);
+
+    msgpack_zbuffer_destroy(&zbuf);
 }
 
 


### PR DESCRIPTION
This pull request fixes msgpack::zbuffer::write and msgpack_zbuffer_write to handle empty strings correctly.  Essentially the deflate call should be skipped entirely when there is no data to write, because it will return Z_BUFFER_ERROR and make the rest of the code think that something is wrong.

This fixes msgpack/msgpack-c#291.