### PR TITLE
Check whether MSGPACK_ENDIAN_LITTLE_BYTE is true, not defined.

### DIFF
--- a/include/msgpack/sysdep.h
+++ b/include/msgpack/sysdep.h
@@ -78,7 +78,7 @@
 
 #endif
 
-#ifdef MSGPACK_ENDIAN_LITTLE_BYTE
+#if MSGPACK_ENDIAN_LITTLE_BYTE
 
 #   ifdef _WIN32
 #       if defined(ntohs)


### PR DESCRIPTION
msgpack/predef/other/endian.h always defines both
MSGPACK_ENDIAN_LITTLE_BYTE and MSGPACK_ENDIAN_BIG_BYTE, but they're
defined to a true or false value depending on whether the system is
little/big endian.

Fix this condition to check the truthiness rather than whether it is
defined, like the other locations this macro is checked.

Closes #403

Signed-off-by: James McCoy <jamessan@jamessan.com>