### PR TITLE
Fixed #446.

### DIFF
--- a/include/msgpack/v1/object.hpp
+++ b/include/msgpack/v1/object.hpp
@@ -37,7 +37,14 @@ public:
      * @param obj object
      * @param z zone
      */
-    object_handle(msgpack::object const& obj, msgpack::unique_ptr<msgpack::zone> z) :
+    object_handle(
+        msgpack::object const& obj,
+#if defined(MSGPACK_USE_CPP03)
+        msgpack::unique_ptr<msgpack::zone> z
+#else  // defined(MSGPACK_USE_CPP03)
+        msgpack::unique_ptr<msgpack::zone>&& z
+#endif // defined(MSGPACK_USE_CPP03)
+    ) :
         m_obj(obj), m_zone(msgpack::move(z)) { }
 
     // obsolete


### PR DESCRIPTION
Replaced passed by value with passed by rvalue reference on
msgpack::object_handle's constructor.