### PR TITLE
Fixed #440.

### DIFF
--- a/erb/v1/cpp03_zone.hpp.erb
+++ b/erb/v1/cpp03_zone.hpp.erb
@@ -113,6 +113,7 @@ class zone {
                     ::free(c);
                     c = n;
                 } else {
+                    m_head = c;
                     break;
                 }
             }

--- a/include/msgpack/v1/detail/cpp03_zone.hpp
+++ b/include/msgpack/v1/detail/cpp03_zone.hpp
@@ -113,6 +113,7 @@ class zone {
                     ::free(c);
                     c = n;
                 } else {
+                    m_head = c;
                     break;
                 }
             }


### PR DESCRIPTION
Fixed a pointer operation problem at msgpack::zone::chunk_list::clear().
It was only happened on C++03.