### PR TITLE
Add signed flags to MSVC integer definitions

### DIFF
--- a/include/msgpack/sysdep.h
+++ b/include/msgpack/sysdep.h
@@ -15,13 +15,13 @@
 #include <stdlib.h>
 #include <stddef.h>
 #if defined(_MSC_VER) && _MSC_VER < 1600
-    typedef __int8 int8_t;
+    typedef signed __int8 int8_t;
     typedef unsigned __int8 uint8_t;
-    typedef __int16 int16_t;
+    typedef signed __int16 int16_t;
     typedef unsigned __int16 uint16_t;
-    typedef __int32 int32_t;
+    typedef signed __int32 int32_t;
     typedef unsigned __int32 uint32_t;
-    typedef __int64 int64_t;
+    typedef signed __int64 int64_t;
     typedef unsigned __int64 uint64_t;
 #elif defined(_MSC_VER)  // && _MSC_VER >= 1600
 #   include <stdint.h>


### PR DESCRIPTION
This is important because the integer definitions clash with the integer definitions in the rapidjson C++ library, but only at the level of signed/unsigned integers.  We use both libraries in the CoolProp library

