### PR TITLE
Support to-object conversions for std::reference_wrapper<const T>.

### DIFF
--- a/include/msgpack/adaptor/cpp11/reference_wrapper.hpp
+++ b/include/msgpack/adaptor/cpp11/reference_wrapper.hpp
@@ -24,6 +24,7 @@
 #include "msgpack/adaptor/check_container_size.hpp"
 
 #include <memory>
+#include <type_traits>
 
 namespace msgpack {
 
@@ -53,14 +54,14 @@ struct pack<std::reference_wrapper<T>> {
 template <typename T>
 struct object<std::reference_wrapper<T> > {
     void operator()(msgpack::object& o, const std::reference_wrapper<T>& v) const {
-        msgpack::adaptor::object<T>()(o, v.get());
+        msgpack::adaptor::object<typename std::remove_const<T>::type>()(o, v.get());
     }
 };
 
 template <typename T>
 struct object_with_zone<std::reference_wrapper<T>> {
     void operator()(msgpack::object::with_zone& o, const std::reference_wrapper<T>& v) const {
-        msgpack::adaptor::object_with_zone<T>()(o, v.get());
+        msgpack::adaptor::object_with_zone<typename std::remove_const<T>::type>()(o, v.get());
     }
 };
 

--- a/test/reference_wrapper_cpp11.cpp
+++ b/test/reference_wrapper_cpp11.cpp
@@ -17,7 +17,20 @@ TEST(MSGPACK_REFERENCE_WRAPPER, pack_convert)
     msgpack::object_handle oh = msgpack::unpack(ss.str().data(), ss.str().size());
     int i2 = 0;
     std::reference_wrapper<int> val2(i2);
-    oh.get().convert(val2);;
+    oh.get().convert(val2);
+    EXPECT_EQ(i1, i2);
+}
+
+TEST(MSGPACK_REFERENCE_WRAPPER, pack_convert_const)
+{
+    const int i1 = 42;
+    std::reference_wrapper<const int> val1(i1);
+    std::stringstream ss;
+    msgpack::pack(ss, val1);
+    msgpack::object_handle oh = msgpack::unpack(ss.str().data(), ss.str().size());
+    int i2 = 0;
+    std::reference_wrapper<int> val2(i2);
+    oh.get().convert(val2);
     EXPECT_EQ(i1, i2);
 }
 
@@ -44,10 +57,33 @@ TEST(MSGPACK_REFERENCE_WRAPPER, object)
     EXPECT_EQ(i1, i2);
 }
 
+TEST(MSGPACK_REFERENCE_WRAPPER, object_const)
+{
+    const int i1 = 42;
+    std::reference_wrapper<const int> val1(i1);
+    msgpack::object o(val1);
+    int i2 = 0;
+    std::reference_wrapper<int> val2(i2);
+    o.convert(val2);
+    EXPECT_EQ(i1, i2);
+}
+
 TEST(MSGPACK_REFERENCE_WRAPPER, object_with_zone)
 {
     std::string s1 = "ABC";
     std::reference_wrapper<std::string> val1(s1);
+    msgpack::zone z;
+    msgpack::object o(val1, z);
+    std::string s2 = "DE";
+    std::reference_wrapper<std::string> val2(s2);
+    o.convert(val2);
+    EXPECT_EQ(s1, s2);
+}
+
+TEST(MSGPACK_REFERENCE_WRAPPER, object_with_zone_const)
+{
+    const std::string s1 = "ABC";
+    std::reference_wrapper<const std::string> val1(s1);
     msgpack::zone z;
     msgpack::object o(val1, z);
     std::string s2 = "DE";


### PR DESCRIPTION
Previously the conversion would fail because struct object is not
generally provided for the const version of the type, but because
the wrapper would pass down the type unchanged, it would look for
exactly that missing template specialization unsuccessfully.

This is specifically an issue for std::reference_wrapper because
std::cref() returns an std::refererence_wrapper<const T>.

I haven't got GTest set up on my system, hopefully the buildbot runs the tests. If not, please run manually.

Note: convert<>() passes through the same template but it makes little sense to convert from object to const variable, because the variable is const. So I left that part unchanged.