### PR TITLE
Fixed an incompatible type warning

### DIFF
--- a/include/msgpack/fbuffer.h
+++ b/include/msgpack/fbuffer.h
@@ -23,7 +23,7 @@ extern "C" {
  * @{
  */
 
-static inline int msgpack_fbuffer_write(void* data, const char* buf, unsigned int len)
+static inline int msgpack_fbuffer_write(void* data, const char* buf, size_t len)
 {
     return (1 == fwrite(buf, len, 1, (FILE *)data)) ? 0 : -1;
 }


### PR DESCRIPTION
I have fixed a following warning of `msgpack_fbuffer_write()`.

```
warning: incompatible pointer types passing 'int (void *, const char *, unsigned int)' to parameter of type 'msgpack_packer_write' (aka 'int (*)(void *, const char *, size_t)') [-Wincompatible-pointer-types]
        msgpack_packer* pk = msgpack_packer_new(fp, msgpack_fbuffer_write);
                                                    ^~~~~~~~~~~~~~~~~~~~~
/usr/local/Cellar/msgpack/1.3.0/include/msgpack/pack.h:129:76: note: passing argument to parameter 'callback' here
inline msgpack_packer* msgpack_packer_new(void* data, msgpack_packer_write callback)
```