### PR TITLE
Fixed #442.

### DIFF
--- a/include/msgpack/v1/adaptor/adaptor_base.hpp
+++ b/include/msgpack/v1/adaptor/adaptor_base.hpp
@@ -51,25 +51,25 @@ struct object_with_zone {
 template <typename T>
 inline
 msgpack::object const& operator>> (msgpack::object const& o, T& v) {
-    return adaptor::convert<T>()(o, v);
+    return msgpack::adaptor::convert<T>()(o, v);
 }
 
 template <typename Stream, typename T>
 inline
 msgpack::packer<Stream>& operator<< (msgpack::packer<Stream>& o, T const& v) {
-    return adaptor::pack<T>()(o, v);
+    return msgpack::adaptor::pack<T>()(o, v);
 }
 
 template <typename T>
 inline
 void operator<< (msgpack::object& o, T const& v) {
-    adaptor::object<T>()(o, v);
+    msgpack::adaptor::object<T>()(o, v);
 }
 
 template <typename T>
 inline
 void operator<< (msgpack::object::with_zone& o, T const& v) {
-    adaptor::object_with_zone<T>()(o, v);
+    msgpack::adaptor::object_with_zone<T>()(o, v);
 }
 
 /// @cond

--- a/include/msgpack/v2/adaptor/adaptor_base.hpp
+++ b/include/msgpack/v2/adaptor/adaptor_base.hpp
@@ -41,32 +41,6 @@ struct object_with_zone : v1::adaptor::object_with_zone<T, Enabler> {
 
 } // namespace adaptor
 
-// operators
-
-template <typename T>
-inline
-msgpack::object const& operator>> (msgpack::object const& o, T& v) {
-    return adaptor::convert<T>()(o, v);
-}
-
-template <typename Stream, typename T>
-inline
-msgpack::packer<Stream>& operator<< (msgpack::packer<Stream>& o, T const& v) {
-    return adaptor::pack<T>()(o, v);
-}
-
-template <typename T>
-inline
-void operator<< (msgpack::object& o, T const& v) {
-    adaptor::object<T>()(o, v);
-}
-
-template <typename T>
-inline
-void operator<< (msgpack::object::with_zone& o, T const& v) {
-    adaptor::object_with_zone<T>()(o, v);
-}
-
 /// @cond
 } // MSGPACK_API_VERSION_NAMESPACE(v2)
 /// @endcond

--- a/include/msgpack/v2/adaptor/adaptor_base_decl.hpp
+++ b/include/msgpack/v2/adaptor/adaptor_base_decl.hpp
@@ -40,17 +40,8 @@ struct object_with_zone;
 
 // operators
 
-template <typename T>
- msgpack::object const& operator>> (msgpack::object const& o, T& v);
-
-template <typename Stream, typename T>
-msgpack::packer<Stream>& operator<< (msgpack::packer<Stream>& o, T const& v);
-
-template <typename T>
-void operator<< (msgpack::object& o, T const& v);
-
-template <typename T>
-void operator<< (msgpack::object::with_zone& o, T const& v);
+using v1::operator>>;
+using v1::operator<<;
 
 /// @cond
 } // MSGPACK_API_VERSION_NAMESPACE(v2)


### PR DESCRIPTION
Updated msgpack::v1::operator<< and >> implementation.
Those functions refer to current version of convert, pack, object, and object_with_zone.