### PR TITLE
Fix compilation under OS X together with Core Foundation headers

### DIFF
--- a/include/msgpack/cpp_config.hpp
+++ b/include/msgpack/cpp_config.hpp
@@ -121,4 +121,10 @@ MSGPACK_API_VERSION_NAMESPACE(v1) {
 
 #endif // MSGPACK_USE_CPP03
 
+// Core Foundation headers under OS X define nil as NULL breaking compilation
+// of msgpack/adaptor/nil.hpp and all the headers including it.
+#ifdef nil
+#undef nil
+#endif
+
 #endif /* msgpack/cpp_config.hpp */


### PR DESCRIPTION
/usr/include/MacTypes.h included by many (all?) Core Foundation headers
defines "nil" as "NULL" breaking compilation of msgpack code. Undo this
definition in the header included before all the other ones to allow using
msgpack and Core Foundation together.