### PR TITLE
Fixed #243.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,6 +164,7 @@ IF (MSGPACK_ENABLE_CXX)
     LIST (APPEND msgpack_HEADERS
         include/msgpack.hpp
         include/msgpack/adaptor/adaptor_base.hpp
+        include/msgpack/adaptor/array_ref.hpp
         include/msgpack/adaptor/bool.hpp
         include/msgpack/adaptor/boost/fusion.hpp
         include/msgpack/adaptor/boost/optional.hpp

--- a/include/msgpack/adaptor/array_ref.hpp
+++ b/include/msgpack/adaptor/array_ref.hpp
@@ -1,0 +1,182 @@
+//
+// MessagePack for C++ static resolution routine
+//
+// Copyright (C) 2008-2009 FURUHASHI Sadayuki
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+#ifndef MSGPACK_TYPE_ARRAY_REF_HPP
+#define MSGPACK_TYPE_ARRAY_REF_HPP
+
+#include "msgpack/versioning.hpp"
+#include "msgpack/adaptor/adaptor_base.hpp"
+#include "msgpack/adaptor/check_container_size.hpp"
+#include <cstring>
+#include <string>
+
+namespace msgpack {
+
+/// @cond
+MSGPACK_API_VERSION_NAMESPACE(v1) {
+/// @endcond
+
+namespace type {
+
+template <typename T>
+struct array_ref {
+    array_ref() : data(nullptr) {}
+    array_ref(T& t) : data(&t) {}
+
+    T* data;
+
+    template <typename U>
+    bool operator==(array_ref<U> const& t) const {
+        return *data == *t.data;
+    }
+    template <typename U>
+    bool operator!=(array_ref<U> const& t) const {
+        return !(*data == *t.data);
+    }
+    template <typename U>
+    bool operator< (array_ref<U> const& t) const
+    {
+        return *data < *t.data;
+    }
+    template <typename U>
+    bool operator> (array_ref<U> const& t) const
+    {
+        return *t.data < *data;
+    }
+    template <typename U>
+    bool operator<= (array_ref<U> const& t) const
+    {
+        return !(*t.data < *data);
+    }
+    template <typename U>
+    bool operator>= (array_ref<U> const& t) const
+    {
+        return !(*data < *t.data);
+    }
+};
+
+template <typename T>
+inline array_ref<T const> make_array_ref(T const& t) {
+    return array_ref<T const>(t);
+}
+
+template <typename T>
+inline array_ref<T> make_array_ref(T& t) {
+    return array_ref<T>(t);
+}
+
+
+} // namespace type
+
+namespace adaptor {
+
+template <typename T>
+struct convert<msgpack::type::array_ref<T> > {
+    msgpack::object const& operator()(msgpack::object const& o, msgpack::type::array_ref<T>& v) const {
+        if (!v.data) { throw msgpack::type_error(); }
+        if (o.type != msgpack::type::ARRAY) { throw msgpack::type_error(); }
+        if (v.data->size() < o.via.bin.size) { throw msgpack::type_error(); }
+        if (o.via.array.size > 0) {
+            msgpack::object* p = o.via.array.ptr;
+            msgpack::object* const pend = o.via.array.ptr + o.via.array.size;
+            typename T::iterator it = v.data->begin();
+            do {
+                p->convert(*it);
+                ++p;
+                ++it;
+            } while(p < pend);
+        }
+        return o;
+    }
+};
+
+template <typename T>
+struct convert<msgpack::type::array_ref<std::vector<T> > > {
+    msgpack::object const& operator()(msgpack::object const& o, msgpack::type::array_ref<std::vector<T> >& v) const {
+        if (!v.data) { throw msgpack::type_error(); }
+        if (o.type != msgpack::type::ARRAY) { throw msgpack::type_error(); }
+        v.data->resize(o.via.bin.size);
+        if (o.via.array.size > 0) {
+            msgpack::object* p = o.via.array.ptr;
+            msgpack::object* const pend = o.via.array.ptr + o.via.array.size;
+            typename std::vector<T>::iterator it = v.data->begin();
+            do {
+                p->convert(*it);
+                ++p;
+                ++it;
+            } while(p < pend);
+        }
+        return o;
+    }
+};
+
+template <typename T>
+struct pack<msgpack::type::array_ref<T> > {
+    template <typename Stream>
+    msgpack::packer<Stream>& operator()(msgpack::packer<Stream>& o, const msgpack::type::array_ref<T>& v) const {
+        if (!v.data) { throw msgpack::type_error(); }
+        uint32_t size = checked_get_container_size(v.data->size());
+        o.pack_array(size);
+        for (typename T::const_iterator it(v.data->begin()), it_end(v.data->end());
+            it != it_end; ++it) {
+            o.pack(*it);
+        }
+        return o;
+    }
+};
+
+template <typename T>
+struct object_with_zone<msgpack::type::array_ref<T> > {
+    void operator()(msgpack::object::with_zone& o, const msgpack::type::array_ref<T>& v) const {
+        if (!v.data) { throw msgpack::type_error(); }
+        o.type = msgpack::type::ARRAY;
+        if (v.data->empty()) {
+            o.via.array.ptr = nullptr;
+            o.via.array.size = 0;
+        }
+        else {
+            uint32_t size = checked_get_container_size(v.data->size());
+            msgpack::object* p = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object)*size));
+            msgpack::object* const pend = p + size;
+            o.via.array.ptr = p;
+            o.via.array.size = size;
+            typename T::const_iterator it(v.data->begin());
+            do {
+#if (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif // (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)) && !defined(__clang__)
+                *p = msgpack::object(*it, o.zone);
+#if (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif // (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)) && !defined(__clang__)
+                ++p;
+                ++it;
+            } while(p < pend);
+        }
+    }
+};
+
+} // namespace adaptor
+
+/// @cond
+} // MSGPACK_API_VERSION_NAMESPACE(v1)
+/// @endcond
+
+} // namespace msgpack
+
+#endif // MSGPACK_TYPE_ARRAY_REF_HPP

