### PR TITLE
Fixed existing code compile error problem.

### DIFF
--- a/include/msgpack/adaptor/nil.hpp
+++ b/include/msgpack/adaptor/nil.hpp
@@ -23,11 +23,11 @@ namespace type {
 
 struct nil_t { };
 
-#if defined(MSGPACK_USE_LEGACY_NIL)
+#if !defined(MSGPACK_DISABLE_LEGACY_NIL)
 
 typedef nil_t nil;
 
-#endif // defined(MSGPACK_USE_LEGACY_NIL)
+#endif // !defined(MSGPACK_DISABLE_LEGACY_NIL)
 
 inline bool operator<(nil_t const& lhs, nil_t const& rhs) {
     return &lhs < &rhs;


### PR DESCRIPTION
Changed macro name from MSGPACK_USE_LEGACY_NIL to
MSGPACK_DISABLE_LEGACY_NIL. msgpack-c shouldn't make compile error on
existing codes by default without major version up.
So if you want to disable msgpack::type::nil, you need to define
MSGPACK_DISABLE_LEGACY_NIL macro.