### PR TITLE
Fix build on GCC 5.2 / Arch Linux (by declaring things more specifically)

### DIFF
--- a/include/msgpack/adaptor/ext.hpp
+++ b/include/msgpack/adaptor/ext.hpp
@@ -20,6 +20,7 @@
 
 #include "msgpack/versioning.hpp"
 #include "msgpack/adaptor/adaptor_base.hpp"
+#include "msgpack/adaptor/check_container_size.hpp"
 #include <cstring>
 #include <string>
 #include <cassert>
@@ -37,13 +38,13 @@ class ext {
 public:
     ext() : m_data(1, 0) {}
     ext(int8_t t, const char* p, uint32_t s) {
-        detail::check_container_size_for_ext<sizeof(std::size_t)>(s);
+        ::msgpack::detail::check_container_size_for_ext<sizeof(std::size_t)>(s);
         m_data.reserve(static_cast<std::size_t>(s) + 1);
         m_data.push_back(static_cast<char>(t));
         m_data.insert(m_data.end(), p, p + s);
     }
     ext(int8_t t, uint32_t s) {
-        detail::check_container_size_for_ext<sizeof(std::size_t)>(s);
+        ::msgpack::detail::check_container_size_for_ext<sizeof(std::size_t)>(s);
         m_data.resize(static_cast<std::size_t>(s) + 1);
         m_data[0] = static_cast<char>(t);
     }
@@ -136,7 +137,7 @@ public:
     ext_ref(const char* p, uint32_t s) :
         m_ptr(s == 0 ? static_cast<char*>(static_cast<void*>(&m_size)) : p),
         m_size(s == 0 ? 0 : s - 1) {
-        detail::check_container_size_for_ext<sizeof(std::size_t)>(s);
+        ::msgpack::detail::check_container_size_for_ext<sizeof(std::size_t)>(s);
     }
 
     // size limit has aleady been checked at ext's constructor

--- a/include/msgpack/adaptor/string.hpp
+++ b/include/msgpack/adaptor/string.hpp
@@ -22,6 +22,7 @@
 #include "msgpack/adaptor/adaptor_base.hpp"
 #include "msgpack/adaptor/check_container_size.hpp"
 
+#include <cstring> // for memcpy()
 #include <string>
 
 namespace msgpack {


### PR DESCRIPTION
I'm not sure under which circumstances the build compiles, but I stumbled into a number of build issues. I would have to check which ones are caused by GCC 5.2 on Arch being stricter than my previous build environment and which ones result from me newly using msgpack::variant (including `ext`) but either way, these fixes made the build work for me.