--- a/include/msgpack/adaptor/cpp11/array_unsigned_char.hpp
+++ b/include/msgpack/adaptor/cpp11/array_unsigned_char.hpp
@@ -1,0 +1,97 @@
+//
+// MessagePack for C++ static resolution routine
+//
+// Copyright (C) 2014-2015 KONDO Takatoshi
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+#ifndef MSGPACK_TYPE_ARRAY_UNSIGNED_CHAR_HPP
+#define MSGPACK_TYPE_ARRAY_UNSIGNED_CHAR_HPP
+
+#include "msgpack/versioning.hpp"
+#include "msgpack/adaptor/adaptor_base.hpp"
+#include "msgpack/adaptor/check_container_size.hpp"
+
+#include <array>
+
+namespace msgpack {
+
+/// @cond
+MSGPACK_API_VERSION_NAMESPACE(v1) {
+/// @endcond
+
+namespace adaptor {
+
+template <std::size_t N>
+struct convert<std::array<unsigned char, N>> {
+    msgpack::object const& operator()(msgpack::object const& o, std::array<unsigned char, N>& v) const {
+        switch (o.type) {
+        case msgpack::type::BIN:
+            if(o.via.bin.size != N) { throw msgpack::type_error(); }
+            std::memcpy(v.data(), o.via.bin.ptr, o.via.bin.size);
+            break;
+        case msgpack::type::STR:
+            if(o.via.str.size != N) { throw msgpack::type_error(); }
+            std::memcpy(v.data(), o.via.str.ptr, N);
+            break;
+        default:
+            throw msgpack::type_error();
+            break;
+        }
+        return o;
+    }
+};
+
+template <std::size_t N>
+struct pack<std::array<unsigned char, N>> {
+    template <typename Stream>
+    msgpack::packer<Stream>& operator()(msgpack::packer<Stream>& o, const std::array<unsigned char, N>& v) const {
+        uint32_t size = checked_get_container_size(v.size());
+        o.pack_bin(size);
+        o.pack_bin_body(reinterpret_cast<char const*>(v.data()), size);
+
+        return o;
+    }
+};
+
+template <std::size_t N>
+struct object<std::array<unsigned char, N>> {
+    void operator()(msgpack::object& o, const std::array<unsigned char, N>& v) const {
+        uint32_t size = checked_get_container_size(v.size());
+        o.type = msgpack::type::BIN;
+        o.via.bin.ptr = reinterpret_cast<char const*>(v.data());
+        o.via.bin.size = size;
+    }
+};
+
+template <std::size_t N>
+struct object_with_zone<std::array<unsigned char, N>> {
+    void operator()(msgpack::object::with_zone& o, const std::array<unsigned char, N>& v) const {
+        uint32_t size = checked_get_container_size(v.size());
+        o.type = msgpack::type::BIN;
+        char* ptr = static_cast<char*>(o.zone.allocate_align(size));
+        o.via.bin.ptr = ptr;
+        o.via.bin.size = size;
+        std::memcpy(ptr, v.data(), size);
+    }
+};
+
+} // namespace adaptor
+
+/// @cond
+} // MSGPACK_API_VERSION_NAMESPACE(v1)
+/// @endcond
+
+} // namespace msgpack
+
+#endif // MSGPACK_TYPE_ARRAY_UNSIGNED_CHAR_HPP

