### PR TITLE
Update install instructions and QUICKSTART-C.md

### DIFF
--- a/QUICKSTART-C.md
+++ b/QUICKSTART-C.md
@@ -119,7 +119,7 @@ int main(void) {
         /* creates buffer and serializer instance. */
         msgpack_sbuffer* buffer = msgpack_sbuffer_new();
         msgpack_packer* pk = msgpack_packer_new(buffer, msgpack_sbuffer_write);
-        
+
         int j;
 
         for(j = 0; j<23; j++) {

--- a/QUICKSTART-C.md
+++ b/QUICKSTART-C.md
@@ -88,10 +88,10 @@ int main(void) {
 
         /* serializes ["Hello", "MessagePack"]. */
         msgpack_pack_array(pk, 2);
-        msgpack_pack_raw(pk, 5);
-        msgpack_pack_raw_body(pk, "Hello", 5);
-        msgpack_pack_raw(pk, 11);
-        msgpack_pack_raw_body(pk, "MessagePack", 11);
+        msgpack_pack_bin(pk, 5);
+        msgpack_pack_bin_body(pk, "Hello", 5);
+        msgpack_pack_bin(pk, 11);
+        msgpack_pack_bin_body(pk, "MessagePack", 11);
 
         /* deserializes it. */
         msgpack_unpacked msg;
@@ -128,10 +128,10 @@ int main(void) {
 
            /* serializes ["Hello", "MessagePack"]. */
            msgpack_pack_array(pk, 3);
-           msgpack_pack_raw(pk, 5);
-           msgpack_pack_raw_body(pk, "Hello", 5);
-           msgpack_pack_raw(pk, 11);
-           msgpack_pack_raw_body(pk, "MessagePack", 11);
+           msgpack_pack_bin(pk, 5);
+           msgpack_pack_bin_body(pk, "Hello", 5);
+           msgpack_pack_bin(pk, 11);
+           msgpack_pack_bin_body(pk, "MessagePack", 11);
            msgpack_pack_int(pk, j);
 
            /* deserializes it. */

--- a/QUICKSTART-C.md
+++ b/QUICKSTART-C.md
@@ -36,9 +36,9 @@ On Gentoo Linux, you can use emerge. Install [dev-libs/msgpack|http://gentoo-por
 On the other UNIX-like platforms, download source package from [Releases|http://msgpack.org/releases/cpp/] and run `./configure && make && make install`.
 
 ```
-$ wget http://msgpack.org/releases/cpp/msgpack-0.5.5.tar.gz
-$ tar zxvf msgpack-0.5.5.tar.gz
-$ cd msgpack-0.5.5
+$ wget http://msgpack.org/releases/cpp/msgpack-1.3.0.tar.gz
+$ tar zxvf msgpack-1.3.0.tar.gz
+$ cd msgpack-1.3.0
 $ ./configure
 $ make
 $ sudo make install


### PR DESCRIPTION
The QUICKSTART-C.md has install instructions for older msgpack and the
documentation for the same. This can get confusing for users who skip the
version specified in this document—indirectly set to 0.5.5—which is easy to do
so, especially when msgpack is installed using Homebrew.

Am I correct to think that the documentation for 1.x releases is being tracked
on branches related to those versions? If yes, I'll open this PR against 1.1 or
1.2 branches.