### PR TITLE
Fix compile error with -Werror=type-limits on ARM

### DIFF
--- a/include/msgpack/adaptor/int.hpp
+++ b/include/msgpack/adaptor/int.hpp
@@ -70,13 +70,17 @@ namespace detail {
     template <>
     struct object_char_sign<true> {
         static inline void make(msgpack::object& o, char v) {
-            if (v < 0) {
+            // Since 'char' is unsigned on ARM, the condition 'v < 0'
+            // triggers an error if '-Werror=type-limits' is used:
+            //   comparison is always false due to limited range of data type
+            int i = v;
+            if (i < 0) {
                 o.type = msgpack::type::NEGATIVE_INTEGER;
-                o.via.i64 = v;
+                o.via.i64 = i;
             }
             else {
                 o.type = msgpack::type::POSITIVE_INTEGER;
-                o.via.u64 = v;
+                o.via.u64 = i;
             }
         }
     };


### PR DESCRIPTION
Hello,

I hit on a build failure on armv7hl, when updating msgpack package in Fedora:

```
../include/msgpack/adaptor/int.hpp:73:19: error: comparison is always false due to limited range of data type [-Werror=type-limits]
```
https://kojipkgs.fedoraproject.org//work/tasks/4169/12144169/build.log

This is because there is no signed char type in ARM.  For the meantime, I added a work around by casting v to int, but I guess there would be a better fix.