### PR TITLE
Fix compatibility with -Wshadow and ObjC++

### DIFF
--- a/include/msgpack/adaptor/boost/msgpack_variant.hpp
+++ b/include/msgpack/adaptor/boost/msgpack_variant.hpp
@@ -51,7 +51,7 @@ namespace type {
 template <typename STR, typename BIN, typename EXT>
 struct basic_variant :
     boost::variant<
-        nil,               // NIL
+        nil_t,             // NIL
         bool,              // BOOL
         int64_t,           // NEGATIVE_INTEGER
         uint64_t,          // POSITIVE_INTEGER
@@ -70,7 +70,7 @@ struct basic_variant :
     >,
     private boost::totally_ordered<basic_variant<STR, BIN, EXT> > {
     typedef boost::variant<
-        nil,               // NIL
+        nil_t,             // NIL
         bool,              // BOOL
         int64_t,           // NEGATIVE_INTEGER
         uint64_t,          // POSITIVE_INTEGER
@@ -112,7 +112,7 @@ struct basic_variant :
     basic_variant(unsigned long long v):base(uint64_t(v)) {}
 
     bool is_nil() const {
-        return boost::get<nil>(this);
+        return boost::get<nil_t>(this);
     }
     bool is_bool() const {
         return boost::get<bool>(this);
@@ -276,7 +276,7 @@ struct as<msgpack::type::basic_variant<STR, BIN, EXT> > {
     msgpack::type::basic_variant<STR, BIN, EXT> operator()(msgpack::object const& o) const {
         switch(o.type) {
         case type::NIL:
-            return o.as<msgpack::type::nil>();
+            return o.as<msgpack::type::nil_t>();
         case type::BOOLEAN:
             return o.as<bool>();
         case type::POSITIVE_INTEGER:
@@ -312,7 +312,7 @@ struct convert<msgpack::type::basic_variant<STR, BIN, EXT> > {
         msgpack::type::basic_variant<STR, BIN, EXT>& v) const {
         switch(o.type) {
         case type::NIL:
-            v = o.as<msgpack::type::nil>();
+            v = o.as<msgpack::type::nil_t>();
             break;
         case type::BOOLEAN:
             v = o.as<bool>();
@@ -374,8 +374,8 @@ struct pack<msgpack::type::basic_variant<STR, BIN, EXT> > {
 namespace detail {
 
 struct object_imp : boost::static_visitor<void> {
-    void operator()(msgpack::type::nil const& v) const {
-        object<msgpack::type::nil>()(o_, v);
+    void operator()(msgpack::type::nil_t const& v) const {
+        object<msgpack::type::nil_t>()(o_, v);
     }
     void operator()(bool const& v) const {
         object<bool>()(o_, v);

--- a/include/msgpack/adaptor/fixint.hpp
+++ b/include/msgpack/adaptor/fixint.hpp
@@ -34,7 +34,7 @@ namespace type {
 template <typename T>
 struct fix_int {
     fix_int() : value(0) { }
-    fix_int(T value) : value(value) { }
+    fix_int(T v) : value(v) { }
 
     operator T() const { return value; }
 

--- a/include/msgpack/adaptor/nil.hpp
+++ b/include/msgpack/adaptor/nil.hpp
@@ -29,13 +29,13 @@ MSGPACK_API_VERSION_NAMESPACE(v1) {
 
 namespace type {
 
-struct nil { };
+struct nil_t { };
 
-inline bool operator<(nil const& lhs, nil const& rhs) {
+inline bool operator<(nil_t const& lhs, nil_t const& rhs) {
     return &lhs < &rhs;
 }
 
-inline bool operator==(nil const& lhs, nil const& rhs) {
+inline bool operator==(nil_t const& lhs, nil_t const& rhs) {
     return &lhs == &rhs;
 }
 
@@ -44,32 +44,32 @@ inline bool operator==(nil const& lhs, nil const& rhs) {
 namespace adaptor {
 
 template <>
-struct convert<type::nil> {
-    msgpack::object const& operator()(msgpack::object const& o, type::nil&) const {
+struct convert<type::nil_t> {
+    msgpack::object const& operator()(msgpack::object const& o, type::nil_t&) const {
         if(o.type != msgpack::type::NIL) { throw msgpack::type_error(); }
         return o;
     }
 };
 
 template <>
-struct pack<type::nil> {
+struct pack<type::nil_t> {
     template <typename Stream>
-    msgpack::packer<Stream>& operator()(msgpack::packer<Stream>& o, const type::nil&) const {
+    msgpack::packer<Stream>& operator()(msgpack::packer<Stream>& o, const type::nil_t&) const {
         o.pack_nil();
         return o;
     }
 };
 
 template <>
-struct object<type::nil> {
-    void operator()(msgpack::object& o, type::nil) const {
+struct object<type::nil_t> {
+    void operator()(msgpack::object& o, type::nil_t) const {
         o.type = msgpack::type::NIL;
     }
 };
 
 template <>
-struct object_with_zone<type::nil> {
-    void operator()(msgpack::object::with_zone& o, type::nil v) const {
+struct object_with_zone<type::nil_t> {
+    void operator()(msgpack::object::with_zone& o, type::nil_t v) const {
         static_cast<msgpack::object&>(o) << v;
     }
 };
@@ -79,7 +79,7 @@ struct object_with_zone<type::nil> {
 template <>
 inline void msgpack::object::as<void>() const
 {
-    msgpack::type::nil v;
+    msgpack::type::nil_t v;
     convert(v);
 }
 

--- a/include/msgpack/object_fwd.hpp
+++ b/include/msgpack/object_fwd.hpp
@@ -188,7 +188,7 @@ struct object_kv {
 };
 
 struct object::with_zone : object {
-    with_zone(msgpack::zone& zone) : zone(zone) { }
+    with_zone(msgpack::zone& z) : zone(z) { }
     msgpack::zone& zone;
 private:
     with_zone();


### PR DESCRIPTION
Hi, we have a project that uses ObjC++ and `msgpack-c`. Therefore, we can't use nil as the name of a type since it's a preprocessor macro in ObjC that resolves to `0`. This PR changes the name to `nil_t` for compatibility and hopefully adds a new audience for msgpack-c.

Additionally, we compile with `-Wshadow` in clang, which doesn't like 

    with_zone(msgpack::zone& zone) : zone(zone) { }

What do you think? I'm happy to split into two PRs if that would be better for you.

Thanks!