### PR TITLE
c++11 code should use nothrow instead of throw()

### DIFF
--- a/include/msgpack/detail/cpp11_zone.hpp
+++ b/include/msgpack/detail/cpp11_zone.hpp
@@ -203,21 +203,21 @@ public:
     void swap(zone& o);
 
 
-    static void* operator new(std::size_t size) throw(std::bad_alloc)
+    static void* operator new(std::size_t size)
     {
         void* p = ::malloc(size);
         if (!p) throw std::bad_alloc();
         return p;
     }
-    static void operator delete(void *p) throw()
+    static void operator delete(void *p) noexcept
     {
         ::free(p);
     }
-    static void* operator new(std::size_t /*size*/, void* mem) throw()
+    static void* operator new(std::size_t /*size*/, void* mem) noexcept
     {
         return mem;
     }
-    static void operator delete(void * /*p*/, void* /*mem*/) throw()
+    static void operator delete(void * /*p*/, void* /*mem*/) noexcept
     {
     }
 

--- a/include/msgpack/detail/cpp11_zone.hpp
+++ b/include/msgpack/detail/cpp11_zone.hpp
@@ -97,7 +97,6 @@ private:
 
             ++m_tail;
         }
-#if !defined(MSGPACK_USE_CPP03)
         finalizer_array(finalizer_array&& other) noexcept
             :m_tail(other.m_tail), m_end(other.m_end), m_array(other.m_array)
         {
@@ -111,7 +110,7 @@ private:
             new (this) finalizer_array(std::move(other));
             return *this;
         }
-#endif
+
         finalizer* m_tail;
         finalizer* m_end;
         finalizer* m_array;
@@ -162,7 +161,6 @@ private:
             m_free = chunk_size;
             m_ptr  = reinterpret_cast<char*>(m_head) + sizeof(chunk);
         }
-#if !defined(MSGPACK_USE_CPP03)
         chunk_list(chunk_list&& other) noexcept
             :m_free(other.m_free), m_ptr(other.m_ptr), m_head(other.m_head)
         {
@@ -174,7 +172,7 @@ private:
             new (this) chunk_list(std::move(other));
             return *this;
         }
-#endif
+
         size_t m_free;
         char* m_ptr;
         chunk* m_head;


### PR DESCRIPTION
C++11 should not use deprecated throw(std::bad_alloc) / throw(), but instead use nothrow.

Also there are two 
#if !defined(MSGPACK_USE_CPP03) 
checks in c++11 specific code. Should not this always be true?