### PR TITLE
Add move semantics to sbuffer in c++11 mode

### DIFF
--- a/include/msgpack/sbuffer.hpp
+++ b/include/msgpack/sbuffer.hpp
@@ -51,7 +51,30 @@ public:
         ::free(m_data);
     }
 
-public:
+#if !defined(MSGPACK_USE_CPP03)
+    sbuffer(const sbuffer&) = delete;
+    sbuffer& operator=(const sbuffer&) = delete;
+
+    sbuffer(sbuffer&& other) :
+        m_size(other.m_size), m_alloc(other.m_alloc), m_data(other.m_data)
+    {
+        other.m_size = other.m_alloc = 0;
+        other.m_data = nullptr;
+    }
+
+    sbuffer& operator=(sbuffer&& other)
+    {
+        ::free(m_data);
+
+        m_size = other.m_size;
+        m_alloc = other.m_alloc;
+        m_data = other.m_data;
+
+        other.m_size = other.m_alloc = 0;
+        other.m_data = nullptr;
+    }
+#endif // !defined(MSGPACK_USE_CPP03)
+
     void write(const char* buf, size_t len)
     {
         if(m_alloc - m_size < len) {
@@ -118,10 +141,7 @@ private:
 private:
     sbuffer(const sbuffer&);
     sbuffer& operator=(const sbuffer&);
-#else  // defined(MSGPACK_USE_CPP03)
-    sbuffer(const sbuffer&) = delete;
-    sbuffer& operator=(const sbuffer&) = delete;
-#endif // defined(MSGPACK_USE_CPP03)
+#endif  // defined(MSGPACK_USE_CPP03)
 
 private:
     size_t m_size;

--- a/include/msgpack/sbuffer.hpp
+++ b/include/msgpack/sbuffer.hpp
@@ -56,7 +56,7 @@ public:
     sbuffer& operator=(const sbuffer&) = delete;
 
     sbuffer(sbuffer&& other) :
-        m_size(other.m_size), m_alloc(other.m_alloc), m_data(other.m_data)
+        m_size(other.m_size), m_data(other.m_data), m_alloc(other.m_alloc)
     {
         other.m_size = other.m_alloc = 0;
         other.m_data = nullptr;

--- a/include/msgpack/sbuffer.hpp
+++ b/include/msgpack/sbuffer.hpp
@@ -72,6 +72,8 @@ public:
 
         other.m_size = other.m_alloc = 0;
         other.m_data = nullptr;
+
+        return *this;
     }
 #endif // !defined(MSGPACK_USE_CPP03)
 


### PR DESCRIPTION
sbuffer class would benefit from move semantics, so that it can be returned from functions.

P.S.
I've moved deleted copy constructor/assignment operator (= delete) from private section to public. Scott Meyers was suggesting this, so that compiler may provide better error message (not that it is only not accessible, but that it is explicitly deleted).