--- a/include/msgpack/adaptor/vector_unsigned_char.hpp
+++ b/include/msgpack/adaptor/vector_unsigned_char.hpp
@@ -1,0 +1,97 @@
+//
+// MessagePack for C++ static resolution routine
+//
+// Copyright (C) 2014-2015 KONDO Takatoshi
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+#ifndef MSGPACK_TYPE_VECTOR_UNSIGNED_CHAR_HPP
+#define MSGPACK_TYPE_VECTOR_UNSIGNED_CHAR_HPP
+
+#include "msgpack/versioning.hpp"
+#include "msgpack/adaptor/adaptor_base.hpp"
+#include "msgpack/adaptor/check_container_size.hpp"
+
+#include <vector>
+
+namespace msgpack {
+
+/// @cond
+MSGPACK_API_VERSION_NAMESPACE(v1) {
+/// @endcond
+
+namespace adaptor {
+
+template <typename Alloc>
+struct convert<std::vector<unsigned char, Alloc> > {
+    msgpack::object const& operator()(msgpack::object const& o, std::vector<unsigned char, Alloc>& v) const {
+        switch (o.type) {
+        case msgpack::type::BIN:
+            v.resize(o.via.bin.size);
+            std::memcpy(&v.front(), o.via.bin.ptr, o.via.bin.size);
+            break;
+        case msgpack::type::STR:
+            v.resize(o.via.str.size);
+            std::memcpy(&v.front(), o.via.str.ptr, o.via.str.size);
+            break;
+        default:
+            throw msgpack::type_error();
+            break;
+        }
+        return o;
+    }
+};
+
+template <typename Alloc>
+struct pack<std::vector<unsigned char, Alloc> > {
+    template <typename Stream>
+    msgpack::packer<Stream>& operator()(msgpack::packer<Stream>& o, const std::vector<unsigned char, Alloc>& v) const {
+        uint32_t size = checked_get_container_size(v.size());
+        o.pack_bin(size);
+        o.pack_bin_body(reinterpret_cast<char const*>(&v.front()), size);
+
+        return o;
+    }
+};
+
+template <typename Alloc>
+struct object<std::vector<unsigned char, Alloc> > {
+    void operator()(msgpack::object& o, const std::vector<unsigned char, Alloc>& v) const {
+        uint32_t size = checked_get_container_size(v.size());
+        o.type = msgpack::type::BIN;
+        o.via.bin.ptr = reinterpret_cast<char const*>(&v.front());
+        o.via.bin.size = size;
+    }
+};
+
+template <typename Alloc>
+struct object_with_zone<std::vector<unsigned char, Alloc> > {
+    void operator()(msgpack::object::with_zone& o, const std::vector<unsigned char, Alloc>& v) const {
+        uint32_t size = checked_get_container_size(v.size());
+        o.type = msgpack::type::BIN;
+        char* ptr = static_cast<char*>(o.zone.allocate_align(size));
+        o.via.bin.ptr = ptr;
+        o.via.bin.size = size;
+        std::memcpy(ptr, &v.front(), size);
+    }
+};
+
+} // namespace adaptor
+
+/// @cond
+} // MSGPACK_API_VERSION_NAMESPACE(v1)
+/// @endcond
+
+} // namespace msgpack
+
+#endif // MSGPACK_TYPE_VECTOR_UNSIGNED_CHAR_HPP

--- a/include/msgpack/cpp_config.hpp
+++ b/include/msgpack/cpp_config.hpp
@@ -78,6 +78,22 @@ template <typename T>
 struct enable_if<false, T> {
 };
 
+template<typename T, T val>
+struct integral_constant {
+    static T const value = val;
+    typedef T value_type;
+    typedef integral_constant<T, val> type;
+};
+
+typedef integral_constant<bool, true> true_type;
+typedef integral_constant<bool, false> false_type;
+
+template<class T, class U>
+struct is_same : false_type {};
+
+template<class T>
+struct is_same<T, T> : true_type {};
+
 /// @cond
 }  // MSGPACK_API_VERSION_NAMESPACE(v1)
 /// @endcond
@@ -104,6 +120,7 @@ MSGPACK_API_VERSION_NAMESPACE(v1) {
     using std::move;
     using std::swap;
     using std::enable_if;
+    using std::is_same;
 
 /// @cond
 }  // MSGPACK_API_VERSION_NAMESPACE(v1)

