### PR TITLE
Feature vs2015 support

### DIFF
--- a/include/msgpack/adaptor/detail/cpp11_msgpack_tuple.hpp
+++ b/include/msgpack/adaptor/detail/cpp11_msgpack_tuple.hpp
@@ -71,11 +71,11 @@ namespace type {
 
         template< std::size_t I>
         typename tuple_element<I, base >::type&
-        get() { return std::get<I>(*this); }
+        get() & { return std::get<I>(*this); }
 
         template< std::size_t I>
         typename tuple_element<I, base >::type const&
-        get() const { return std::get<I>(*this); }
+        get() const& { return std::get<I>(*this); }
 
         template< std::size_t I>
         typename tuple_element<I, base >::type&&

--- a/include/msgpack/cpp_config.hpp
+++ b/include/msgpack/cpp_config.hpp
@@ -21,10 +21,11 @@
 #include "msgpack/versioning.hpp"
 
 #if !defined(MSGPACK_USE_CPP03)
-  // If MSVC would support C++11 completely,
-  // then 'defined(_MSC_VER)' would replace with
-  // '_MSC_VER < XXXX'
-# if (__cplusplus < 201103L) || defined(_MSC_VER)
+# if defined(_MSC_VER)
+#  if _MSC_VER < 1900
+#    define MSGPACK_USE_CPP03
+#  endif
+# elif (__cplusplus < 201103L)
 #  define MSGPACK_USE_CPP03
 # endif
 #endif // MSGPACK_USE_CPP03


### PR DESCRIPTION
Visual Studio 2015 is c++11 compliant.
Just had to fix one error about member ref-specifiers.