### PR TITLE
Replace stdint.h header in check_container_size_decl.hpp

### DIFF
--- a/include/msgpack/v1/adaptor/check_container_size_decl.hpp
+++ b/include/msgpack/v1/adaptor/check_container_size_decl.hpp
@@ -12,7 +12,7 @@
 
 #include "msgpack/versioning.hpp"
 #include <cstdlib>
-#include <stdint.h>
+#include "msgpack/sysdep.h"
 
 namespace msgpack {
 


### PR DESCRIPTION
``#include <stdint.h>`` is invalid in MSVC 9 2008 .  Using the system dependent header does work in my testing with MSVC9, and should be safe for other compilers I think.