--- a/include/msgpack/type.hpp
+++ b/include/msgpack/type.hpp
@@ -1,4 +1,5 @@
 #include "cpp_config.hpp"
+#include "adaptor/array_ref.hpp"
 #include "adaptor/bool.hpp"
 #include "adaptor/char_ptr.hpp"
 #include "adaptor/deque.hpp"
@@ -17,6 +18,7 @@
 #include "adaptor/vector.hpp"
 #include "adaptor/vector_bool.hpp"
 #include "adaptor/vector_char.hpp"
+#include "adaptor/vector_unsigned_char.hpp"
 #include "adaptor/msgpack_tuple.hpp"
 #include "adaptor/define.hpp"
 
@@ -29,6 +31,7 @@
 
 #include "adaptor/cpp11/array.hpp"
 #include "adaptor/cpp11/array_char.hpp"
+#include "adaptor/cpp11/array_unsigned_char.hpp"
 #include "adaptor/cpp11/forward_list.hpp"
 #include "adaptor/cpp11/shared_ptr.hpp"
 #include "adaptor/cpp11/tuple.hpp"

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -173,6 +173,7 @@ if ENABLE_CXX
 nobase_include_HEADERS += \
 		../include/msgpack.hpp \
 		../include/msgpack/adaptor/adaptor_base.hpp \
