### PR TITLE
Fixed #395

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,13 +125,13 @@ int main(int argc, char * argv[])
 " MSGPACK_ENABLE_GCC_CXX_ATOMIC)
 
 IF (MSGPACK_ENABLE_GCC_CXX_ATOMIC)
-    LIST (APPEND msgpack_SOURCES
+    LIST (APPEND msgpackc_SOURCES
         src/gcc_atomic.cpp
     )
 ENDIF ()
 
 
-LIST (APPEND msgpack_SOURCES
+LIST (APPEND msgpackc_SOURCES
     src/unpack.c
     src/objectc.c
     src/version.c
@@ -139,7 +139,7 @@ LIST (APPEND msgpack_SOURCES
     src/zone.c
 )
 
-LIST (APPEND msgpack_HEADERS
+LIST (APPEND msgpackc_HEADERS
     include/msgpack/pack_define.h
     include/msgpack/pack_template.h
     include/msgpack/unpack_define.h
@@ -162,8 +162,8 @@ LIST (APPEND msgpack_HEADERS
 
 FILE (GLOB_RECURSE PREDEF_FILES RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/include/msgpack/predef/*.h)
 
-LIST (APPEND msgpack_HEADERS ${PREDEF_FILES})
-LIST (APPEND msgpack_HEADERS include/msgpack/predef.h)
+LIST (APPEND msgpackc_HEADERS ${PREDEF_FILES})
+LIST (APPEND msgpackc_HEADERS include/msgpack/predef.h)
 
 IF (MSGPACK_ENABLE_CXX)
     LIST (APPEND msgpack_HEADERS
@@ -234,8 +234,8 @@ IF (MSGPACK_ENABLE_CXX)
     )
     FILE (GLOB_RECURSE PREPROCESSOR_FILES RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/include/msgpack/preprocessor/*.hpp)
 
-    LIST (APPEND msgpack_HEADERS ${PREPROCESSOR_FILES})
-    LIST (APPEND msgpack_HEADERS include/msgpack/preprocessor.hpp)
+    LIST (APPEND msgpackc_HEADERS ${PREPROCESSOR_FILES})
+    LIST (APPEND msgpackc_HEADERS include/msgpack/preprocessor.hpp)
 ENDIF ()
 
 EXECUTE_PROCESS (
@@ -255,21 +255,21 @@ INCLUDE_DIRECTORIES (
 )
 
 IF (MSGPACK_ENABLE_SHARED)
-    ADD_LIBRARY (msgpack SHARED
-        ${msgpack_SOURCES}
-        ${msgpack_HEADERS}
+    ADD_LIBRARY (msgpackc SHARED
+        ${msgpackc_SOURCES}
+        ${msgpackc_HEADERS}
     )
 ENDIF ()
 
-ADD_LIBRARY (msgpack-static STATIC
-    ${msgpack_SOURCES}
-    ${msgpack_HEADERS}
+ADD_LIBRARY (msgpackc-static STATIC
+    ${msgpackc_SOURCES}
+    ${msgpackc_HEADERS}
 )
 
-SET_TARGET_PROPERTIES (msgpack-static PROPERTIES OUTPUT_NAME "msgpack")
+SET_TARGET_PROPERTIES (msgpackc-static PROPERTIES OUTPUT_NAME "msgpackc")
 IF (MSGPACK_ENABLE_SHARED)
-    SET_TARGET_PROPERTIES (msgpack PROPERTIES IMPORT_SUFFIX "_import.lib")
-    SET_TARGET_PROPERTIES (msgpack PROPERTIES SOVERSION 4 VERSION 4.0.0)
+    SET_TARGET_PROPERTIES (msgpackc PROPERTIES IMPORT_SUFFIX "_import.lib")
+    SET_TARGET_PROPERTIES (msgpackc PROPERTIES SOVERSION 2 VERSION 2.0.0)
 ENDIF ()
 
 IF (MSGPACK_BUILD_TESTS)
@@ -283,9 +283,9 @@ ENDIF ()
 
 IF ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
     IF (MSGPACK_ENABLE_SHARED)
-        SET_PROPERTY (TARGET msgpack APPEND_STRING PROPERTY COMPILE_FLAGS "-Wall -Wextra -Wno-mismatched-tags -Werror -g -O3 -DPIC")
+        SET_PROPERTY (TARGET msgpackc APPEND_STRING PROPERTY COMPILE_FLAGS "-Wall -Wextra -Wno-mismatched-tags -Werror -g -O3 -DPIC")
     ENDIF ()
-    SET_PROPERTY (TARGET msgpack-static APPEND_STRING PROPERTY COMPILE_FLAGS "-Wall -Wextra -Wno-mismatched-tags -Werror -g -O3" )
+    SET_PROPERTY (TARGET msgpackc-static APPEND_STRING PROPERTY COMPILE_FLAGS "-Wall -Wextra -Wno-mismatched-tags -Werror -g -O3" )
 ENDIF ()
 IF ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
     IF (CMAKE_CXX_FLAGS MATCHES "/W[0-4]")
@@ -296,7 +296,7 @@ IF ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
 ENDIF ()
 
 IF ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC90" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC10")
-    SET_SOURCE_FILES_PROPERTIES(${msgpack_SOURCES} PROPERTIES LANGUAGE CXX)
+    SET_SOURCE_FILES_PROPERTIES(${msgpackc_SOURCES} PROPERTIES LANGUAGE CXX)
 ENDIF()
 
 IF (NOT DEFINED CMAKE_INSTALL_LIBDIR)
@@ -308,9 +308,9 @@ IF (MSGPACK_BUILD_EXAMPLES)
 ENDIF ()
 
 IF (MSGPACK_ENABLE_SHARED)
-    SET (MSGPACK_INSTALLTARGETS msgpack msgpack-static)
+    SET (MSGPACK_INSTALLTARGETS msgpackc msgpackc-static)
 ELSE()
-    SET (MSGPACK_INSTALLTARGETS msgpack-static)
+    SET (MSGPACK_INSTALLTARGETS msgpackc-static)
 ENDIF ()
 
 INSTALL (TARGETS ${MSGPACK_INSTALLTARGETS} DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/QUICKSTART-C.md
+++ b/QUICKSTART-C.md
@@ -184,7 +184,7 @@ int main(void) {
         }
 
         /* results:
-         * $ gcc stream.cc -lmsgpack -o stream
+         * $ gcc stream.cc -lmsgpackc -o stream
          * $ ./stream
          * 1
          * 2

--- a/QUICKSTART-CPP.md
+++ b/QUICKSTART-CPP.md
@@ -47,7 +47,7 @@ int main(void) {
 Compile it as follows:
 
 ```
-$ g++ hello.cc -lmsgpack -o hello
+$ g++ hello.cc -o hello
 $ ./hello
 ["Hello", "MessagePack"]
 ```
@@ -83,7 +83,7 @@ int main(void) {
         }
 
         // results:
-        // $ g++ stream.cc -lmsgpack -o stream
+        // $ g++ stream.cc -o stream
         // $ ./stream
         // "Log message ... 1"
         // "Log message ... 2"

--- a/example/c/CMakeLists.txt
+++ b/example/c/CMakeLists.txt
@@ -17,7 +17,7 @@ FOREACH (source_file ${exec_PROGRAMS})
         ${source_file}
     )
     TARGET_LINK_LIBRARIES (${source_file_we}
-        msgpack
+        msgpackc
     )
     IF ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
         SET_PROPERTY (TARGET ${source_file_we} APPEND_STRING PROPERTY COMPILE_FLAGS "-Wall -Wextra -Werror -Wno-mismatched-tags -g -O3")

--- a/msgpack.pc.in
+++ b/msgpack.pc.in
@@ -6,5 +6,5 @@ includedir=@includedir@
 Name: MessagePack
 Description: Binary-based efficient object serialization library
 Version: @VERSION@
-Libs: -L${libdir} -lmsgpack
+Libs: -L${libdir} -lmsgpackc
 Cflags: -I${includedir}

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,25 +1,14 @@
-lib_LTLIBRARIES = libmsgpack.la
+# For C++
+#
+# The C++ parts of msgpack-c is a header only library,
+# so there is no libraries.
 
-AM_CPPFLAGS = -I../include
+# For C
 
-libmsgpack_la_SOURCES = \
-		unpack.c \
-		objectc.c \
-		version.c \
-		vrefbuffer.c \
-		zone.c
+lib_LTLIBRARIES = libmsgpackc.la
 
-if ENABLE_GCC_CXX_ATOMIC
-	CXXFLAGS="$CXXFLAGS -DENABLE_GCC_CXX_ATOMIC"
-endif
-
-
-# -version-info CURRENT:REVISION:AGE
-libmsgpack_la_LDFLAGS = -version-info 4:0:0 -no-undefined
-
-
-# backward compatibility
-lib_LTLIBRARIES += libmsgpackc.la
+#AM_CPPFLAGS = -I../include
+AM_CFLAGS = -I../include
 
 libmsgpackc_la_SOURCES = \
 		unpack.c \
@@ -28,6 +17,7 @@ libmsgpackc_la_SOURCES = \
 		vrefbuffer.c \
 		zone.c
 
+# -version-info CURRENT:REVISION:AGE
 libmsgpackc_la_LDFLAGS = -version-info 2:0:0 -no-undefined
 
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -56,9 +56,9 @@ IF (MSGPACK_CXX11)
 ENDIF ()
 
 IF (MSGPACK_ENABLE_SHARED)
-    SET (MSGPACK_TEST_LIB msgpack)
+    SET (MSGPACK_TEST_LIB msgpackc)
 ELSE ()
-    SET (MSGPACK_TEST_LIB msgpack-static)
+    SET (MSGPACK_TEST_LIB msgpackc-static)
 ENDIF ()
 
 FOREACH (source_file ${check_PROGRAMS})

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -1,6 +1,6 @@
 AM_CPPFLAGS   = -I$(top_srcdir)/include -pthread
 AM_C_CPPFLAGS = -I$(top_srcdir)/include -pthread
-AM_LDFLAGS = $(top_builddir)/src/libmsgpack.la -lgtest_main -lgtest -lpthread
+AM_LDFLAGS = $(top_builddir)/src/libmsgpackc.la -lgtest_main -lgtest -lpthread
 
 check_PROGRAMS = \
 		array_ref \


### PR DESCRIPTION
libmsgpack.[a|so] is the library file for C++.
libmsgpackc.[a|so] is the library file for C.
Since version 1.0.0, the C++ parts of msgpack-c is a header only
library. So libmsgpack.* shouldn't be generated.

On the autotools building environment, removed libmsgpack.*
generation. On the cmake building environment, replaced libmsgpack.*
with libmsgpackc.* and set so-version to 2.0.0.