### PR TITLE
Fixed #422.

### DIFF
--- a/include/msgpack/v1/adaptor/detail/cpp11_msgpack_tuple.hpp
+++ b/include/msgpack/v1/adaptor/detail/cpp11_msgpack_tuple.hpp
@@ -21,78 +21,29 @@ MSGPACK_API_VERSION_NAMESPACE(v1) {
 /// @endcond
 
 namespace type {
-    // tuple
-    using std::get;
-    using std::tuple_size;
-    using std::tuple_element;
-    using std::uses_allocator;
-    using std::ignore;
-    using std::swap;
 
-    template< class... Types >
-    class tuple : public std::tuple<Types...> {
-    public:
-        using base = std::tuple<Types...>;
+template <class... Args>
+inline tuple<Args...> make_tuple(Args&&... args) {
+    return tuple<Args...>(std::forward<Args>(args)...);
+}
 
-        using base::base;
+template<class... Args>
+inline tuple<Args&&...> forward_as_tuple (Args&&... args) noexcept {
+    return tuple<Args&&...>(std::forward<Args>(args)...);
+}
 
-        tuple() = default;
-        tuple(tuple const&) = default;
-        tuple(tuple&&) = default;
+template <class... Tuples>
+inline auto tuple_cat(Tuples&&... args) ->
+    decltype(
+        std::tuple_cat(std::forward<typename std::remove_reference<Tuples>::type::base>(args)...)
+    ) {
+    return std::tuple_cat(std::forward<typename std::remove_reference<Tuples>::type::base>(args)...);
+}
 
-        template<typename... OtherTypes>
-        tuple(tuple<OtherTypes...> const& other):base(static_cast<std::tuple<OtherTypes...> const&>(other)) {}
-        template<typename... OtherTypes>
-        tuple(tuple<OtherTypes...> && other):base(static_cast<std::tuple<OtherTypes...> &&>(other)) {}
-
-        tuple& operator=(tuple const&) = default;
-        tuple& operator=(tuple&&) = default;
-
-        template<typename... OtherTypes>
-        tuple& operator=(tuple<OtherTypes...> const& other) {
-            *static_cast<base*>(this) = static_cast<std::tuple<OtherTypes...> const&>(other);
-            return *this;
-        }
-        template<typename... OtherTypes>
-        tuple& operator=(tuple<OtherTypes...> && other) {
-            *static_cast<base*>(this) = static_cast<std::tuple<OtherTypes...> &&>(other);
-            return *this;
-        }
-
-        template< std::size_t I>
-        typename tuple_element<I, base >::type&
-        get() & { return std::get<I>(*this); }
-
-        template< std::size_t I>
-        typename tuple_element<I, base >::type const&
-        get() const& { return std::get<I>(*this); }
-
-        template< std::size_t I>
-        typename tuple_element<I, base >::type&&
-        get() && { return std::get<I>(*this); }
-    };
-
-    template <class... Args>
-    inline tuple<Args...> make_tuple(Args&&... args) {
-        return tuple<Args...>(args...);
-    }
-
-    template<class... Args>
-    inline tuple<Args&&...> forward_as_tuple (Args&&... args) noexcept {
-        return tuple<Args&&...>(std::forward<Args>(args)...);
-    }
-
-    template <class... Tuples>
-    inline auto tuple_cat(Tuples&&... args) ->
-        decltype(
-            std::tuple_cat(std::forward<typename std::remove_reference<Tuples>::type::base>(args)...)
-        ) {
-        return std::tuple_cat(std::forward<typename std::remove_reference<Tuples>::type::base>(args)...);
-    }
-    template <class... Args>
-    inline tuple<Args&...> tie(Args&... args) {
-        return tuple<Args&...>(args...);
-    }
+template <class... Args>
+inline tuple<Args&...> tie(Args&... args) {
+    return tuple<Args&...>(args...);
+}
 } // namespace type
 
 // --- Pack from tuple to packer stream ---

--- a/include/msgpack/v1/adaptor/detail/cpp11_msgpack_tuple_decl.hpp
+++ b/include/msgpack/v1/adaptor/detail/cpp11_msgpack_tuple_decl.hpp
@@ -32,7 +32,45 @@ namespace type {
     using std::swap;
 
     template< class... Types >
-    class tuple;
+    class tuple : public std::tuple<Types...> {
+    public:
+        using base = std::tuple<Types...>;
+
+        tuple(tuple const&) = default;
+        tuple(tuple&&) = default;
+
+        template<typename... OtherTypes>
+        tuple(OtherTypes&&... other):base(std::forward<OtherTypes>(other)...) {}
+
+        template<typename... OtherTypes>
+        tuple(tuple<OtherTypes...> && other):base(static_cast<std::tuple<OtherTypes...>>(other)) {}
+
+        tuple& operator=(tuple const&) = default;
+        tuple& operator=(tuple&&) = default;
+
+        template<typename... OtherTypes>
+        tuple& operator=(tuple<OtherTypes...> const& other) {
+            *static_cast<base*>(this) = static_cast<std::tuple<OtherTypes...> const&>(other);
+            return *this;
+        }
+        template<typename... OtherTypes>
+        tuple& operator=(tuple<OtherTypes...> && other) {
+            *static_cast<base*>(this) = static_cast<std::tuple<OtherTypes...> &&>(other);
+            return *this;
+        }
+
+        template< std::size_t I>
+        typename tuple_element<I, base >::type&
+        get() & { return std::get<I>(*this); }
+
+        template< std::size_t I>
+        typename tuple_element<I, base >::type const&
+        get() const& { return std::get<I>(*this); }
+
+        template< std::size_t I>
+        typename tuple_element<I, base >::type&&
+        get() && { return std::get<I>(*this); }
+    };
 
     template <class... Args>
     tuple<Args...> make_tuple(Args&&... args);


### PR DESCRIPTION
Replaced the inheriting constructor with a forwarding constructor.
Removed the template constructors that are covered by the forwarding constructor.
Added std::forward() to make_tuple.
Added conversion constructor.

Moved msgpack::type::tuple to
include/msgpack/v1/adaptor/detail/cpp11_msgpack_tuple_decl.hpp from
include/msgpack/v1/adaptor/detail/cpp11_msgpack_tuple.hpp.
msgpack::type::tuple_cat requires the class template tuple definition.