+		../include/msgpack/adaptor/array_ref.hpp \
 		../include/msgpack/adaptor/bool.hpp \
 		../include/msgpack/adaptor/boost/fusion.hpp \
 		../include/msgpack/adaptor/boost/optional.hpp \

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -8,6 +8,7 @@ INCLUDE_DIRECTORIES (
 )
 
 LIST (APPEND check_PROGRAMS
+    array_ref.cpp
     buffer.cpp
     cases.cpp
     convert.cpp

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -3,6 +3,7 @@ AM_C_CPPFLAGS = -I$(top_srcdir)/include -pthread
 AM_LDFLAGS = $(top_builddir)/src/libmsgpack.la -lgtest_main -lgtest -lpthread
 
 check_PROGRAMS = \
+		array_ref \
 		buffer \
 		cases \
 		convert \
@@ -45,6 +46,7 @@ check_PROGRAMS += \
 
 TESTS = $(check_PROGRAMS)
 
+array_ref_SOURCES = array_ref.cpp
 buffer_SOURCES = buffer.cpp
 cases_SOURCES = cases.cpp
 convert_SOURCES = convert.cpp

--- a/test/array_ref.cpp
+++ b/test/array_ref.cpp
@@ -1,0 +1,310 @@
+#include <msgpack.hpp>
+
+#include <string>
+#include <sstream>
+
+#include <gtest/gtest.h>
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+TEST(MSGPACK_ARRAY_REF, pack_unpack_convert_vector_char)
+{
+    std::vector<char> v;
+    v.push_back('a');
+    v.push_back('b');
+    v.push_back('c');
+
+    msgpack::type::array_ref<std::vector<char> > ar1 = msgpack::type::make_array_ref(v);
+    std::stringstream ss;
+    msgpack::pack(ss, ar1);
+
+    msgpack::unpacked upd;
+    msgpack::unpack(upd, ss.str().data(), ss.str().size());
+    EXPECT_EQ(upd.get().type, msgpack::type::ARRAY);
+    std::vector<char> v2;
+    msgpack::type::array_ref<std::vector<char> > ar2(v2);
+    upd.get().convert(ar2);
+    EXPECT_EQ(ar1, ar2);
+}
+
+TEST(MSGPACK_ARRAY_REF, pack_unpack_convert_vector_char_const)
+{
+    std::vector<char> v;
+    v.push_back('a');
+    v.push_back('b');
+    v.push_back('c');
+
+    std::vector<char> const& cv = v;
+
+    msgpack::type::array_ref<std::vector<char> const> ar1 = msgpack::type::make_array_ref(cv);
+    std::stringstream ss;
+    msgpack::pack(ss, ar1);
+
+    msgpack::unpacked upd;
+    msgpack::unpack(upd, ss.str().data(), ss.str().size());
+    EXPECT_EQ(upd.get().type, msgpack::type::ARRAY);
+    std::vector<char> v2;
+    msgpack::type::array_ref<std::vector<char> > ar2(v2);
+    upd.get().convert(ar2);
+    EXPECT_EQ(ar1, ar2);
+}
+
+TEST(MSGPACK_ARRAY_REF, pack_unpack_convert_vector_unsigned_char)
+{
+    std::vector<unsigned char> v;
+    v.push_back('a');
+    v.push_back('b');
+    v.push_back('c');
+
+    msgpack::type::array_ref<std::vector<unsigned char> > ar1 = msgpack::type::make_array_ref(v);
+    std::stringstream ss;
+    msgpack::pack(ss, ar1);
+
+    msgpack::unpacked upd;
+    msgpack::unpack(upd, ss.str().data(), ss.str().size());
+    EXPECT_EQ(upd.get().type, msgpack::type::ARRAY);
+    std::vector<unsigned char> v2;
+    msgpack::type::array_ref<std::vector<unsigned char> > ar2(v2);
+    upd.get().convert(ar2);
+    EXPECT_EQ(ar1, ar2);
+}
+
+TEST(MSGPACK_ARRAY_REF, pack_unpack_convert_vector_unsigned_char_const)
+{
+    std::vector<unsigned char> v;
+    v.push_back('a');
+    v.push_back('b');
+    v.push_back('c');
+
+    std::vector<unsigned char> const& cv = v;
+
+    msgpack::type::array_ref<std::vector<unsigned char> const> ar1 = msgpack::type::make_array_ref(cv);
+    std::stringstream ss;
+    msgpack::pack(ss, ar1);
+
+    msgpack::unpacked upd;
+    msgpack::unpack(upd, ss.str().data(), ss.str().size());
+    EXPECT_EQ(upd.get().type, msgpack::type::ARRAY);
+    std::vector<unsigned char> v2;
+    msgpack::type::array_ref<std::vector<unsigned char> > ar2(v2);
+    upd.get().convert(ar2);
+    EXPECT_EQ(ar1, ar2);
+}
+
+TEST(MSGPACK_ARRAY_REF, object_with_zone_vector_char)
+{
+    std::vector<char> v;
+    v.push_back('a');
+    v.push_back('b');
+    v.push_back('c');
+
+    msgpack::type::array_ref<std::vector<char> > ar1 = msgpack::type::make_array_ref(v);
+    msgpack::zone z;
+    msgpack::object obj(ar1, z);
+
+    EXPECT_EQ(obj.type, msgpack::type::ARRAY);
+    std::vector<char> v2;
+    msgpack::type::array_ref<std::vector<char> > ar2(v2);
+    obj.convert(ar2);
+    EXPECT_EQ(ar1, ar2);
+}
+
+TEST(MSGPACK_ARRAY_REF, object_with_zone_vector_char_const)
+{
+    std::vector<char> v;
+    v.push_back('a');
+    v.push_back('b');
+    v.push_back('c');
+
+    std::vector<char> const& cv = v;
+
+    msgpack::type::array_ref<std::vector<char> const> ar1 = msgpack::type::make_array_ref(cv);
+    msgpack::zone z;
+    msgpack::object obj(ar1, z);
+
+    EXPECT_EQ(obj.type, msgpack::type::ARRAY);
+    std::vector<char> v2;
+    msgpack::type::array_ref<std::vector<char> > ar2(v2);
+    obj.convert(ar2);
+    EXPECT_EQ(ar1, ar2);
+}
+
+TEST(MSGPACK_ARRAY_REF, object_with_zone_vector_unsigned_char)
+{
+    std::vector<unsigned char> v;
+    v.push_back('a');
+    v.push_back('b');
+    v.push_back('c');
+
+    msgpack::type::array_ref<std::vector<unsigned char> > ar1 = msgpack::type::make_array_ref(v);
+    msgpack::zone z;
+    msgpack::object obj(ar1, z);
+
+    EXPECT_EQ(obj.type, msgpack::type::ARRAY);
+    std::vector<unsigned char> v2;
+    msgpack::type::array_ref<std::vector<unsigned char> > ar2(v2);
+    obj.convert(ar2);
+    EXPECT_EQ(ar1, ar2);
+}
+
+TEST(MSGPACK_ARRAY_REF, object_with_zone_vector_unsigned_char_const)
+{
+    std::vector<unsigned char> v;
+    v.push_back('a');
+    v.push_back('b');
+    v.push_back('c');
+
+    std::vector<unsigned char> const& cv = v;
+
+    msgpack::type::array_ref<std::vector<unsigned char> const> ar1 = msgpack::type::make_array_ref(cv);
+    msgpack::zone z;
+    msgpack::object obj(ar1, z);
+
+    EXPECT_EQ(obj.type, msgpack::type::ARRAY);
+    std::vector<unsigned char> v2;
+    msgpack::type::array_ref<std::vector<unsigned char> > ar2(v2);
+    obj.convert(ar2);
+    EXPECT_EQ(ar1, ar2);
+}
+
+#if !defined(MSGPACK_USE_CPP03)
+
+TEST(MSGPACK_ARRAY_REF, pack_unpack_convert_array_char)
+{
+    std::array<char, 3> v { { 'a', 'b', 'c' } };
+
+    msgpack::type::array_ref<std::array<char, 3> > ar1 = msgpack::type::make_array_ref(v);
+    std::stringstream ss;
+    msgpack::pack(ss, ar1);
+
+    msgpack::unpacked upd;
+    msgpack::unpack(upd, ss.str().data(), ss.str().size());
+    EXPECT_EQ(upd.get().type, msgpack::type::ARRAY);
+    std::array<char, 3> v2;
+    msgpack::type::array_ref<std::array<char, 3> > ar2(v2);
+    upd.get().convert(ar2);
+    EXPECT_EQ(ar1, ar2);
+}
+
+TEST(MSGPACK_ARRAY_REF, pack_unpack_convert_array_char_const)
+{
+    std::array<char, 3> v { { 'a', 'b', 'c' } };
+
+    std::array<char, 3> const& cv = v;
+
+    msgpack::type::array_ref<std::array<char, 3> const> ar1 = msgpack::type::make_array_ref(cv);
+    std::stringstream ss;
+    msgpack::pack(ss, ar1);
+
+    msgpack::unpacked upd;
+    msgpack::unpack(upd, ss.str().data(), ss.str().size());
+    EXPECT_EQ(upd.get().type, msgpack::type::ARRAY);
+    std::array<char, 3> v2;
+    msgpack::type::array_ref<std::array<char, 3> > ar2(v2);
+    upd.get().convert(ar2);
+    EXPECT_EQ(ar1, ar2);
+}
+
+TEST(MSGPACK_ARRAY_REF, pack_unpack_convert_array_unsigned_char)
+{
+    std::array<unsigned char, 3> v { { 'a', 'b', 'c' } };
+
+    msgpack::type::array_ref<std::array<unsigned char, 3> > ar1 = msgpack::type::make_array_ref(v);
+    std::stringstream ss;
+    msgpack::pack(ss, ar1);
+
+    msgpack::unpacked upd;
+    msgpack::unpack(upd, ss.str().data(), ss.str().size());
+    EXPECT_EQ(upd.get().type, msgpack::type::ARRAY);
+    std::array<unsigned char, 3> v2;
+    msgpack::type::array_ref<std::array<unsigned char, 3> > ar2(v2);
+    upd.get().convert(ar2);
+    EXPECT_EQ(ar1, ar2);
+}
+
+TEST(MSGPACK_ARRAY_REF, pack_unpack_convert_array_unsigned_char_const)
+{
+    std::array<unsigned char, 3> v { { 'a', 'b', 'c' } };
+
+    std::array<unsigned char, 3> const& cv = v;
+
+    msgpack::type::array_ref<std::array<unsigned char, 3> const> ar1 = msgpack::type::make_array_ref(cv);
+    std::stringstream ss;
+    msgpack::pack(ss, ar1);
+
+    msgpack::unpacked upd;
+    msgpack::unpack(upd, ss.str().data(), ss.str().size());
+    EXPECT_EQ(upd.get().type, msgpack::type::ARRAY);
+    std::array<unsigned char, 3> v2;
+    msgpack::type::array_ref<std::array<unsigned char, 3> > ar2(v2);
+    upd.get().convert(ar2);
+    EXPECT_EQ(ar1, ar2);
+}
+
+TEST(MSGPACK_ARRAY_REF, object_with_zone_array_char)
+{
+    std::array<char, 3> v { { 'a', 'b', 'c' } };
+
+    msgpack::type::array_ref<std::array<char, 3> > ar1 = msgpack::type::make_array_ref(v);
+    msgpack::zone z;
+    msgpack::object obj(ar1, z);
+
+    EXPECT_EQ(obj.type, msgpack::type::ARRAY);
+    std::array<char, 3> v2;
+    msgpack::type::array_ref<std::array<char, 3> > ar2(v2);
+    obj.convert(ar2);
+    EXPECT_EQ(ar1, ar2);
+}
+
+TEST(MSGPACK_ARRAY_REF, object_with_zone_array_char_const)
+{
+    std::array<char, 3> v { { 'a', 'b', 'c' } };
+
+    std::array<char, 3> const& cv = v;
+
+    msgpack::type::array_ref<std::array<char, 3> const> ar1 = msgpack::type::make_array_ref(cv);
+    msgpack::zone z;
+    msgpack::object obj(ar1, z);
+
+    EXPECT_EQ(obj.type, msgpack::type::ARRAY);
+    std::array<char, 3> v2;
+    msgpack::type::array_ref<std::array<char, 3> > ar2(v2);
+    obj.convert(ar2);
+    EXPECT_EQ(ar1, ar2);
+}
+
+TEST(MSGPACK_ARRAY_REF, object_with_zone_array_unsigned_char)
+{
+    std::array<unsigned char, 3> v { { 'a', 'b', 'c' } };
+
+    msgpack::type::array_ref<std::array<unsigned char, 3> > ar1 = msgpack::type::make_array_ref(v);
+    msgpack::zone z;
+    msgpack::object obj(ar1, z);
+
+    EXPECT_EQ(obj.type, msgpack::type::ARRAY);
+    std::array<unsigned char, 3> v2;
+    msgpack::type::array_ref<std::array<unsigned char, 3> > ar2(v2);
+    obj.convert(ar2);
+    EXPECT_EQ(ar1, ar2);
+}
+
+TEST(MSGPACK_ARRAY_REF, object_with_zone_array_unsigned_char_const)
+{
+    std::array<unsigned char, 3> v { { 'a', 'b', 'c' } };
+
+    std::array<unsigned char, 3> const& cv = v;
+
+    msgpack::type::array_ref<std::array<unsigned char, 3> const> ar1 = msgpack::type::make_array_ref(cv);
+    msgpack::zone z;
+    msgpack::object obj(ar1, z);
+
+    EXPECT_EQ(obj.type, msgpack::type::ARRAY);
+    std::array<unsigned char, 3> v2;
+    msgpack::type::array_ref<std::array<unsigned char, 3> > ar2(v2);
+    obj.convert(ar2);
+    EXPECT_EQ(ar1, ar2);
+}
+
+#endif // !defined(MSGPACK_USE_CPP03)

--- a/test/msgpack_container.cpp
+++ b/test/msgpack_container.cpp
@@ -72,6 +72,43 @@ TEST(MSGPACK_STL, simple_buffer_vector_char)
     }
 }
 
