### PR TITLE
type::nil is defined only if MSGPACK_USE_LEGACY_NIL in v2.

### DIFF
--- a/include/msgpack/v2/adaptor/nil_decl.hpp
+++ b/include/msgpack/v2/adaptor/nil_decl.hpp
@@ -22,6 +22,12 @@ namespace type {
 
 using v1::type::nil_t;
 
+#if defined(MSGPACK_USE_LEGACY_NIL)
+
+typedef nil_t nil;
+
+#endif // defined(MSGPACK_USE_LEGACY_NIL)
+
 using v1::type::operator<;
 using v1::type::operator==;
 


### PR DESCRIPTION
Note: In v1, type::nil is defined if NOT defined MSGPACK_DISABLE_LEGACY_NIL.