+TEST(MSGPACK_STL, simple_buffer_vector_unsigned_char)
+{
+    typedef vector<unsigned char, test::allocator<unsigned char> > type;
+    for (unsigned int k = 0; k < kLoop; k++) {
+        type val1;
+        for (unsigned int i = 0; i < kElements; i++)
+            val1.push_back(rand());
+        msgpack::sbuffer sbuf;
+        msgpack::pack(sbuf, val1);
+        msgpack::unpacked ret;
+        msgpack::unpack(ret, sbuf.data(), sbuf.size());
+        EXPECT_EQ(ret.get().type, msgpack::type::BIN);
+        type const& val2 = ret.get().as<type>();
+        EXPECT_EQ(val1.size(), val2.size());
+        EXPECT_TRUE(equal(val1.begin(), val1.end(), val2.begin()));
+    }
+}
+
+TEST(MSGPACK_STL, simple_buffer_vector_uint8_t)
+{
+    if (!msgpack::is_same<uint8_t, unsigned char>::value) return;
+    typedef vector<uint8_t, test::allocator<uint8_t> > type;
+    for (unsigned int k = 0; k < kLoop; k++) {
+        type val1;
+        for (unsigned int i = 0; i < kElements; i++)
+            val1.push_back(rand());
+        msgpack::sbuffer sbuf;
+        msgpack::pack(sbuf, val1);
+        msgpack::unpacked ret;
+        msgpack::unpack(ret, sbuf.data(), sbuf.size());
+        EXPECT_EQ(ret.get().type, msgpack::type::BIN);
+        type const& val2 = ret.get().as<type>();
+        EXPECT_EQ(val1.size(), val2.size());
+        EXPECT_TRUE(equal(val1.begin(), val1.end(), val2.begin()));
+    }
+}
+
 TEST(MSGPACK_STL, simple_buffer_vector_bool)
 {
     typedef vector<bool, test::allocator<bool> > type;

--- a/test/msgpack_cpp11.cpp
+++ b/test/msgpack_cpp11.cpp
@@ -93,6 +93,24 @@ TEST(MSGPACK_CPP11, simple_buffer_array_char)
     }
 }
 
+TEST(MSGPACK_CPP11, simple_buffer_array_unsigned_char)
+{
+    if (!msgpack::is_same<uint8_t, unsigned char>::value) return;
+    for (unsigned int k = 0; k < kLoop; k++) {
+        array<unsigned char, kElements> val1;
+        for (unsigned int i = 0; i < kElements; i++)
+            val1[i] = rand();
+        msgpack::sbuffer sbuf;
+        msgpack::pack(sbuf, val1);
+        msgpack::unpacked ret;
+        msgpack::unpack(ret, sbuf.data(), sbuf.size());
+        EXPECT_EQ(ret.get().type, msgpack::type::BIN);
+        array<unsigned char, kElements> val2 = ret.get().as<array<unsigned char, kElements> >();
+        EXPECT_EQ(val1.size(), val2.size());
+        EXPECT_TRUE(equal(val1.begin(), val1.end(), val2.begin()));
+    }
+}
+
 // strong typedefs
 namespace test {
 

--- a/test/object_with_zone.cpp
+++ b/test/object_with_zone.cpp
@@ -240,6 +240,39 @@ TEST(object_without_zone, vector_char)
     }
 }
 
+// vector_unsgined_char
+TEST(object_with_zone, vector_unsigned_char)
+{
+    if (!msgpack::is_same<uint8_t, unsigned char>::value) return;
+    for (unsigned int k = 0; k < kLoop; k++) {
+        vector<unsigned char> v1;
+        v1.push_back(1);
+        for (unsigned int i = 1; i < kElements; i++)
+            v1.push_back(static_cast<unsigned char>(i));
+        msgpack::zone z;
+        msgpack::object obj(v1, z);
+        EXPECT_EQ(obj.as<vector<unsigned char> >(), v1);
+        v1.front() = 42;
+        EXPECT_EQ(obj.as<vector<unsigned char> >().front(), 1);
+    }
+}
+
+TEST(object_without_zone, vector_unsigned_char)
+{
+    if (!msgpack::is_same<uint8_t, unsigned char>::value) return;
+    for (unsigned int k = 0; k < kLoop; k++) {
+        vector<unsigned char> v1;
+        v1.push_back(1);
+        for (unsigned int i = 1; i < kElements; i++)
+            v1.push_back(static_cast<unsigned char>(i));
+        msgpack::object obj(v1);
+        EXPECT_EQ(obj.as<vector<unsigned char> >(), v1);
+        v1.front() = 42;
+        // obj refer to v1
+        EXPECT_EQ(obj.as<vector<unsigned char> >().front(), 42);
+    }
+}
+
 // list
 TEST(object_with_zone, list)
 {
@@ -817,6 +850,40 @@ TEST(object_with_zone, array_char)
 TEST(object_without_zone, array_char)
 {
     typedef array<char, kElements> test_t;
+    for (unsigned int k = 0; k < kLoop; k++) {
+        test_t v1;
+        v1[0] = 1;
+        for (unsigned int i = 1; i < kElements; i++)
+            v1[i] = rand();
+        msgpack::object obj(v1);
+        EXPECT_EQ(obj.as<test_t>(), v1);
+        v1.front() = 42;
+        // obj refer to v1
+        EXPECT_EQ(obj.as<test_t>().front(), 42);
+    }
+}
+
+TEST(object_with_zone, array_unsigned_char)
+{
+    if (!msgpack::is_same<uint8_t, unsigned char>::value) return;
+    typedef array<unsigned char, kElements> test_t;
+    for (unsigned int k = 0; k < kLoop; k++) {
+        test_t v1;
+        v1[0] = 1;
+        for (unsigned int i = 1; i < kElements; i++)
+            v1[i] = rand();
+        msgpack::zone z;
+        msgpack::object obj(v1, z);
+        EXPECT_EQ(obj.as<test_t>(), v1);
+        v1.front() = 42;
+        EXPECT_EQ(obj.as<test_t>().front(), 1);
+    }
+}
+
+TEST(object_without_zone, array_unsigned_char)
+{
+    if (!msgpack::is_same<uint8_t, unsigned char>::value) return;
+    typedef array<unsigned char, kElements> test_t;
     for (unsigned int k = 0; k < kLoop; k++) {
         test_t v1;
         v1[0] = 1;


### PR DESCRIPTION
std::vector<unsigned char> and std::array<unsigned char> are mapped to BIN.
std::vector<uint8_t> and std::array<uint8_t> are mapped to BIN if uint8_t is the same type of unsigned char, otherwise mapped to ARRAY.

Added array_ref. When client wraps BIN mapped types above with array_ref as msgpack::type::array_ref<std::vector<char> >, the type is mapped to ARRAY.