### PR TITLE
Replaced msgpack::unpacked with msgpack::object_handle.

### DIFF
--- a/QUICKSTART-CPP.md
+++ b/QUICKSTART-CPP.md
@@ -31,11 +31,11 @@ int main(void) {
         msgpack::pack(sbuf, vec);
 
         // deserialize it.
-        msgpack::unpacked msg;
-        msgpack::unpack(&msg, sbuf.data(), sbuf.size());
+        msgpack::object_handle oh =
+            msgpack::unpack(sbuf.data(), sbuf.size());
 
         // print the deserialized object.
-        msgpack::object obj = msg.get();
+        msgpack::object obj = oh.get();
         std::cout << obj << std::endl;  //=> ["Hello", "MessagePack"]
 
         // convert it into statically typed object.
@@ -79,9 +79,9 @@ int main(void) {
         pac.buffer_consumed(buffer.size());
 
         // now starts streaming deserialization.
-        msgpack::unpacked result;
-        while(pac.next(&result)) {
-            std::cout << result.get() << std::endl;
+        msgpack::object_handle oh;
+        while(pac.next(&oh)) {
+            std::cout << oh.get() << std::endl;
         }
 
         // results:
@@ -151,10 +151,10 @@ int main(void) {
         msgpack::sbuffer sbuf;
         msgpack::pack(sbuf, vec);
 
-        msgpack::unpacked msg;
-        msgpack::unpack(&msg, sbuf.data(), sbuf.size());
+        msgpack::object_handle oh =
+            msgpack::unpack(sbuf.data(), sbuf.size());
 
-        msgpack::object obj = msg.get();
+        msgpack::object obj = oh.get();
 
         // you can convert object to myclass directly
         std::vector<myclass> rvec;

--- a/README.md
+++ b/README.md
@@ -83,12 +83,11 @@ int main(void)
     // deserialize the buffer into msgpack::object instance.
     std::string str(buffer.str());
 
-    msgpack::unpacked result;
+    msgpack::object_handle oh =
+        msgpack::unpack(str.data(), str.size());
 
-    msgpack::unpack(result, str.data(), str.size());
-
-    // deserialized object is valid during the msgpack::unpacked instance alive.
-    msgpack::object deserialized = result.get();
+    // deserialized object is valid during the msgpack::object_handle instance is alive.
+    msgpack::object deserialized = oh.get();
 
     // msgpack::object supports ostream.
     std::cout << deserialized << std::endl;

--- a/example/boost/msgpack_variant_capitalize.cpp
+++ b/example/boost/msgpack_variant_capitalize.cpp
@@ -73,8 +73,8 @@ int main() {
     msgpack::pack(ss1, u);
     print(ss1.str());
 
-    msgpack::unpacked unp1 = msgpack::unpack(ss1.str().data(), ss1.str().size());
-    msgpack::object const& obj1 = unp1.get();
+    msgpack::object_handle oh1 = msgpack::unpack(ss1.str().data(), ss1.str().size());
+    msgpack::object const& obj1 = oh1.get();
     std::cout << "Unpacked msgpack object." << std::endl;
     std::cout << obj1 << std::endl;
 
@@ -87,8 +87,8 @@ int main() {
     msgpack::pack(ss2, v);
     print(ss2.str());
 
-    msgpack::unpacked unp2 = msgpack::unpack(ss2.str().data(), ss2.str().size());
-    msgpack::object const& obj2 = unp2.get();
+    msgpack::object_handle oh2 = msgpack::unpack(ss2.str().data(), ss2.str().size());
+    msgpack::object const& obj2 = oh2.get();
     std::cout << "Modified msgpack object." << std::endl;
     std::cout << obj2 << std::endl;
 }

--- a/example/boost/msgpack_variant_mapbased.cpp
+++ b/example/boost/msgpack_variant_mapbased.cpp
@@ -79,8 +79,8 @@ int main() {
     u.address = "Tokyo";
     msgpack::pack(ss, u);
 
-    msgpack::unpacked unp = msgpack::unpack(ss.str().data(), ss.str().size());
-    msgpack::object const& obj = unp.get();
+    msgpack::object_handle oh = msgpack::unpack(ss.str().data(), ss.str().size());
+    msgpack::object const& obj = oh.get();
     std::cout << "Unpacked msgpack object." << std::endl;
     std::cout << obj << std::endl;
     msgpack::type::variant_ref v = obj.as<msgpack::type::variant_ref>();

--- a/example/cpp03/class_intrusive.cpp
+++ b/example/cpp03/class_intrusive.cpp
@@ -84,9 +84,9 @@ int main() {
 
         print(ss.str());
 
-        msgpack::unpacked unp;
-        msgpack::unpack(unp, ss.str().data(), ss.str().size());
-        msgpack::object obj = unp.get();
+        msgpack::object_handle oh =
+            msgpack::unpack(ss.str().data(), ss.str().size());
+        msgpack::object obj = oh.get();
         std::cout << obj << std::endl;
         assert(obj.as<my_class>() == my);
     }

--- a/example/cpp03/class_intrusive_map.cpp
+++ b/example/cpp03/class_intrusive_map.cpp
@@ -59,9 +59,9 @@ int main() {
 
         print(ss.str());
 
-        msgpack::unpacked unp;
-        msgpack::unpack(unp, ss.str().data(), ss.str().size());
-        msgpack::object obj = unp.get();
+        msgpack::object_handle oh =
+            msgpack::unpack(ss.str().data(), ss.str().size());
+        msgpack::object obj = oh.get();
         std::cout << obj << std::endl;
         assert(obj.as<my_class>() == my);
     }

--- a/example/cpp03/class_non_intrusive.cpp
+++ b/example/cpp03/class_non_intrusive.cpp
@@ -102,9 +102,9 @@ int main() {
 
         print(ss.str());
 
-        msgpack::unpacked unp;
-        msgpack::unpack(unp, ss.str().data(), ss.str().size());
-        msgpack::object obj = unp.get();
+        msgpack::object_handle oh =
+            msgpack::unpack(ss.str().data(), ss.str().size());
+        msgpack::object obj = oh.get();
         std::cout << obj << std::endl;
         assert(obj.as<my_class>() == my);
     }

--- a/example/cpp03/custom.cpp
+++ b/example/cpp03/custom.cpp
@@ -40,9 +40,9 @@ int main(void)
         std::stringstream sbuf;
         msgpack::pack(sbuf, oc);
 
-        msgpack::unpacked result;
-        msgpack::unpack(result, sbuf.str().data(), sbuf.str().size());
-        msgpack::object obj = result.get();
+        msgpack::object_handle oh =
+            msgpack::unpack(sbuf.str().data(), sbuf.str().size());
+        msgpack::object obj = oh.get();
 
         obj.convert(nc);
 
@@ -56,9 +56,9 @@ int main(void)
         std::stringstream sbuf;
         msgpack::pack(sbuf, nc);
 
-        msgpack::unpacked result;
-        msgpack::unpack(result, sbuf.str().data(), sbuf.str().size());
-        msgpack::object obj = result.get();
+        msgpack::object_handle oh =
+            msgpack::unpack(sbuf.str().data(), sbuf.str().size());
+        msgpack::object obj = oh.get();
 
         obj.convert(oc);
 

--- a/example/cpp03/enum.cpp
+++ b/example/cpp03/enum.cpp
@@ -30,20 +30,20 @@ int main(void)
         my_enum e3 = elem3;
         msgpack::pack(sbuf, e3);
 
-        msgpack::unpacked result;
+        msgpack::object_handle oh;
         std::size_t off = 0;
 
-        msgpack::unpack(result, sbuf.str().data(), sbuf.str().size(), off);
-        std::cout << result.get().as<my_enum>() << std::endl;
-        assert(result.get().as<my_enum>() == elem1);
+        msgpack::unpack(oh, sbuf.str().data(), sbuf.str().size(), off);
+        std::cout << oh.get().as<my_enum>() << std::endl;
+        assert(oh.get().as<my_enum>() == elem1);
 
-        msgpack::unpack(result, sbuf.str().data(), sbuf.str().size(), off);
-        std::cout << result.get().as<my_enum>() << std::endl;
-        assert(result.get().as<my_enum>() == elem2);
+        msgpack::unpack(oh, sbuf.str().data(), sbuf.str().size(), off);
+        std::cout << oh.get().as<my_enum>() << std::endl;
+        assert(oh.get().as<my_enum>() == elem2);
 
-        msgpack::unpack(result, sbuf.str().data(), sbuf.str().size(), off);
-        std::cout << result.get().as<my_enum>() << std::endl;
-        assert(result.get().as<my_enum>() == elem3);
+        msgpack::unpack(oh, sbuf.str().data(), sbuf.str().size(), off);
+        std::cout << oh.get().as<my_enum>() << std::endl;
+        assert(oh.get().as<my_enum>() == elem3);
     }
     {   // create object without zone
         msgpack::object obj(elem2);

--- a/example/cpp03/map_based_versionup.cpp
+++ b/example/cpp03/map_based_versionup.cpp
@@ -71,9 +71,9 @@ int main() {
 
         print(ss.str());
 
-        msgpack::unpacked unp = msgpack::unpack(ss.str().data(), ss.str().size());
+        msgpack::object_handle oh = msgpack::unpack(ss.str().data(), ss.str().size());
 
-        msgpack::object obj = unp.get();
+        msgpack::object obj = oh.get();
         std::cout << obj << std::endl;
 
         v2 newv = obj.as<v2>();

--- a/example/cpp03/protocol.cpp
+++ b/example/cpp03/protocol.cpp
@@ -57,9 +57,9 @@ int main(void)
     {
         std::string buffer(stream.str());
 
-        msgpack::unpacked result;
-        msgpack::unpack(result, buffer.data(), buffer.size());
-        msgpack::object o = result.get();
+        msgpack::object_handle oh =
+            msgpack::unpack(buffer.data(), buffer.size());
+        msgpack::object o = oh.get();
 
         myprotocol::Get req;
         o.convert(req);
@@ -85,9 +85,9 @@ int main(void)
     {
         std::string buffer(stream.str());
 
-        msgpack::unpacked result;
-        msgpack::unpack(result, buffer.data(), buffer.size());
-        msgpack::object o = result.get();
+        msgpack::object_handle oh =
+            msgpack::unpack(buffer.data(), buffer.size());
+        msgpack::object o = oh.get();
 
 
         myprotocol::MultiGet req;

--- a/example/cpp03/protocol_new.cpp
+++ b/example/cpp03/protocol_new.cpp
@@ -44,9 +44,9 @@ int main(void)
     {
         std::string buffer(stream.str());
 
-        msgpack::unpacked result;
-        msgpack::unpack(result, buffer.data(), buffer.size());
-        msgpack::object o = result.get();
+        msgpack::object_handle oh =
+            msgpack::unpack(buffer.data(), buffer.size());
+        msgpack::object o = oh.get();
 
         myprotocol::Get req;
         o.convert(req);
@@ -72,9 +72,9 @@ int main(void)
     {
         std::string buffer(stream.str());
 
-        msgpack::unpacked result;
-        msgpack::unpack(result, buffer.data(), buffer.size());
-        msgpack::object o = result.get();
+        msgpack::object_handle oh =
+            msgpack::unpack(buffer.data(), buffer.size());
+        msgpack::object o = oh.get();
 
 
         myprotocol::MultiGet req;

--- a/example/cpp03/simple.cpp
+++ b/example/cpp03/simple.cpp
@@ -27,12 +27,10 @@ int main(void)
     // deserialize the buffer into msgpack::object instance.
     std::string str(buffer.str());
 
-    msgpack::unpacked result;
+    msgpack::object_handle oh = msgpack::unpack(str.data(), str.size());
 
-    msgpack::unpack(result, str.data(), str.size());
-
-    // deserialized object is valid during the msgpack::unpacked instance alive.
-    msgpack::object deserialized = result.get();
+    // deserialized object is valid during the msgpack::object_handle instance alive.
+    msgpack::object deserialized = oh.get();
 
     // msgpack::object supports ostream.
     std::cout << deserialized << std::endl;

--- a/example/cpp03/speed_test.cpp
+++ b/example/cpp03/speed_test.cpp
@@ -37,11 +37,11 @@ void test_map_pack_unpack() {
     buffer.seekg(0);
     std::string str(buffer.str());
 
-    msgpack::unpacked unpacked;
-    std::cout << "Start unpacking...by void unpack(unpacked& result, const char* data, size_t len)" << std::endl;
+    msgpack::object_handle oh;
+    std::cout << "Start unpacking...by void unpack(object_handle& oh, const char* data, size_t len)" << std::endl;
     {
         boost::timer::cpu_timer timer;
-        msgpack::unpack(unpacked, str.data(), str.size());
+        msgpack::unpack(oh, str.data(), str.size());
         std::string result = timer.format();
         std::cout << result << std::endl;
     }
@@ -50,7 +50,7 @@ void test_map_pack_unpack() {
     std::cout << "Start converting..." << std::endl;
     {
         boost::timer::cpu_timer timer;
-        unpacked.get().convert(m2);
+        oh.get().convert(m2);
         std::string result = timer.format();
         std::cout << result << std::endl;
     }

--- a/example/cpp03/speed_test_nested_array.cpp
+++ b/example/cpp03/speed_test_nested_array.cpp
@@ -60,11 +60,11 @@ void test_array_of_array() {
     buffer.seekg(0);
     std::string str(buffer.str());
 
-    msgpack::unpacked unpacked;
-    std::cout << "Start unpacking...by void unpack(unpacked& result, const char* data, size_t len)" << std::endl;
+    msgpack::object_handle oh;
+    std::cout << "Start unpacking...by void unpack(object_handle& oh, const char* data, size_t len)" << std::endl;
     {
         boost::timer::cpu_timer timer;
-        msgpack::unpack(unpacked, str.data(), str.size());
+        msgpack::unpack(oh, str.data(), str.size());
         std::string result = timer.format();
         std::cout << result << std::endl;
     }
@@ -73,7 +73,7 @@ void test_array_of_array() {
     std::cout << "Start converting..." << std::endl;
     {
         boost::timer::cpu_timer timer;
-        unpacked.get().convert(v2);
+        oh.get().convert(v2);
         std::string result = timer.format();
         std::cout << result << std::endl;
     }

--- a/example/cpp03/stream.cpp
+++ b/example/cpp03/stream.cpp
@@ -43,10 +43,10 @@ public:
 
         m_pac.buffer_consumed(count);
 
-        msgpack::unpacked result;
-        while (m_pac.next(&result)) {
-            msgpack::object msg = result.get();
-            unique_zone& life = result.zone();
+        msgpack::object_handle oh;
+        while (m_pac.next(&oh)) {
+            msgpack::object msg = oh.get();
+            unique_zone& life = oh.zone();
             process_message(msg, life);
         }
 

--- a/example/cpp11/container.cpp
+++ b/example/cpp11/container.cpp
@@ -25,8 +25,8 @@ void array() {
     std::stringstream ss;
     msgpack::pack(ss, a);
 
-    msgpack::unpacked und = msgpack::unpack(ss.str().data(), ss.str().size());
-    msgpack::object obj = und.get();
+    msgpack::object_handle oh = msgpack::unpack(ss.str().data(), ss.str().size());
+    msgpack::object obj = oh.get();
 
     std::cout << obj << std::endl;
     assert((obj.as<std::array<int, 5>>()) == a);
@@ -37,8 +37,8 @@ void tuple() {
     std::stringstream ss;
     msgpack::pack(ss, t);
 
-    auto und = msgpack::unpack(ss.str().data(), ss.str().size());
-    auto obj = und.get();
+    auto oh = msgpack::unpack(ss.str().data(), ss.str().size());
+    auto obj = oh.get();
 
     std::cout << obj << std::endl;
     assert(obj.as<decltype(t)>() == t);
@@ -49,8 +49,8 @@ void unordered_map() {
     std::stringstream ss;
     msgpack::pack(ss, m);
 
-    auto und = msgpack::unpack(ss.str().data(), ss.str().size());
-    msgpack::object obj = und.get();
+    auto oh = msgpack::unpack(ss.str().data(), ss.str().size());
+    msgpack::object obj = oh.get();
 
     std::cout << obj << std::endl;
     assert(obj.as<decltype(m)>() == m);
@@ -61,8 +61,8 @@ void unordered_set() {
     std::stringstream ss;
     msgpack::pack(ss, s);
 
-    auto und = msgpack::unpack(ss.str().data(), ss.str().size());
-    auto obj = und.get();
+    auto oh = msgpack::unpack(ss.str().data(), ss.str().size());
+    auto obj = oh.get();
 
     std::cout << obj << std::endl;
     assert(obj.as<decltype(s)>() == s);
@@ -74,8 +74,8 @@ void forward_list() {
     std::stringstream ss;
     msgpack::pack(ss, f);
 
-    auto und = msgpack::unpack(ss.str().data(), ss.str().size());
-    auto obj = und.get();
+    auto oh = msgpack::unpack(ss.str().data(), ss.str().size());
+    auto obj = oh.get();
 
     std::cout << obj << std::endl;
     assert(obj.as<type>() == f);
@@ -98,40 +98,40 @@ void combi() {
     std::size_t offset = 0;
     std::cout << "offset: " << offset << std::endl;
     {
-        auto und = msgpack::unpack(ss.str().data(), ss.str().size(), offset);
-        auto obj = und.get();
+        auto oh = msgpack::unpack(ss.str().data(), ss.str().size(), offset);
+        auto obj = oh.get();
 
         std::cout << obj << std::endl;
         assert(obj.as<decltype(a)>() == a);
     }
     std::cout << "offset: " << offset << std::endl;
     {
-        auto und = msgpack::unpack(ss.str().data(), ss.str().size(), offset);
-        auto obj = und.get();
+        auto oh = msgpack::unpack(ss.str().data(), ss.str().size(), offset);
+        auto obj = oh.get();
 
         std::cout << obj << std::endl;
         assert(obj.as<decltype(t)>() == t);
     }
     std::cout << "offset: " << offset << std::endl;
     {
-        auto und = msgpack::unpack(ss.str().data(), ss.str().size(), offset);
-        auto obj = und.get();
+        auto oh = msgpack::unpack(ss.str().data(), ss.str().size(), offset);
+        auto obj = oh.get();
 
         std::cout << obj << std::endl;
         assert(obj.as<decltype(m)>() == m);
     }
     std::cout << "offset: " << offset << std::endl;
     {
-        auto und = msgpack::unpack(ss.str().data(), ss.str().size(), offset);
-        auto obj = und.get();
+        auto oh = msgpack::unpack(ss.str().data(), ss.str().size(), offset);
+        auto obj = oh.get();
 
         std::cout << obj << std::endl;
         assert(obj.as<decltype(s)>() == s);
     }
     std::cout << "offset: " << offset << std::endl;
     {
-        auto und = msgpack::unpack(ss.str().data(), ss.str().size(), offset);
-        auto obj = und.get();
+        auto oh = msgpack::unpack(ss.str().data(), ss.str().size(), offset);
+        auto obj = oh.get();
 
         std::cout << obj << std::endl;
         assert(obj.as<decltype(f)>() == f);

--- a/include/msgpack/v1/unpack.hpp
+++ b/include/msgpack/v1/unpack.hpp
@@ -1003,7 +1003,7 @@ public:
      * This function is obsolete. Use the reference inteface version of next() function instead of
      * the pointer interface version.
      */
-    bool next(unpacked* result);
+    bool next(object_handle* result);
 
     /// Unpack one msgpack::object.
     /**
@@ -1019,7 +1019,7 @@ public:
      * See:
      * https://github.com/msgpack/msgpack-c/wiki/v1_1_cpp_unpacker#msgpack-controls-a-buffer
      */
-    bool next(unpacked& result, bool& referenced);
+    bool next(object_handle& result, bool& referenced);
 
     /// Unpack one msgpack::object.
     /**
@@ -1033,7 +1033,7 @@ public:
      * See:
      * https://github.com/msgpack/msgpack-c/wiki/v1_1_cpp_unpacker#msgpack-controls-a-buffer
      */
-    bool next(unpacked& result);
+    bool next(object_handle& result);
 
     /// Get message size.
     /**
@@ -1281,7 +1281,7 @@ inline void unpacker::buffer_consumed(std::size_t size)
     m_free -= size;
 }
 
-inline bool unpacker::next(unpacked& result, bool& referenced)
+inline bool unpacker::next(object_handle& result, bool& referenced)
 {
     referenced = false;
     int ret = execute_imp();
@@ -1303,13 +1303,13 @@ inline bool unpacker::next(unpacked& result, bool& referenced)
     }
 }
 
-inline bool unpacker::next(unpacked& result)
+inline bool unpacker::next(object_handle& result)
 {
     bool referenced;
     return next(result, referenced);
 }
 
-inline bool unpacker::next(unpacked* result)
+inline bool unpacker::next(object_handle* result)
 {
     return next(*result);
 }
@@ -1461,7 +1461,7 @@ unpack_imp(const char* data, std::size_t len, std::size_t& off,
 
 // reference version
 
-inline unpacked unpack(
+inline object_handle unpack(
     const char* data, std::size_t len, std::size_t& off, bool& referenced,
     unpack_reference_func f, void* user_data,
     unpack_limit const& limit
@@ -1477,20 +1477,20 @@ inline unpacked unpack(
     switch(ret) {
     case UNPACK_SUCCESS:
         off = noff;
-        return unpacked(obj, msgpack::move(z));
+        return object_handle(obj, msgpack::move(z));
     case UNPACK_EXTRA_BYTES:
         off = noff;
-        return unpacked(obj, msgpack::move(z));
+        return object_handle(obj, msgpack::move(z));
     case UNPACK_CONTINUE:
         throw msgpack::insufficient_bytes("insufficient bytes");
     case UNPACK_PARSE_ERROR:
     default:
         throw msgpack::parse_error("parse error");
     }
-    return unpacked();
+    return object_handle();
 }
 
-inline unpacked unpack(
+inline object_handle unpack(
     const char* data, std::size_t len, std::size_t& off,
     unpack_reference_func f, void* user_data,
     unpack_limit const& limit)
@@ -1499,7 +1499,7 @@ inline unpacked unpack(
     return unpack(data, len, off, referenced, f, user_data, limit);
 }
 
-inline unpacked unpack(
+inline object_handle unpack(
     const char* data, std::size_t len, bool& referenced,
     unpack_reference_func f, void* user_data,
     unpack_limit const& limit)
@@ -1508,7 +1508,7 @@ inline unpacked unpack(
     return unpack(data, len, off, referenced, f, user_data, limit);
 }
 
-inline unpacked unpack(
+inline object_handle unpack(
     const char* data, std::size_t len,
     unpack_reference_func f, void* user_data,
     unpack_limit const& limit)
@@ -1519,7 +1519,7 @@ inline unpacked unpack(
 }
 
 inline void unpack(
-    unpacked& result,
+    object_handle& result,
     const char* data, std::size_t len, std::size_t& off, bool& referenced,
     unpack_reference_func f, void* user_data,
     unpack_limit const& limit)
@@ -1551,7 +1551,7 @@ inline void unpack(
 }
 
 inline void unpack(
-    unpacked& result,
+    object_handle& result,
     const char* data, std::size_t len, std::size_t& off,
     unpack_reference_func f, void* user_data,
             unpack_limit const& limit)
@@ -1561,7 +1561,7 @@ inline void unpack(
 }
 
 inline void unpack(
-    unpacked& result,
+    object_handle& result,
     const char* data, std::size_t len, bool& referenced,
     unpack_reference_func f, void* user_data,
     unpack_limit const& limit)
@@ -1571,7 +1571,7 @@ inline void unpack(
 }
 
 inline void unpack(
-    unpacked& result,
+    object_handle& result,
     const char* data, std::size_t len,
     unpack_reference_func f, void* user_data,
     unpack_limit const& limit)
@@ -1644,7 +1644,7 @@ inline msgpack::object unpack(
 // obsolete
 // pointer version
 inline void unpack(
-    unpacked* result,
+    object_handle* result,
     const char* data, std::size_t len, std::size_t* off, bool* referenced,
     unpack_reference_func f, void* user_data,
     unpack_limit const& limit)

--- a/include/msgpack/v1/unpack_decl.hpp
+++ b/include/msgpack/v1/unpack_decl.hpp
@@ -218,10 +218,10 @@ class unpacker;
  * @param user_data This parameter is passed to f.
  * @param limit The size limit information of msgpack::object.
  *
- * @return unpacked object that contains unpacked data.
+ * @return object_handle that contains unpacked data.
  *
  */
-unpacked unpack(
+object_handle unpack(
     const char* data, std::size_t len, std::size_t& off, bool& referenced,
     unpack_reference_func f = nullptr, void* user_data = nullptr, unpack_limit const& limit = unpack_limit());
 
@@ -234,10 +234,10 @@ unpacked unpack(
  * @param user_data This parameter is passed to f.
  * @param limit The size limit information of msgpack::object.
  *
- * @return unpacked object that contains unpacked data.
+ * @return object_handle that contains unpacked data.
  *
  */
-unpacked unpack(
+object_handle unpack(
     const char* data, std::size_t len, std::size_t& off,
     unpack_reference_func f = nullptr, void* user_data = nullptr, unpack_limit const& limit = unpack_limit());
 
@@ -250,10 +250,10 @@ unpacked unpack(
  * @param user_data This parameter is passed to f.
  * @param limit The size limit information of msgpack::object.
  *
- * @return unpacked object that contains unpacked data.
+ * @return object_handle that contains unpacked data.
  *
  */
-unpacked unpack(
+object_handle unpack(
     const char* data, std::size_t len, bool& referenced,
     unpack_reference_func f = nullptr, void* user_data = nullptr, unpack_limit const& limit = unpack_limit());
 
@@ -265,17 +265,17 @@ unpacked unpack(
  * @param user_data This parameter is passed to f.
  * @param limit The size limit information of msgpack::object.
  *
- * @return unpacked object that contains unpacked data.
+ * @return object_handle that contains unpacked data.
  *
  */
-unpacked unpack(
+object_handle unpack(
     const char* data, std::size_t len,
     unpack_reference_func f = nullptr, void* user_data = nullptr, unpack_limit const& limit = unpack_limit());
 
 
 /// Unpack msgpack::object from a buffer.
 /**
- * @param result The object that contains unpacked data.
+ * @param result The object_handle that contains unpacked data.
  * @param data The pointer to the buffer.
  * @param len The length of the buffer.
  * @param off The offset position of the buffer. It is read and overwritten.
@@ -287,13 +287,13 @@ unpacked unpack(
  *
  */
 void unpack(
-    unpacked& result,
+    object_handle& result,
     const char* data, std::size_t len, std::size_t& off, bool& referenced,
     unpack_reference_func f = nullptr, void* user_data = nullptr, unpack_limit const& limit = unpack_limit());
 
 /// Unpack msgpack::object from a buffer.
 /**
- * @param result The object that contains unpacked data.
+ * @param result The object_handle that contains unpacked data.
  * @param data The pointer to the buffer.
  * @param len The length of the buffer.
  * @param off The offset position of the buffer. It is read and overwritten.
@@ -304,13 +304,13 @@ void unpack(
  *
  */
 void unpack(
-    unpacked& result,
+    object_handle& result,
     const char* data, std::size_t len, std::size_t& off,
     unpack_reference_func f = nullptr, void* user_data = nullptr, unpack_limit const& limit = unpack_limit());
 
 /// Unpack msgpack::object from a buffer.
 /**
- * @param result The object that contains unpacked data.
+ * @param result The object_handle that contains unpacked data.
  * @param data The pointer to the buffer.
  * @param len The length of the buffer.
  * @param referenced If the unpacked object contains reference of the buffer, then set as true, otherwise false.
@@ -321,13 +321,13 @@ void unpack(
  *
  */
 void unpack(
-    unpacked& result,
+    object_handle& result,
     const char* data, std::size_t len, bool& referenced,
     unpack_reference_func f = nullptr, void* user_data = nullptr, unpack_limit const& limit = unpack_limit());
 
 /// Unpack msgpack::object from a buffer.
 /**
- * @param result The object that contains unpacked data.
+ * @param result The object_handle that contains unpacked data.
  * @param data The pointer to the buffer.
  * @param len The length of the buffer.
  * @param f A judging function that msgpack::object refer to the buffer.
@@ -337,7 +337,7 @@ void unpack(
  *
  */
 void unpack(
-    unpacked& result,
+    object_handle& result,
     const char* data, std::size_t len,
     unpack_reference_func f = nullptr, void* user_data = nullptr, unpack_limit const& limit = unpack_limit());
 
@@ -416,7 +416,7 @@ msgpack::object unpack(
 
 /// Unpack msgpack::object from a buffer. [obsolete]
 /**
- * @param result The object that contains unpacked data.
+ * @param result The object_handle that contains unpacked data.
  * @param data The pointer to the buffer.
  * @param len The length of the buffer.
  * @param off The offset position of the buffer. It is read and overwritten.
@@ -428,7 +428,7 @@ msgpack::object unpack(
  * This function is obsolete. Use the reference inteface version of unpack functions instead of the pointer interface version.
  */
 void unpack(
-    unpacked* result,
+    object_handle* result,
     const char* data, std::size_t len, std::size_t* off = nullptr, bool* referenced = nullptr,
     unpack_reference_func f = nullptr, void* user_data = nullptr, unpack_limit const& limit = unpack_limit());
 

--- a/test/array_ref.cpp
+++ b/test/array_ref.cpp
@@ -20,12 +20,12 @@ TEST(MSGPACK_ARRAY_REF, pack_unpack_convert_vector_char)
     std::stringstream ss;
     msgpack::pack(ss, ar1);
 
-    msgpack::unpacked upd;
-    msgpack::unpack(upd, ss.str().data(), ss.str().size());
-    EXPECT_EQ(upd.get().type, msgpack::type::ARRAY);
+    msgpack::object_handle oh =
+        msgpack::unpack(ss.str().data(), ss.str().size());
+    EXPECT_EQ(oh.get().type, msgpack::type::ARRAY);
     std::vector<char> v2;
     msgpack::type::array_ref<std::vector<char> > ar2(v2);
-    upd.get().convert(ar2);
+    oh.get().convert(ar2);
     EXPECT_TRUE(ar1 == ar2);
 }
 
@@ -42,12 +42,12 @@ TEST(MSGPACK_ARRAY_REF, pack_unpack_convert_vector_char_const)
     std::stringstream ss;
     msgpack::pack(ss, ar1);
 
-    msgpack::unpacked upd;
-    msgpack::unpack(upd, ss.str().data(), ss.str().size());
-    EXPECT_EQ(upd.get().type, msgpack::type::ARRAY);
+    msgpack::object_handle oh =
+        msgpack::unpack(ss.str().data(), ss.str().size());
+    EXPECT_EQ(oh.get().type, msgpack::type::ARRAY);
     std::vector<char> v2;
     msgpack::type::array_ref<std::vector<char> > ar2(v2);
-    upd.get().convert(ar2);
+    oh.get().convert(ar2);
     EXPECT_TRUE(ar1 == ar2);
 }
 
@@ -62,12 +62,12 @@ TEST(MSGPACK_ARRAY_REF, pack_unpack_convert_vector_unsigned_char)
     std::stringstream ss;
     msgpack::pack(ss, ar1);
 
-    msgpack::unpacked upd;
-    msgpack::unpack(upd, ss.str().data(), ss.str().size());
-    EXPECT_EQ(upd.get().type, msgpack::type::ARRAY);
+    msgpack::object_handle oh =
+        msgpack::unpack(ss.str().data(), ss.str().size());
+    EXPECT_EQ(oh.get().type, msgpack::type::ARRAY);
     std::vector<unsigned char> v2;
     msgpack::type::array_ref<std::vector<unsigned char> > ar2(v2);
-    upd.get().convert(ar2);
+    oh.get().convert(ar2);
     EXPECT_TRUE(ar1 == ar2);
 }
 
@@ -84,12 +84,12 @@ TEST(MSGPACK_ARRAY_REF, pack_unpack_convert_vector_unsigned_char_const)
     std::stringstream ss;
     msgpack::pack(ss, ar1);
 
-    msgpack::unpacked upd;
-    msgpack::unpack(upd, ss.str().data(), ss.str().size());
-    EXPECT_EQ(upd.get().type, msgpack::type::ARRAY);
+    msgpack::object_handle oh =
+        msgpack::unpack(ss.str().data(), ss.str().size());
+    EXPECT_EQ(oh.get().type, msgpack::type::ARRAY);
     std::vector<unsigned char> v2;
     msgpack::type::array_ref<std::vector<unsigned char> > ar2(v2);
-    upd.get().convert(ar2);
+    oh.get().convert(ar2);
     EXPECT_TRUE(ar1 == ar2);
 }
 
@@ -179,12 +179,12 @@ TEST(MSGPACK_ARRAY_REF, pack_unpack_convert_array_char)
     std::stringstream ss;
     msgpack::pack(ss, ar1);
 
-    msgpack::unpacked upd;
-    msgpack::unpack(upd, ss.str().data(), ss.str().size());
-    EXPECT_EQ(upd.get().type, msgpack::type::ARRAY);
+    msgpack::object_handle oh =
+        msgpack::unpack(ss.str().data(), ss.str().size());
+    EXPECT_EQ(oh.get().type, msgpack::type::ARRAY);
     std::array<char, 3> v2;
     msgpack::type::array_ref<std::array<char, 3> > ar2(v2);
-    upd.get().convert(ar2);
+    oh.get().convert(ar2);
     EXPECT_TRUE(ar1 == ar2);
 }
 
@@ -198,12 +198,12 @@ TEST(MSGPACK_ARRAY_REF, pack_unpack_convert_array_char_const)
     std::stringstream ss;
     msgpack::pack(ss, ar1);
 
-    msgpack::unpacked upd;
-    msgpack::unpack(upd, ss.str().data(), ss.str().size());
-    EXPECT_EQ(upd.get().type, msgpack::type::ARRAY);
+    msgpack::object_handle oh =
+        msgpack::unpack(ss.str().data(), ss.str().size());
+    EXPECT_EQ(oh.get().type, msgpack::type::ARRAY);
     std::array<char, 3> v2;
     msgpack::type::array_ref<std::array<char, 3> > ar2(v2);
-    upd.get().convert(ar2);
+    oh.get().convert(ar2);
     EXPECT_TRUE(ar1 == ar2);
 }
 
@@ -215,12 +215,12 @@ TEST(MSGPACK_ARRAY_REF, pack_unpack_convert_array_unsigned_char)
     std::stringstream ss;
     msgpack::pack(ss, ar1);
 
-    msgpack::unpacked upd;
-    msgpack::unpack(upd, ss.str().data(), ss.str().size());
-    EXPECT_EQ(upd.get().type, msgpack::type::ARRAY);
+    msgpack::object_handle oh =
+        msgpack::unpack(ss.str().data(), ss.str().size());
+    EXPECT_EQ(oh.get().type, msgpack::type::ARRAY);
     std::array<unsigned char, 3> v2;
     msgpack::type::array_ref<std::array<unsigned char, 3> > ar2(v2);
-    upd.get().convert(ar2);
+    oh.get().convert(ar2);
     EXPECT_TRUE(ar1 == ar2);
 }
 
@@ -234,12 +234,12 @@ TEST(MSGPACK_ARRAY_REF, pack_unpack_convert_array_unsigned_char_const)
     std::stringstream ss;
     msgpack::pack(ss, ar1);
 
-    msgpack::unpacked upd;
-    msgpack::unpack(upd, ss.str().data(), ss.str().size());
-    EXPECT_EQ(upd.get().type, msgpack::type::ARRAY);
+    msgpack::object_handle oh =
+        msgpack::unpack(ss.str().data(), ss.str().size());
+    EXPECT_EQ(oh.get().type, msgpack::type::ARRAY);
     std::array<unsigned char, 3> v2;
     msgpack::type::array_ref<std::array<unsigned char, 3> > ar2(v2);
-    upd.get().convert(ar2);
+    oh.get().convert(ar2);
     EXPECT_TRUE(ar1 == ar2);
 }
 

--- a/test/boost_fusion.cpp
+++ b/test/boost_fusion.cpp
@@ -21,7 +21,7 @@ BOOST_FUSION_DEFINE_STRUCT(
     mystruct,
     (int, f1)
     (double, f2)
-    )
+)
 
 TEST(MSGPACK_BOOST, fusion_pack_unpack_convert)
 {
@@ -30,9 +30,9 @@ TEST(MSGPACK_BOOST, fusion_pack_unpack_convert)
     val1.f1 = 42;
     val1.f2 = 123.45;
     msgpack::pack(ss, val1);
-    msgpack::unpacked ret;
-    msgpack::unpack(ret, ss.str().data(), ss.str().size());
-    mystruct val2 = ret.get().as<mystruct>();
+    msgpack::object_handle oh =
+        msgpack::unpack(ss.str().data(), ss.str().size());
+    mystruct val2 = oh.get().as<mystruct>();
     EXPECT_TRUE(val1.f1 == val2.f1);
     EXPECT_TRUE(fabs(val2.f2 - val1.f2) <= kEPS);
 }
@@ -84,27 +84,27 @@ inline bool operator!=(no_def_con2 const& lhs, no_def_con2 const& rhs) {
 
 namespace msgpack {
 MSGPACK_API_VERSION_NAMESPACE(MSGPACK_DEFAULT_API_NS) {
-namespace adaptor {
+    namespace adaptor {
 
-template <>
-struct as<no_def_con1> {
-    no_def_con1 operator()(msgpack::object const& o) const {
-        if (o.type != msgpack::type::ARRAY) throw msgpack::type_error();
-        if (o.via.array.size != 1) throw msgpack::type_error();
-        return no_def_con1(o.via.array.ptr[0].as<int>());
-    }
-};
+    template <>
+    struct as<no_def_con1> {
+        no_def_con1 operator()(msgpack::object const& o) const {
+            if (o.type != msgpack::type::ARRAY) throw msgpack::type_error();
+            if (o.via.array.size != 1) throw msgpack::type_error();
+            return no_def_con1(o.via.array.ptr[0].as<int>());
+        }
+    };
 
-template <>
-struct as<no_def_con2> {
-    no_def_con2 operator()(msgpack::object const& o) const {
-        if (o.type != msgpack::type::ARRAY) throw msgpack::type_error();
-        if (o.via.array.size != 1) throw msgpack::type_error();
-        return no_def_con2(o.via.array.ptr[0].as<int>());
-    }
-};
+    template <>
+    struct as<no_def_con2> {
+        no_def_con2 operator()(msgpack::object const& o) const {
+            if (o.type != msgpack::type::ARRAY) throw msgpack::type_error();
+            if (o.via.array.size != 1) throw msgpack::type_error();
+            return no_def_con2(o.via.array.ptr[0].as<int>());
+        }
+    };
 
-} // adaptor
+    } // adaptor
 } // MSGPACK_API_VERSION_NAMESPACE(MSGPACK_DEFAULT_API_NS)
 } // msgpack
 
@@ -138,7 +138,7 @@ BOOST_FUSION_ADAPT_STRUCT(
     f1, // *1
     f2, // *2
     f3  // *3
-    )
+)
 
 
 // MSVC2015's std::tuple requires default constructor during 'as' process.
@@ -151,9 +151,9 @@ TEST(MSGPACK_BOOST, pack_convert_no_def_con)
     std::stringstream ss;
     mystruct_no_def_con val1(no_def_con1(1), no_def_con2(2), no_def_con1(3));
     msgpack::pack(ss, val1);
-    msgpack::unpacked ret;
-    msgpack::unpack(ret, ss.str().data(), ss.str().size());
-    mystruct_no_def_con val2 = ret.get().as<mystruct_no_def_con>();
+    msgpack::object_handle oh =
+        msgpack::unpack(ss.str().data(), ss.str().size());
+    mystruct_no_def_con val2 = oh.get().as<mystruct_no_def_con>();
     EXPECT_TRUE(val1 == val2);
 }
 

--- a/test/boost_optional.cpp
+++ b/test/boost_optional.cpp
@@ -14,9 +14,9 @@ TEST(MSGPACK_BOOST, pack_convert_nil)
     std::stringstream ss;
     boost::optional<int> val1;
     msgpack::pack(ss, val1);
-    msgpack::unpacked ret;
-    msgpack::unpack(ret, ss.str().data(), ss.str().size());
-    boost::optional<int> val2 = ret.get().as<boost::optional<int> >();
+    msgpack::object_handle oh =
+        msgpack::unpack(ss.str().data(), ss.str().size());
+    boost::optional<int> val2 = oh.get().as<boost::optional<int> >();
     EXPECT_TRUE(val1 == val2);
 }
 
@@ -25,9 +25,9 @@ TEST(MSGPACK_BOOST, pack_convert_int)
     std::stringstream ss;
     boost::optional<int> val1 = 1;
     msgpack::pack(ss, val1);
-    msgpack::unpacked ret;
-    msgpack::unpack(ret, ss.str().data(), ss.str().size());
-    boost::optional<int> val2 = ret.get().as<boost::optional<int> >();
+    msgpack::object_handle oh =
+        msgpack::unpack(ss.str().data(), ss.str().size());
+    boost::optional<int> val2 = oh.get().as<boost::optional<int> >();
     EXPECT_TRUE(val1 == val2);
 }
 
@@ -42,9 +42,9 @@ TEST(MSGPACK_BOOST, pack_convert_vector)
     v.push_back(3);
     val1 = v;
     msgpack::pack(ss, val1);
-    msgpack::unpacked ret;
-    msgpack::unpack(ret, ss.str().data(), ss.str().size());
-    ovi_t  val2 = ret.get().as<ovi_t>();
+    msgpack::object_handle oh =
+        msgpack::unpack(ss.str().data(), ss.str().size());
+    ovi_t  val2 = oh.get().as<ovi_t>();
     EXPECT_TRUE(val1 == val2);
 }
 
@@ -57,9 +57,9 @@ TEST(MSGPACK_BOOST, pack_convert_vector_optional)
     val1[0] = 1;
     val1[2] = 3;
     msgpack::pack(ss, val1);
-    msgpack::unpacked ret;
-    msgpack::unpack(ret, ss.str().data(), ss.str().size());
-    voi_t  val2 = ret.get().as<voi_t>();
+    msgpack::object_handle oh =
+        msgpack::unpack(ss.str().data(), ss.str().size());
+    voi_t  val2 = oh.get().as<voi_t>();
     EXPECT_TRUE(val1 == val2);
 }
 
@@ -81,19 +81,19 @@ TEST(MSGPACK_BOOST, object_int)
 
 // Compile error as expected
 /*
-TEST(MSGPACK_BOOST, object_vector)
-{
-    typedef boost::optional<std::vector<int> > ovi_t;
-    ovi_t val1;
-    std::vector<int> v;
-    v.push_back(1);
-    v.push_back(2);
-    v.push_back(3);
-    val1 = v;
-    msgpack::object obj(val1);
-    ovi_t  val2 = obj.as<ovi_t>();
-    EXPECT_TRUE(val1 == val2);
-}
+  TEST(MSGPACK_BOOST, object_vector)
+  {
+  typedef boost::optional<std::vector<int> > ovi_t;
+  ovi_t val1;
+  std::vector<int> v;
+  v.push_back(1);
+  v.push_back(2);
+  v.push_back(3);
+  val1 = v;
+  msgpack::object obj(val1);
+  ovi_t  val2 = obj.as<ovi_t>();
+  EXPECT_TRUE(val1 == val2);
+  }
 */
 
 TEST(MSGPACK_BOOST, object_with_zone_nil)
@@ -146,16 +146,16 @@ inline bool operator!=(no_def_con const& lhs, no_def_con const& rhs) {
 
 namespace msgpack {
 MSGPACK_API_VERSION_NAMESPACE(MSGPACK_DEFAULT_API_NS) {
-namespace adaptor {
-template <>
-struct as<no_def_con> {
-    no_def_con operator()(msgpack::object const& o) const {
-        if (o.type != msgpack::type::ARRAY) throw msgpack::type_error();
-        if (o.via.array.size != 1) throw msgpack::type_error();
-        return no_def_con(o.via.array.ptr[0].as<int>());
-    }
-};
-} // adaptor
+    namespace adaptor {
+    template <>
+    struct as<no_def_con> {
+        no_def_con operator()(msgpack::object const& o) const {
+            if (o.type != msgpack::type::ARRAY) throw msgpack::type_error();
+            if (o.via.array.size != 1) throw msgpack::type_error();
+            return no_def_con(o.via.array.ptr[0].as<int>());
+        }
+    };
+    } // adaptor
 } // MSGPACK_API_VERSION_NAMESPACE(MSGPACK_DEFAULT_API_NS)
 } // msgpack
 
@@ -164,9 +164,9 @@ TEST(MSGPACK_BOOST, pack_convert_no_def_con)
     std::stringstream ss;
     boost::optional<no_def_con> val1 = no_def_con(1);
     msgpack::pack(ss, val1);
-    msgpack::unpacked ret;
-    msgpack::unpack(ret, ss.str().data(), ss.str().size());
-    boost::optional<no_def_con> val2 = ret.get().as<boost::optional<no_def_con>>();
+    msgpack::object_handle oh =
+        msgpack::unpack(ss.str().data(), ss.str().size());
+    boost::optional<no_def_con> val2 = oh.get().as<boost::optional<no_def_con>>();
     EXPECT_TRUE(val1 == val2);
 }
 

--- a/test/boost_string_ref.cpp
+++ b/test/boost_string_ref.cpp
@@ -18,9 +18,9 @@ TEST(MSGPACK_BOOST, pack_convert_string_ref)
 
     msgpack::pack(ss, val1);
 
-    msgpack::unpacked ret;
-    msgpack::unpack(ret, ss.str().data(), ss.str().size());
-    boost::string_ref val2 = ret.get().as<boost::string_ref>();
+    msgpack::object_handle oh;
+    msgpack::unpack(oh, ss.str().data(), ss.str().size());
+    boost::string_ref val2 = oh.get().as<boost::string_ref>();
     EXPECT_TRUE(val1 == val2);
 }
 

--- a/test/boost_variant.cpp
+++ b/test/boost_variant.cpp
@@ -21,9 +21,9 @@ TEST(MSGPACK_BOOST, pack_convert_variant_nil)
     EXPECT_TRUE(val1.is_nil());
     msgpack::pack(ss, val1);
 
-    msgpack::unpacked ret;
-    msgpack::unpack(ret, ss.str().data(), ss.str().size());
-    msgpack::type::variant val2 = ret.get().as<msgpack::type::variant>();
+    msgpack::object_handle oh =
+        msgpack::unpack(ss.str().data(), ss.str().size());
+    msgpack::type::variant val2 = oh.get().as<msgpack::type::variant>();
     EXPECT_TRUE(val2.is_nil());
     EXPECT_NO_THROW(boost::get<msgpack::type::nil_t>(val2));
 }
@@ -59,9 +59,9 @@ TEST(MSGPACK_BOOST, pack_convert_variant_nil_default)
 
     msgpack::pack(ss, val1);
 
-    msgpack::unpacked ret;
-    msgpack::unpack(ret, ss.str().data(), ss.str().size());
-    msgpack::type::variant val2 = ret.get().as<msgpack::type::variant>();
+    msgpack::object_handle oh =
+        msgpack::unpack(ss.str().data(), ss.str().size());
+    msgpack::type::variant val2 = oh.get().as<msgpack::type::variant>();
     EXPECT_TRUE(val2.is_nil());
     EXPECT_NO_THROW(boost::get<msgpack::type::nil_t>(val2));
 }
@@ -98,9 +98,9 @@ TEST(MSGPACK_BOOST, pack_convert_variant_bool)
 
     msgpack::pack(ss, val1);
 
-    msgpack::unpacked ret;
-    msgpack::unpack(ret, ss.str().data(), ss.str().size());
-    msgpack::type::variant val2 = ret.get().as<msgpack::type::variant>();
+    msgpack::object_handle oh =
+        msgpack::unpack(ss.str().data(), ss.str().size());
+    msgpack::type::variant val2 = oh.get().as<msgpack::type::variant>();
     EXPECT_TRUE(val2.is_bool());
     EXPECT_TRUE(val2.as_bool());
     EXPECT_NO_THROW(boost::get<bool>(val2));
@@ -151,9 +151,9 @@ TEST(MSGPACK_BOOST, pack_convert_variant_positive_integer)
 
     msgpack::pack(ss, val1);
 
-    msgpack::unpacked ret;
-    msgpack::unpack(ret, ss.str().data(), ss.str().size());
-    msgpack::type::variant val2 = ret.get().as<msgpack::type::variant>();
+    msgpack::object_handle oh =
+        msgpack::unpack(ss.str().data(), ss.str().size());
+    msgpack::type::variant val2 = oh.get().as<msgpack::type::variant>();
     EXPECT_TRUE(val2.is_uint64_t());
     EXPECT_EQ(val2.as_uint64_t(), 123U);
     EXPECT_NO_THROW(boost::get<uint64_t>(val2));
@@ -198,9 +198,9 @@ TEST(MSGPACK_BOOST, pack_convert_variant_negative_integer)
 
     msgpack::pack(ss, val1);
 
-    msgpack::unpacked ret;
-    msgpack::unpack(ret, ss.str().data(), ss.str().size());
-    msgpack::type::variant val2 = ret.get().as<msgpack::type::variant>();
+    msgpack::object_handle oh =
+        msgpack::unpack(ss.str().data(), ss.str().size());
+    msgpack::type::variant val2 = oh.get().as<msgpack::type::variant>();
     EXPECT_TRUE(val2.is_int64_t());
     EXPECT_EQ(val2.as_int64_t(), -123);
     EXPECT_NO_THROW(boost::get<int64_t>(val2));
@@ -245,9 +245,9 @@ TEST(MSGPACK_BOOST, pack_convert_variant_float)
 
     msgpack::pack(ss, val1);
 
-    msgpack::unpacked ret;
-    msgpack::unpack(ret, ss.str().data(), ss.str().size());
-    msgpack::type::variant val2 = ret.get().as<msgpack::type::variant>();
+    msgpack::object_handle oh =
+        msgpack::unpack(ss.str().data(), ss.str().size());
+    msgpack::type::variant val2 = oh.get().as<msgpack::type::variant>();
     EXPECT_TRUE(val2.is_double());
     EXPECT_TRUE(fabs(12.34 - val2.as_double()) <= kEPS);
     EXPECT_NO_THROW(boost::get<double>(val2));
@@ -292,9 +292,9 @@ TEST(MSGPACK_BOOST, pack_convert_variant_str)
 
     msgpack::pack(ss, val1);
 
-    msgpack::unpacked ret;
-    msgpack::unpack(ret, ss.str().data(), ss.str().size());
-    msgpack::type::variant val2 = ret.get().as<msgpack::type::variant>();
+    msgpack::object_handle oh =
+        msgpack::unpack(ss.str().data(), ss.str().size());
+    msgpack::type::variant val2 = oh.get().as<msgpack::type::variant>();
     EXPECT_TRUE(val2.is_string());
     EXPECT_EQ(val2.as_string(), "ABC");
     EXPECT_NO_THROW(boost::get<std::string>(val2));
@@ -354,9 +354,9 @@ TEST(MSGPACK_BOOST, pack_convert_variant_bin)
 
     msgpack::pack(ss, val1);
 
-    msgpack::unpacked ret;
-    msgpack::unpack(ret, ss.str().data(), ss.str().size());
-    msgpack::type::variant val2 = ret.get().as<msgpack::type::variant>();
+    msgpack::object_handle oh =
+        msgpack::unpack(ss.str().data(), ss.str().size());
+    msgpack::type::variant val2 = oh.get().as<msgpack::type::variant>();
     EXPECT_TRUE(val2.is_vector_char());
     EXPECT_EQ(val2.as_vector_char(), v);
     EXPECT_NO_THROW(boost::get<std::vector<char> >(val2));
@@ -425,9 +425,9 @@ TEST(MSGPACK_BOOST, pack_convert_variant_ext)
 
     msgpack::pack(ss, val1);
 
-    msgpack::unpacked ret;
-    msgpack::unpack(ret, ss.str().data(), ss.str().size());
-    msgpack::type::variant val2 = ret.get().as<msgpack::type::variant>();
+    msgpack::object_handle oh =
+        msgpack::unpack(ss.str().data(), ss.str().size());
+    msgpack::type::variant val2 = oh.get().as<msgpack::type::variant>();
     EXPECT_TRUE(val2.is_ext());
     EXPECT_EQ(val2.as_ext(), e);
     EXPECT_NO_THROW(boost::get<msgpack::type::ext>(val2));
@@ -492,9 +492,9 @@ TEST(MSGPACK_BOOST, pack_convert_variant_array)
 
     msgpack::pack(ss, val1);
 
-    msgpack::unpacked ret;
-    msgpack::unpack(ret, ss.str().data(), ss.str().size());
-    msgpack::type::variant val2 = ret.get().as<msgpack::type::variant>();
+    msgpack::object_handle oh =
+        msgpack::unpack(ss.str().data(), ss.str().size());
+    msgpack::type::variant val2 = oh.get().as<msgpack::type::variant>();
     EXPECT_TRUE(val2.is_vector());
     EXPECT_EQ(val2.as_vector(), v);
     EXPECT_NO_THROW(boost::get<std::vector<msgpack::type::variant> >(val2));
@@ -534,9 +534,9 @@ TEST(MSGPACK_BOOST, pack_convert_variant_map)
 
     msgpack::pack(ss, val1);
 
-    msgpack::unpacked ret;
-    msgpack::unpack(ret, ss.str().data(), ss.str().size());
-    msgpack::type::variant val2 = ret.get().as<msgpack::type::variant>();
+    msgpack::object_handle oh =
+        msgpack::unpack(ss.str().data(), ss.str().size());
+    msgpack::type::variant val2 = oh.get().as<msgpack::type::variant>();
     EXPECT_TRUE(val2.is_multimap());
     EXPECT_EQ(val2.as_multimap(), v);
     EXPECT_NO_THROW(boost::get<multimap_t>(val2));
@@ -578,9 +578,9 @@ TEST(MSGPACK_BOOST, pack_convert_variant_ref_str)
 
     msgpack::pack(ss, val1);
 
-    msgpack::unpacked ret;
-    msgpack::unpack(ret, ss.str().data(), ss.str().size());
-    msgpack::type::variant_ref val2 = ret.get().as<msgpack::type::variant_ref>();
+    msgpack::object_handle oh =
+        msgpack::unpack(ss.str().data(), ss.str().size());
+    msgpack::type::variant_ref val2 = oh.get().as<msgpack::type::variant_ref>();
     EXPECT_TRUE(val2.is_boost_string_ref());
     EXPECT_EQ(val2.as_boost_string_ref(), sr);
     EXPECT_NO_THROW(boost::get<boost::string_ref>(val2));
@@ -623,9 +623,9 @@ TEST(MSGPACK_BOOST, pack_convert_variant_ref_bin)
 
     msgpack::pack(ss, val1);
 
-    msgpack::unpacked ret;
-    msgpack::unpack(ret, ss.str().data(), ss.str().size());
-    msgpack::type::variant_ref val2 = ret.get().as<msgpack::type::variant_ref>();
+    msgpack::object_handle oh =
+        msgpack::unpack(ss.str().data(), ss.str().size());
+    msgpack::type::variant_ref val2 = oh.get().as<msgpack::type::variant_ref>();
     EXPECT_TRUE(val2.is_raw_ref());
     EXPECT_EQ(val2.as_raw_ref(), rr);
     EXPECT_NO_THROW(boost::get<msgpack::type::raw_ref>(val2));
@@ -670,9 +670,9 @@ TEST(MSGPACK_BOOST, pack_convert_variant_ref_ext)
 
     msgpack::pack(ss, val1);
 
-    msgpack::unpacked ret;
-    msgpack::unpack(ret, ss.str().data(), ss.str().size());
-    msgpack::type::variant_ref val2 = ret.get().as<msgpack::type::variant_ref>();
+    msgpack::object_handle oh =
+        msgpack::unpack(ss.str().data(), ss.str().size());
+    msgpack::type::variant_ref val2 = oh.get().as<msgpack::type::variant_ref>();
     EXPECT_NO_THROW(boost::get<msgpack::type::ext_ref>(val2));
     EXPECT_TRUE(val2.is_ext_ref());
     EXPECT_EQ(val2.as_ext_ref(), er);
@@ -720,9 +720,9 @@ TEST(MSGPACK_BOOST, pack_convert_variant_ref_array)
 
     msgpack::pack(ss, val1);
 
-    msgpack::unpacked ret;
-    msgpack::unpack(ret, ss.str().data(), ss.str().size());
-    msgpack::type::variant_ref val2 = ret.get().as<msgpack::type::variant_ref>();
+    msgpack::object_handle oh =
+        msgpack::unpack(ss.str().data(), ss.str().size());
+    msgpack::type::variant_ref val2 = oh.get().as<msgpack::type::variant_ref>();
     EXPECT_TRUE(val2.is_vector());
     EXPECT_EQ(val2.as_vector(), v);
     EXPECT_NO_THROW(boost::get<std::vector<msgpack::type::variant_ref> >(val2));
@@ -773,9 +773,9 @@ TEST(MSGPACK_BOOST, pack_convert_variant_ref_map)
 
     msgpack::pack(ss, val1);
 
-    msgpack::unpacked ret;
-    msgpack::unpack(ret, ss.str().data(), ss.str().size());
-    msgpack::type::variant_ref val2 = ret.get().as<msgpack::type::variant_ref>();
+    msgpack::object_handle oh =
+        msgpack::unpack(ss.str().data(), ss.str().size());
+    msgpack::type::variant_ref val2 = oh.get().as<msgpack::type::variant_ref>();
     EXPECT_TRUE(val2.is_multimap());
     EXPECT_EQ(val2.as_multimap(), v);
     EXPECT_NO_THROW(boost::get<multimap_t>(val2));

--- a/test/cases.cpp
+++ b/test/cases.cpp
@@ -26,12 +26,12 @@ TEST(cases, format)
     feed_file(pac, "cases.mpac");
     feed_file(pac_compact, "cases_compact.mpac");
 
-    msgpack::unpacked result;
-    while(pac.next(&result)) {
-        msgpack::unpacked result_compact;
-        EXPECT_TRUE( pac_compact.next(&result_compact) );
-        EXPECT_EQ(result_compact.get(), result.get());
+    msgpack::object_handle oh;
+    while(pac.next(&oh)) {
+        msgpack::object_handle oh_compact;
+        EXPECT_TRUE( pac_compact.next(&oh_compact) );
+        EXPECT_EQ(oh_compact.get(), oh.get());
     }
 
-    EXPECT_FALSE( pac_compact.next(&result) );
+    EXPECT_FALSE( pac_compact.next(&oh) );
 }

--- a/test/fixint.cpp
+++ b/test/fixint.cpp
@@ -29,15 +29,15 @@ void check_convert() {
     msgpack::sbuffer sbuf;
     msgpack::pack(sbuf, v1);
 
-    msgpack::unpacked msg;
-    msgpack::unpack(&msg, sbuf.data(), sbuf.size());
+    msgpack::object_handle oh =
+        msgpack::unpack(sbuf.data(), sbuf.size());
 
     T v2;
-    msg.get().convert(v2);
+    oh.get().convert(v2);
 
     EXPECT_EQ(v1.get(), v2.get());
 
-    EXPECT_EQ(msg.get(), msgpack::object(T(v1.get())));
+    EXPECT_EQ(oh.get(), msgpack::object(T(v1.get())));
 }
 
 TEST(fixint, convert)

--- a/test/iterator_cpp11.cpp
+++ b/test/iterator_cpp11.cpp
@@ -26,10 +26,10 @@ TEST(iterator, vector)
     msgpack::sbuffer sbuf;
     msgpack::pack(sbuf, vec);
 
-    msgpack::unpacked ret;
-    msgpack::unpack(ret, sbuf.data(), sbuf.size());
+    msgpack::object_handle oh =
+        msgpack::unpack(sbuf.data(), sbuf.size());
 
-    auto const& msgarr = ret.get().via.array;
+    auto const& msgarr = oh.get().via.array;
     auto dist = std::distance(begin(msgarr), end(msgarr));
     auto vecSize = vec.size();
     EXPECT_EQ(dist, vecSize);
@@ -52,10 +52,10 @@ TEST(iterator, map)
     msgpack::sbuffer sbuf;
     msgpack::pack(sbuf, map);
 
-    msgpack::unpacked ret;
-    msgpack::unpack(ret, sbuf.data(), sbuf.size());
+    msgpack::object_handle oh =
+        msgpack::unpack(sbuf.data(), sbuf.size());
 
-    auto const& msgmap = ret.get().via.map;
+    auto const& msgmap = oh.get().via.map;
     auto dist = std::distance(begin(msgmap), end(msgmap));
     auto mapSize = map.size();
     EXPECT_EQ(dist, mapSize);

--- a/test/limit.cpp
+++ b/test/limit.cpp
@@ -11,8 +11,8 @@ TEST(limit, unpack_array_no_over)
     v.push_back(3);
     msgpack::pack(ss, v);
     try {
-        msgpack::unpacked unp;
-        msgpack::unpack(unp, ss.str().c_str(), ss.str().size(), nullptr, nullptr,
+        msgpack::object_handle oh =
+            msgpack::unpack(ss.str().c_str(), ss.str().size(), nullptr, nullptr,
                         msgpack::unpack_limit(3, 0, 0, 0, 0));
         EXPECT_TRUE(true);
     }
@@ -33,8 +33,8 @@ TEST(limit, unpack_array_over)
     v.push_back(3);
     msgpack::pack(ss, v);
     try {
-        msgpack::unpacked unp;
-        msgpack::unpack(unp, ss.str().c_str(), ss.str().size(), nullptr, nullptr,
+        msgpack::object_handle oh =
+            msgpack::unpack(ss.str().c_str(), ss.str().size(), nullptr, nullptr,
                         msgpack::unpack_limit(2, 0, 0, 0, 0));
         EXPECT_TRUE(false);
     }
@@ -55,8 +55,8 @@ TEST(limit, unpack_map_no_over)
     m[3] = 3;
     msgpack::pack(ss, m);
     try {
-        msgpack::unpacked unp;
-        msgpack::unpack(unp, ss.str().c_str(), ss.str().size(), nullptr, nullptr,
+        msgpack::object_handle oh =
+            msgpack::unpack(ss.str().c_str(), ss.str().size(), nullptr, nullptr,
                         msgpack::unpack_limit(0, 3, 0, 0, 0));
         EXPECT_TRUE(true);
     }
@@ -77,8 +77,8 @@ TEST(limit, unpack_map_over)
     m[3] = 3;
     msgpack::pack(ss, m);
     try {
-        msgpack::unpacked unp;
-        msgpack::unpack(unp, ss.str().c_str(), ss.str().size(), nullptr, nullptr,
+        msgpack::object_handle oh =
+            msgpack::unpack(ss.str().c_str(), ss.str().size(), nullptr, nullptr,
                         msgpack::unpack_limit(0, 2, 0, 0, 0));
         EXPECT_TRUE(false);
     }
@@ -96,8 +96,8 @@ TEST(limit, unpack_str_no_over)
     std::string s("123");
     msgpack::pack(ss, s);
     try {
-        msgpack::unpacked unp;
-        msgpack::unpack(unp, ss.str().c_str(), ss.str().size(), nullptr, nullptr,
+        msgpack::object_handle oh =
+            msgpack::unpack(ss.str().c_str(), ss.str().size(), nullptr, nullptr,
                         msgpack::unpack_limit(0, 0, 3, 0, 0));
         EXPECT_TRUE(true);
     }
@@ -115,8 +115,8 @@ TEST(limit, unpack_str_over)
     std::string s("123");
     msgpack::pack(ss, s);
     try {
-        msgpack::unpacked unp;
-        msgpack::unpack(unp, ss.str().c_str(), ss.str().size(), nullptr, nullptr,
+        msgpack::object_handle oh =
+            msgpack::unpack(ss.str().c_str(), ss.str().size(), nullptr, nullptr,
                         msgpack::unpack_limit(0, 0, 2, 0, 0));
         EXPECT_TRUE(false);
     }
@@ -137,8 +137,8 @@ TEST(limit, unpack_bin_no_over)
     v.push_back('3');
     msgpack::pack(ss, v);
     try {
-        msgpack::unpacked unp;
-        msgpack::unpack(unp, ss.str().c_str(), ss.str().size(), nullptr, nullptr,
+        msgpack::object_handle oh =
+            msgpack::unpack(ss.str().c_str(), ss.str().size(), nullptr, nullptr,
                         msgpack::unpack_limit(0, 0, 0, 3, 0));
         EXPECT_TRUE(true);
     }
@@ -159,8 +159,8 @@ TEST(limit, unpack_bin_over)
     v.push_back('3');
     msgpack::pack(ss, v);
     try {
-        msgpack::unpacked unp;
-        msgpack::unpack(unp, ss.str().c_str(), ss.str().size(), nullptr, nullptr,
+        msgpack::object_handle oh =
+            msgpack::unpack(ss.str().c_str(), ss.str().size(), nullptr, nullptr,
                         msgpack::unpack_limit(0, 0, 0, 2, 0));
         EXPECT_TRUE(false);
     }
@@ -180,8 +180,8 @@ TEST(limit, unpack_ext_no_over)
     packer.pack_ext(sizeof(buf), 1);
     packer.pack_ext_body(buf, sizeof(buf));
     try {
-        msgpack::unpacked unp;
-        msgpack::unpack(unp, ss.str().c_str(), ss.str().size(), nullptr, nullptr,
+        msgpack::object_handle oh =
+            msgpack::unpack(ss.str().c_str(), ss.str().size(), nullptr, nullptr,
                         msgpack::unpack_limit(0, 0, 0, 0, 3+1));
         EXPECT_TRUE(true);
     }
@@ -201,8 +201,8 @@ TEST(limit, unpack_ext_over)
     packer.pack_ext(sizeof(buf), 1);
     packer.pack_ext_body(buf, sizeof(buf));
     try {
-        msgpack::unpacked unp;
-        msgpack::unpack(unp, ss.str().c_str(), ss.str().size(), nullptr, nullptr,
+        msgpack::object_handle oh =
+            msgpack::unpack(ss.str().c_str(), ss.str().size(), nullptr, nullptr,
                         msgpack::unpack_limit(0, 0, 0, 0, 2+1));
         EXPECT_TRUE(false);
     }
@@ -226,7 +226,7 @@ TEST(limit, unpack_ext_over_32_bit)
             static_cast<char>(0x01u),
         };
         try {
-            msgpack::unpacked unp;
+            msgpack::object_handle unp;
             msgpack::unpack(unp, buf, sizeof(buf), nullptr, nullptr,
                             msgpack::unpack_limit(0, 0, 0, 0, 0xffffffff));
             EXPECT_TRUE(false);
@@ -252,7 +252,7 @@ TEST(limit, unpack_ext_no_over_64_bit)
             static_cast<char>(0x01u),
         };
         try {
-            msgpack::unpacked unp;
+            msgpack::object_handle unp;
             msgpack::unpack(unp, buf, sizeof(buf), nullptr, nullptr,
                             msgpack::unpack_limit(0, 0, 0, 0, 0xffffffff));
             EXPECT_TRUE(false);
@@ -278,7 +278,7 @@ TEST(limit, unpack_depth_no_over)
     outer.push_back(inner);
     msgpack::pack(ss, outer);
     try {
-        msgpack::unpacked unp;
+        msgpack::object_handle unp;
         msgpack::unpack(unp, ss.str().c_str(), ss.str().size(), nullptr, nullptr,
                         msgpack::unpack_limit(1, 0, 0, 0, 0, 2));
         EXPECT_TRUE(true);
@@ -300,7 +300,7 @@ TEST(limit, unpack_depth_over)
     outer.push_back(inner);
     msgpack::pack(ss, outer);
     try {
-        msgpack::unpacked unp;
+        msgpack::object_handle unp;
         msgpack::unpack(unp, ss.str().c_str(), ss.str().size(), nullptr, nullptr,
                         msgpack::unpack_limit(1, 0, 0, 0, 0, 1));
         EXPECT_TRUE(false);
@@ -326,7 +326,7 @@ TEST(limit, unpack_array_over_cpp11_no_off_no_ref)
     v.push_back(3);
     msgpack::pack(ss, v);
     try {
-        msgpack::unpacked unp =
+        msgpack::object_handle unp =
             msgpack::unpack(ss.str().c_str(), ss.str().size(), nullptr, nullptr,
                             msgpack::unpack_limit(2, 0, 0, 0, 0));
         EXPECT_TRUE(false);
@@ -349,7 +349,7 @@ TEST(limit, unpack_array_over_cpp11_no_off_ref)
     msgpack::pack(ss, v);
     try {
         bool ref;
-        msgpack::unpacked unp =
+        msgpack::object_handle unp =
             msgpack::unpack(ss.str().c_str(), ss.str().size(), ref, nullptr, nullptr,
                             msgpack::unpack_limit(2, 0, 0, 0, 0));
         EXPECT_TRUE(false);
@@ -372,7 +372,7 @@ TEST(limit, unpack_array_over_cpp11_off_no_ref)
     msgpack::pack(ss, v);
     try {
         std::size_t off = 0;
-        msgpack::unpacked unp =
+        msgpack::object_handle unp =
             msgpack::unpack(ss.str().c_str(), ss.str().size(), off, nullptr, nullptr,
                             msgpack::unpack_limit(2, 0, 0, 0, 0));
         EXPECT_TRUE(false);
@@ -396,7 +396,7 @@ TEST(limit, unpack_array_over_cpp11_off_ref)
     try {
         bool ref;
         std::size_t off = 0;
-        msgpack::unpacked unp =
+        msgpack::object_handle unp =
             msgpack::unpack(ss.str().c_str(), ss.str().size(), off, ref, nullptr, nullptr,
                             msgpack::unpack_limit(2, 0, 0, 0, 0));
         EXPECT_TRUE(false);
@@ -420,7 +420,7 @@ TEST(limit, unpack_array_over_no_off_no_ref)
     v.push_back(3);
     msgpack::pack(ss, v);
     try {
-        msgpack::unpacked unp;
+        msgpack::object_handle unp;
         msgpack::unpack(unp, ss.str().c_str(), ss.str().size(), nullptr, nullptr,
                         msgpack::unpack_limit(2, 0, 0, 0, 0));
         EXPECT_TRUE(false);
@@ -443,7 +443,7 @@ TEST(limit, unpack_array_over_no_off_ref)
     msgpack::pack(ss, v);
     try {
         bool ref;
-        msgpack::unpacked unp;
+        msgpack::object_handle unp;
         msgpack::unpack(unp, ss.str().c_str(), ss.str().size(), ref, nullptr, nullptr,
                         msgpack::unpack_limit(2, 0, 0, 0, 0));
         EXPECT_TRUE(false);
@@ -466,7 +466,7 @@ TEST(limit, unpack_array_over_off_no_ref)
     msgpack::pack(ss, v);
     try {
         std::size_t off = 0;
-        msgpack::unpacked unp;
+        msgpack::object_handle unp;
         msgpack::unpack(unp, ss.str().c_str(), ss.str().size(), off, nullptr, nullptr,
                         msgpack::unpack_limit(2, 0, 0, 0, 0));
         EXPECT_TRUE(false);
@@ -490,7 +490,7 @@ TEST(limit, unpack_array_over_off_ref)
     try {
         bool ref;
         std::size_t off = 0;
-        msgpack::unpacked unp;
+        msgpack::object_handle unp;
         msgpack::unpack(unp, ss.str().c_str(), ss.str().size(), off, ref, nullptr, nullptr,
                         msgpack::unpack_limit(2, 0, 0, 0, 0));
         EXPECT_TRUE(false);
@@ -515,7 +515,7 @@ TEST(limit, unpack_array_over_off_ref_pointer)
     try {
         bool ref;
         std::size_t off = 0;
-        msgpack::unpacked unp;
+        msgpack::object_handle unp;
         msgpack::unpack(&unp, ss.str().c_str(), ss.str().size(), &off, &ref, nullptr, nullptr,
                         msgpack::unpack_limit(2, 0, 0, 0, 0));
         EXPECT_TRUE(false);
@@ -542,7 +542,7 @@ TEST(limit, unpacker_array_over)
         u.reserve_buffer(ss.str().size());
         memcpy(u.buffer(), ss.str().c_str(), ss.str().size());
         u.buffer_consumed(ss.str().size());
-        msgpack::unpacked unp;
+        msgpack::object_handle unp;
         u.next(unp);
         EXPECT_TRUE(false);
     }

--- a/test/msgpack_basic.cpp
+++ b/test/msgpack_basic.cpp
@@ -27,169 +27,169 @@ const unsigned int kLoop = 10000;
 const unsigned int kElements = 100;
 const double kEPS = 1e-10;
 
-#define GEN_TEST(test_type)                                           \
-  do {                                                                \
-    vector<test_type> v;                                              \
-    v.push_back(0);                                                   \
-    v.push_back(1);                                                   \
-    v.push_back(2);                                                   \
-    v.push_back(numeric_limits<test_type>::min());                    \
-    v.push_back(numeric_limits<test_type>::max());                    \
-    for (unsigned int i = 0; i < kLoop; i++)                          \
-      v.push_back(rand());                                            \
-    for (unsigned int i = 0; i < v.size() ; i++) {                    \
-      msgpack::sbuffer sbuf;                                          \
-      test_type val1 = v[i];                                          \
-      msgpack::pack(sbuf, val1);                                      \
-      msgpack::unpacked ret;                                          \
-      msgpack::unpack(ret, sbuf.data(), sbuf.size());                 \
-      EXPECT_EQ(val1, ret.get().as<test_type>());                     \
-    }                                                                 \
-} while(0)
+#define GEN_TEST(test_type)                                 \
+    do {                                                    \
+        vector<test_type> v;                                \
+        v.push_back(0);                                     \
+        v.push_back(1);                                     \
+        v.push_back(2);                                     \
+        v.push_back(numeric_limits<test_type>::min());      \
+        v.push_back(numeric_limits<test_type>::max());      \
+        for (unsigned int i = 0; i < kLoop; i++)            \
+            v.push_back(rand());                            \
+        for (unsigned int i = 0; i < v.size() ; i++) {      \
+            msgpack::sbuffer sbuf;                          \
+            test_type val1 = v[i];                          \
+            msgpack::pack(sbuf, val1);                      \
+            msgpack::object_handle oh =                     \
+                msgpack::unpack(sbuf.data(), sbuf.size());  \
+            EXPECT_EQ(val1, oh.get().as<test_type>());      \
+        }                                                   \
+    } while(0)
 
 TEST(MSGPACK, simple_buffer_char)
 {
-  GEN_TEST(char);
+    GEN_TEST(char);
 }
 
 TEST(MSGPACK, simple_buffer_signed_char)
 {
-  GEN_TEST(signed char);
+    GEN_TEST(signed char);
 }
 
 TEST(MSGPACK, simple_buffer_unsigned_char)
 {
-  GEN_TEST(unsigned char);
+    GEN_TEST(unsigned char);
 }
 
 
 TEST(MSGPACK, simple_buffer_short)
 {
-  GEN_TEST(short);
+    GEN_TEST(short);
 }
 
 TEST(MSGPACK, simple_buffer_int)
 {
-  GEN_TEST(int);
+    GEN_TEST(int);
 }
 
 TEST(MSGPACK, simple_buffer_long)
 {
-  GEN_TEST(long);
+    GEN_TEST(long);
 }
 
 TEST(MSGPACK, simple_buffer_long_long)
 {
-  GEN_TEST(long long);
+    GEN_TEST(long long);
 }
 
 TEST(MSGPACK, simple_buffer_unsigned_short)
 {
-  GEN_TEST(unsigned short);
+    GEN_TEST(unsigned short);
 }
 
 TEST(MSGPACK, simple_buffer_unsigned_int)
 {
-  GEN_TEST(unsigned int);
+    GEN_TEST(unsigned int);
 }
 
 TEST(MSGPACK, simple_buffer_unsigned_long)
 {
-  GEN_TEST(unsigned long);
+    GEN_TEST(unsigned long);
 }
 
 TEST(MSGPACK, simple_buffer_unsigned_long_long)
 {
-  GEN_TEST(unsigned long long);
+    GEN_TEST(unsigned long long);
 }
 
 TEST(MSGPACK, simple_buffer_uint8)
 {
-  GEN_TEST(uint8_t);
+    GEN_TEST(uint8_t);
 }
 
 TEST(MSGPACK, simple_buffer_uint16)
 {
-  GEN_TEST(uint16_t);
+    GEN_TEST(uint16_t);
 }
 
 TEST(MSGPACK, simple_buffer_uint32)
 {
-  GEN_TEST(uint32_t);
+    GEN_TEST(uint32_t);
 }
 
 TEST(MSGPACK, simple_buffer_uint64)
 {
-  GEN_TEST(uint64_t);
+    GEN_TEST(uint64_t);
 }
 
 TEST(MSGPACK, simple_buffer_int8)
 {
-  GEN_TEST(int8_t);
+    GEN_TEST(int8_t);
 }
 
 TEST(MSGPACK, simple_buffer_int16)
 {
-  GEN_TEST(int16_t);
+    GEN_TEST(int16_t);
 }
 
 TEST(MSGPACK, simple_buffer_int32)
 {
-  GEN_TEST(int32_t);
+    GEN_TEST(int32_t);
 }
 
 TEST(MSGPACK, simple_buffer_int64)
 {
-  GEN_TEST(int64_t);
+    GEN_TEST(int64_t);
 }
 
 TEST(MSGPACK, simple_buffer_float)
 {
-  vector<float> v;
-  v.push_back(0.0);
-  v.push_back(-0.0);
-  v.push_back(1.0);
-  v.push_back(-1.0);
-  v.push_back(numeric_limits<float>::min());
-  v.push_back(numeric_limits<float>::max());
-  v.push_back(nanf("tag"));
-  if (numeric_limits<float>::has_infinity) {
-    v.push_back(numeric_limits<float>::infinity());
-    v.push_back(-numeric_limits<float>::infinity());
-  }
-  if (numeric_limits<float>::has_quiet_NaN) {
-    v.push_back(numeric_limits<float>::quiet_NaN());
-  }
-  if (numeric_limits<float>::has_signaling_NaN) {
-    v.push_back(numeric_limits<float>::signaling_NaN());
-  }
+    vector<float> v;
+    v.push_back(0.0);
+    v.push_back(-0.0);
+    v.push_back(1.0);
+    v.push_back(-1.0);
+    v.push_back(numeric_limits<float>::min());
+    v.push_back(numeric_limits<float>::max());
+    v.push_back(nanf("tag"));
+    if (numeric_limits<float>::has_infinity) {
+        v.push_back(numeric_limits<float>::infinity());
+        v.push_back(-numeric_limits<float>::infinity());
+    }
+    if (numeric_limits<float>::has_quiet_NaN) {
+        v.push_back(numeric_limits<float>::quiet_NaN());
+    }
+    if (numeric_limits<float>::has_signaling_NaN) {
+        v.push_back(numeric_limits<float>::signaling_NaN());
+    }
 
-  for (unsigned int i = 0; i < kLoop; i++) {
-    v.push_back(static_cast<float>(msgpack_rand()));
-    v.push_back(static_cast<float>(-msgpack_rand()));
-  }
-  for (unsigned int i = 0; i < v.size() ; i++) {
-    msgpack::sbuffer sbuf;
-    float val1 = v[i];
-    msgpack::pack(sbuf, val1);
-    msgpack::unpacked ret;
-    msgpack::unpack(ret, sbuf.data(), sbuf.size());
-    float val2 = ret.get().as<float>();
+    for (unsigned int i = 0; i < kLoop; i++) {
+        v.push_back(static_cast<float>(msgpack_rand()));
+        v.push_back(static_cast<float>(-msgpack_rand()));
+    }
+    for (unsigned int i = 0; i < v.size() ; i++) {
+        msgpack::sbuffer sbuf;
+        float val1 = v[i];
+        msgpack::pack(sbuf, val1);
+        msgpack::object_handle oh =
+            msgpack::unpack(sbuf.data(), sbuf.size());
+        float val2 = oh.get().as<float>();
 
-    if (std::isnan(val1))
-      EXPECT_TRUE(std::isnan(val2));
-    else if (std::isinf(val1))
-      EXPECT_TRUE(std::isinf(val2));
-    else
-      EXPECT_TRUE(fabs(val2 - val1) <= kEPS);
-  }
+        if (std::isnan(val1))
+            EXPECT_TRUE(std::isnan(val2));
+        else if (std::isinf(val1))
+            EXPECT_TRUE(std::isinf(val2));
+        else
+            EXPECT_TRUE(fabs(val2 - val1) <= kEPS);
+    }
 }
 
 namespace {
 template<typename F, typename I>
 struct TypePair {
-  typedef F float_type;
-  typedef I integer_type;
+    typedef F float_type;
+    typedef I integer_type;
 };
 } // namespace
 
@@ -200,25 +200,25 @@ TYPED_TEST_CASE_P(IntegerToFloatingPointTest);
 
 TYPED_TEST_P(IntegerToFloatingPointTest, simple_buffer)
 {
-  typedef typename TypeParam::float_type float_type;
-  typedef typename TypeParam::integer_type integer_type;
-  vector<integer_type> v;
-  v.push_back(0);
-  v.push_back(1);
-  if (numeric_limits<integer_type>::is_signed) v.push_back(-1);
-  else v.push_back(2);
-  for (unsigned int i = 0; i < kLoop; i++) {
-    v.push_back(rand() % 0x7FFFFF);
-  }
-  for (unsigned int i = 0; i < v.size() ; i++) {
-    msgpack::sbuffer sbuf;
-    integer_type val1 = v[i];
-    msgpack::pack(sbuf, val1);
-    msgpack::unpacked ret;
-    msgpack::unpack(ret, sbuf.data(), sbuf.size());
-    float_type val2 = ret.get().as<float_type>();
-    EXPECT_TRUE(fabs(val2 - val1) <= kEPS);
-  }
+    typedef typename TypeParam::float_type float_type;
+    typedef typename TypeParam::integer_type integer_type;
+    vector<integer_type> v;
+    v.push_back(0);
+    v.push_back(1);
+    if (numeric_limits<integer_type>::is_signed) v.push_back(-1);
+    else v.push_back(2);
+    for (unsigned int i = 0; i < kLoop; i++) {
+        v.push_back(rand() % 0x7FFFFF);
+    }
+    for (unsigned int i = 0; i < v.size() ; i++) {
+        msgpack::sbuffer sbuf;
+        integer_type val1 = v[i];
+        msgpack::pack(sbuf, val1);
+        msgpack::object_handle oh =
+            msgpack::unpack(sbuf.data(), sbuf.size());
+        float_type val2 = oh.get().as<float_type>();
+        EXPECT_TRUE(fabs(val2 - val1) <= kEPS);
+    }
 }
 
 REGISTER_TYPED_TEST_CASE_P(IntegerToFloatingPointTest,
@@ -234,375 +234,375 @@ INSTANTIATE_TYPED_TEST_CASE_P(IntegerToFloatingPointTestInstance,
 
 TEST(MSGPACK, simple_buffer_double)
 {
-  vector<double> v;
-  v.push_back(0.0);
-  v.push_back(-0.0);
-  v.push_back(1.0);
-  v.push_back(-1.0);
-  v.push_back(numeric_limits<double>::min());
-  v.push_back(numeric_limits<double>::max());
-  v.push_back(nanf("tag"));
-  if (numeric_limits<double>::has_infinity) {
-    v.push_back(numeric_limits<double>::infinity());
-    v.push_back(-numeric_limits<double>::infinity());
-  }
-  if (numeric_limits<double>::has_quiet_NaN) {
-    v.push_back(numeric_limits<double>::quiet_NaN());
-  }
-  if (numeric_limits<double>::has_signaling_NaN) {
-    v.push_back(numeric_limits<double>::signaling_NaN());
-  }
-  for (unsigned int i = 0; i < kLoop; i++) {
-    v.push_back(msgpack_rand());
-    v.push_back(-msgpack_rand());
-  }
+    vector<double> v;
+    v.push_back(0.0);
+    v.push_back(-0.0);
+    v.push_back(1.0);
+    v.push_back(-1.0);
+    v.push_back(numeric_limits<double>::min());
+    v.push_back(numeric_limits<double>::max());
+    v.push_back(nanf("tag"));
+    if (numeric_limits<double>::has_infinity) {
+        v.push_back(numeric_limits<double>::infinity());
+        v.push_back(-numeric_limits<double>::infinity());
+    }
+    if (numeric_limits<double>::has_quiet_NaN) {
+        v.push_back(numeric_limits<double>::quiet_NaN());
+    }
+    if (numeric_limits<double>::has_signaling_NaN) {
+        v.push_back(numeric_limits<double>::signaling_NaN());
+    }
+    for (unsigned int i = 0; i < kLoop; i++) {
+        v.push_back(msgpack_rand());
+        v.push_back(-msgpack_rand());
+    }
 
-  for (unsigned int i = 0; i < kLoop; i++) {
-    v.push_back(msgpack_rand());
-    v.push_back(-msgpack_rand());
-  }
-  for (unsigned int i = 0; i < v.size() ; i++) {
-    msgpack::sbuffer sbuf;
-    double val1 = v[i];
-    msgpack::pack(sbuf, val1);
-    msgpack::unpacked ret;
-    msgpack::unpack(ret, sbuf.data(), sbuf.size());
-    double val2 = ret.get().as<double>();
+    for (unsigned int i = 0; i < kLoop; i++) {
+        v.push_back(msgpack_rand());
+        v.push_back(-msgpack_rand());
+    }
+    for (unsigned int i = 0; i < v.size() ; i++) {
+        msgpack::sbuffer sbuf;
+        double val1 = v[i];
+        msgpack::pack(sbuf, val1);
+        msgpack::object_handle oh =
+            msgpack::unpack(sbuf.data(), sbuf.size());
+        double val2 = oh.get().as<double>();
 
-    if (std::isnan(val1))
-      EXPECT_TRUE(std::isnan(val2));
-    else if (std::isinf(val1))
-      EXPECT_TRUE(std::isinf(val2));
-    else
-      EXPECT_TRUE(fabs(val2 - val1) <= kEPS);
-  }
+        if (std::isnan(val1))
+            EXPECT_TRUE(std::isnan(val2));
+        else if (std::isinf(val1))
+            EXPECT_TRUE(std::isinf(val2));
+        else
+            EXPECT_TRUE(fabs(val2 - val1) <= kEPS);
+    }
 }
 
 TEST(MSGPACK, simple_buffer_nil)
 {
-  msgpack::sbuffer sbuf;
-  msgpack::packer<msgpack::sbuffer> packer(sbuf);
-  packer.pack_nil();
-  msgpack::unpacked ret;
-  msgpack::unpack(ret, sbuf.data(), sbuf.size());
-  EXPECT_EQ(ret.get().type, msgpack::type::NIL);
+    msgpack::sbuffer sbuf;
+    msgpack::packer<msgpack::sbuffer> packer(sbuf);
+    packer.pack_nil();
+    msgpack::object_handle oh =
+        msgpack::unpack(sbuf.data(), sbuf.size());
+    EXPECT_EQ(oh.get().type, msgpack::type::NIL);
 }
 
 TEST(MSGPACK, simple_buffer_true)
 {
-  msgpack::sbuffer sbuf;
-  bool val1 = true;
-  msgpack::pack(sbuf, val1);
-  msgpack::unpacked ret;
-  msgpack::unpack(ret, sbuf.data(), sbuf.size());
-  bool val2 = ret.get().as<bool>();
-  EXPECT_EQ(val1, val2);
+    msgpack::sbuffer sbuf;
+    bool val1 = true;
+    msgpack::pack(sbuf, val1);
+    msgpack::object_handle oh =
+        msgpack::unpack(sbuf.data(), sbuf.size());
+    bool val2 = oh.get().as<bool>();
+    EXPECT_EQ(val1, val2);
 }
 
 TEST(MSGPACK, simple_buffer_false)
 {
-  msgpack::sbuffer sbuf;
-  bool val1 = false;
-  msgpack::pack(sbuf, val1);
-  msgpack::unpacked ret;
-  msgpack::unpack(ret, sbuf.data(), sbuf.size());
-  bool val2 = ret.get().as<bool>();
-  EXPECT_EQ(val1, val2);
+    msgpack::sbuffer sbuf;
+    bool val1 = false;
+    msgpack::pack(sbuf, val1);
+    msgpack::object_handle oh =
+        msgpack::unpack(sbuf.data(), sbuf.size());
+    bool val2 = oh.get().as<bool>();
+    EXPECT_EQ(val1, val2);
 }
 
 TEST(MSGPACK, simple_buffer_fixext1)
 {
-  msgpack::sbuffer sbuf;
-  msgpack::packer<msgpack::sbuffer> packer(sbuf);
-  char const buf [] = { 2 };
+    msgpack::sbuffer sbuf;
+    msgpack::packer<msgpack::sbuffer> packer(sbuf);
+    char const buf [] = { 2 };
 
-  packer.pack_ext(sizeof(buf), 1);
-  packer.pack_ext_body(buf, sizeof(buf));
-  msgpack::unpacked ret;
-  msgpack::unpack(ret, sbuf.data(), sbuf.size());
-  EXPECT_EQ(1ul, ret.get().via.ext.size);
-  EXPECT_EQ(1, ret.get().via.ext.type());
-  EXPECT_EQ(2, ret.get().via.ext.data()[0]);
+    packer.pack_ext(sizeof(buf), 1);
+    packer.pack_ext_body(buf, sizeof(buf));
+    msgpack::object_handle oh =
+        msgpack::unpack(sbuf.data(), sbuf.size());
+    EXPECT_EQ(1ul, oh.get().via.ext.size);
+    EXPECT_EQ(1, oh.get().via.ext.type());
+    EXPECT_EQ(2, oh.get().via.ext.data()[0]);
 }
 
 TEST(MSGPACK, simple_buffer_fixext2)
 {
-  msgpack::sbuffer sbuf;
-  msgpack::packer<msgpack::sbuffer> packer(sbuf);
-  char const buf [] = { 2, 3 };
+    msgpack::sbuffer sbuf;
+    msgpack::packer<msgpack::sbuffer> packer(sbuf);
+    char const buf [] = { 2, 3 };
 
-  packer.pack_ext(sizeof(buf), 0);
-  packer.pack_ext_body(buf, sizeof(buf));
-  msgpack::unpacked ret;
-  msgpack::unpack(ret, sbuf.data(), sbuf.size());
-  EXPECT_EQ(2ul, ret.get().via.ext.size);
-  EXPECT_EQ(0, ret.get().via.ext.type());
-  EXPECT_TRUE(
-      std::equal(buf, buf + sizeof(buf), ret.get().via.ext.data()));
+    packer.pack_ext(sizeof(buf), 0);
+    packer.pack_ext_body(buf, sizeof(buf));
+    msgpack::object_handle oh =
+        msgpack::unpack(sbuf.data(), sbuf.size());
+    EXPECT_EQ(2ul, oh.get().via.ext.size);
+    EXPECT_EQ(0, oh.get().via.ext.type());
+    EXPECT_TRUE(
+        std::equal(buf, buf + sizeof(buf), oh.get().via.ext.data()));
 }
 
 TEST(MSGPACK, simple_buffer_fixext4)
 {
-  msgpack::sbuffer sbuf;
-  msgpack::packer<msgpack::sbuffer> packer(sbuf);
-  char const buf [] = { 2, 3, 4, 5 };
+    msgpack::sbuffer sbuf;
+    msgpack::packer<msgpack::sbuffer> packer(sbuf);
+    char const buf [] = { 2, 3, 4, 5 };
 
-  packer.pack_ext(sizeof(buf), 1);
-  packer.pack_ext_body(buf, sizeof(buf));
-  msgpack::unpacked ret;
-  msgpack::unpack(ret, sbuf.data(), sbuf.size());
-  EXPECT_EQ(4ul, ret.get().via.ext.size);
-  EXPECT_EQ(1, ret.get().via.ext.type());
-  EXPECT_TRUE(
-      std::equal(buf, buf + sizeof(buf), ret.get().via.ext.data()));
+    packer.pack_ext(sizeof(buf), 1);
+    packer.pack_ext_body(buf, sizeof(buf));
+    msgpack::object_handle oh =
+        msgpack::unpack(sbuf.data(), sbuf.size());
+    EXPECT_EQ(4ul, oh.get().via.ext.size);
+    EXPECT_EQ(1, oh.get().via.ext.type());
+    EXPECT_TRUE(
+        std::equal(buf, buf + sizeof(buf), oh.get().via.ext.data()));
 }
 
 TEST(MSGPACK, simple_buffer_fixext8)
 {
-  msgpack::sbuffer sbuf;
-  msgpack::packer<msgpack::sbuffer> packer(sbuf);
-  char const buf [] = { 2, 3, 4, 5, 6, 7, 8, 9 };
+    msgpack::sbuffer sbuf;
+    msgpack::packer<msgpack::sbuffer> packer(sbuf);
+    char const buf [] = { 2, 3, 4, 5, 6, 7, 8, 9 };
 
-  packer.pack_ext(sizeof(buf), 1);
-  packer.pack_ext_body(buf, sizeof(buf));
-  msgpack::unpacked ret;
-  msgpack::unpack(ret, sbuf.data(), sbuf.size());
-  EXPECT_EQ(8ul, ret.get().via.ext.size);
-  EXPECT_EQ(1, ret.get().via.ext.type());
-  EXPECT_TRUE(
-      std::equal(buf, buf + sizeof(buf), ret.get().via.ext.data()));
+    packer.pack_ext(sizeof(buf), 1);
+    packer.pack_ext_body(buf, sizeof(buf));
+    msgpack::object_handle oh =
+        msgpack::unpack(sbuf.data(), sbuf.size());
+    EXPECT_EQ(8ul, oh.get().via.ext.size);
+    EXPECT_EQ(1, oh.get().via.ext.type());
+    EXPECT_TRUE(
+        std::equal(buf, buf + sizeof(buf), oh.get().via.ext.data()));
 }
 
 TEST(MSGPACK, simple_buffer_fixext16)
 {
-  msgpack::sbuffer sbuf;
-  msgpack::packer<msgpack::sbuffer> packer(sbuf);
-  char const buf [] = { 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17 };
+    msgpack::sbuffer sbuf;
+    msgpack::packer<msgpack::sbuffer> packer(sbuf);
+    char const buf [] = { 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17 };
 
-  packer.pack_ext(sizeof(buf), 1);
-  packer.pack_ext_body(buf, sizeof(buf));
-  msgpack::unpacked ret;
-  msgpack::unpack(ret, sbuf.data(), sbuf.size());
-  EXPECT_EQ(16ul, ret.get().via.ext.size);
-  EXPECT_EQ(1, ret.get().via.ext.type());
-  EXPECT_TRUE(
-      std::equal(buf, buf + sizeof(buf), ret.get().via.ext.data()));
+    packer.pack_ext(sizeof(buf), 1);
+    packer.pack_ext_body(buf, sizeof(buf));
+    msgpack::object_handle oh =
+        msgpack::unpack(sbuf.data(), sbuf.size());
+    EXPECT_EQ(16ul, oh.get().via.ext.size);
+    EXPECT_EQ(1, oh.get().via.ext.type());
+    EXPECT_TRUE(
+        std::equal(buf, buf + sizeof(buf), oh.get().via.ext.data()));
 }
 
 TEST(MSGPACK, simple_buffer_fixext_1byte_0)
 {
-  std::size_t const size = 0;
-  msgpack::sbuffer sbuf;
-  msgpack::packer<msgpack::sbuffer> packer(sbuf);
+    std::size_t const size = 0;
+    msgpack::sbuffer sbuf;
+    msgpack::packer<msgpack::sbuffer> packer(sbuf);
 
-  packer.pack_ext(size, 77);
-  msgpack::unpacked ret;
-  msgpack::unpack(ret, sbuf.data(), sbuf.size());
-  EXPECT_EQ(size, ret.get().via.ext.size);
-  EXPECT_EQ(77, ret.get().via.ext.type());
+    packer.pack_ext(size, 77);
+    msgpack::object_handle oh =
+        msgpack::unpack(sbuf.data(), sbuf.size());
+    EXPECT_EQ(size, oh.get().via.ext.size);
+    EXPECT_EQ(77, oh.get().via.ext.type());
 }
 
 TEST(MSGPACK, simple_buffer_fixext_1byte_255)
 {
-  std::size_t const size = 255;
-  msgpack::sbuffer sbuf;
-  msgpack::packer<msgpack::sbuffer> packer(sbuf);
-  char buf[size];
-  for (std::size_t i = 0; i != size; ++i) buf[i] = static_cast<char>(i);
-  packer.pack_ext(sizeof(buf), 77);
-  packer.pack_ext_body(buf, sizeof(buf));
+    std::size_t const size = 255;
+    msgpack::sbuffer sbuf;
+    msgpack::packer<msgpack::sbuffer> packer(sbuf);
+    char buf[size];
+    for (std::size_t i = 0; i != size; ++i) buf[i] = static_cast<char>(i);
+    packer.pack_ext(sizeof(buf), 77);
+    packer.pack_ext_body(buf, sizeof(buf));
 
-  msgpack::unpacked ret;
-  msgpack::unpack(ret, sbuf.data(), sbuf.size());
-  EXPECT_EQ(size, ret.get().via.ext.size);
-  EXPECT_EQ(77, ret.get().via.ext.type());
-  EXPECT_TRUE(
-      std::equal(buf, buf + sizeof(buf), ret.get().via.ext.data()));
+    msgpack::object_handle oh =
+        msgpack::unpack(sbuf.data(), sbuf.size());
+    EXPECT_EQ(size, oh.get().via.ext.size);
+    EXPECT_EQ(77, oh.get().via.ext.type());
+    EXPECT_TRUE(
+        std::equal(buf, buf + sizeof(buf), oh.get().via.ext.data()));
 }
 
 TEST(MSGPACK, simple_buffer_fixext_2byte_256)
 {
-  std::size_t const size = 256;
-  msgpack::sbuffer sbuf;
-  msgpack::packer<msgpack::sbuffer> packer(sbuf);
-  char buf[size];
-  for (std::size_t i = 0; i != size; ++i) buf[i] = static_cast<char>(i);
-  packer.pack_ext(sizeof(buf), 77);
-  packer.pack_ext_body(buf, sizeof(buf));
+    std::size_t const size = 256;
+    msgpack::sbuffer sbuf;
+    msgpack::packer<msgpack::sbuffer> packer(sbuf);
+    char buf[size];
+    for (std::size_t i = 0; i != size; ++i) buf[i] = static_cast<char>(i);
+    packer.pack_ext(sizeof(buf), 77);
+    packer.pack_ext_body(buf, sizeof(buf));
 
-  msgpack::unpacked ret;
-  msgpack::unpack(ret, sbuf.data(), sbuf.size());
-  EXPECT_EQ(size, ret.get().via.ext.size);
-  EXPECT_EQ(77, ret.get().via.ext.type());
-  EXPECT_TRUE(
-      std::equal(buf, buf + sizeof(buf), ret.get().via.ext.data()));
+    msgpack::object_handle oh =
+        msgpack::unpack(sbuf.data(), sbuf.size());
+    EXPECT_EQ(size, oh.get().via.ext.size);
+    EXPECT_EQ(77, oh.get().via.ext.type());
+    EXPECT_TRUE(
+        std::equal(buf, buf + sizeof(buf), oh.get().via.ext.data()));
 }
 
 TEST(MSGPACK, simple_buffer_fixext_2byte_65535)
 {
-  std::size_t const size = 65535;
-  msgpack::sbuffer sbuf;
-  msgpack::packer<msgpack::sbuffer> packer(sbuf);
-  char buf[size];
-  for (std::size_t i = 0; i != size; ++i) buf[i] = static_cast<char>(i);
-  packer.pack_ext(sizeof(buf), 77);
-  packer.pack_ext_body(buf, sizeof(buf));
+    std::size_t const size = 65535;
+    msgpack::sbuffer sbuf;
+    msgpack::packer<msgpack::sbuffer> packer(sbuf);
+    char buf[size];
+    for (std::size_t i = 0; i != size; ++i) buf[i] = static_cast<char>(i);
+    packer.pack_ext(sizeof(buf), 77);
+    packer.pack_ext_body(buf, sizeof(buf));
 
-  msgpack::unpacked ret;
-  msgpack::unpack(ret, sbuf.data(), sbuf.size());
-  EXPECT_EQ(size, ret.get().via.ext.size);
-  EXPECT_EQ(77, ret.get().via.ext.type());
-  EXPECT_TRUE(
-      std::equal(buf, buf + sizeof(buf), ret.get().via.ext.data()));
+    msgpack::object_handle oh =
+        msgpack::unpack(sbuf.data(), sbuf.size());
+    EXPECT_EQ(size, oh.get().via.ext.size);
+    EXPECT_EQ(77, oh.get().via.ext.type());
+    EXPECT_TRUE(
+        std::equal(buf, buf + sizeof(buf), oh.get().via.ext.data()));
 }
 
 TEST(MSGPACK, simple_buffer_fixext_4byte_65536)
 {
-  std::size_t const size = 65536;
-  msgpack::sbuffer sbuf;
-  msgpack::packer<msgpack::sbuffer> packer(sbuf);
-  char buf[size];
-  for (std::size_t i = 0; i != size; ++i) buf[i] = static_cast<char>(i);
-  packer.pack_ext(sizeof(buf), 77);
-  packer.pack_ext_body(buf, sizeof(buf));
+    std::size_t const size = 65536;
+    msgpack::sbuffer sbuf;
+    msgpack::packer<msgpack::sbuffer> packer(sbuf);
+    char buf[size];
+    for (std::size_t i = 0; i != size; ++i) buf[i] = static_cast<char>(i);
+    packer.pack_ext(sizeof(buf), 77);
+    packer.pack_ext_body(buf, sizeof(buf));
 
-  msgpack::unpacked ret;
-  msgpack::unpack(ret, sbuf.data(), sbuf.size());
-  EXPECT_EQ(size, ret.get().via.ext.size);
-  EXPECT_EQ(77, ret.get().via.ext.type());
-  EXPECT_TRUE(
-      std::equal(buf, buf + sizeof(buf), ret.get().via.ext.data()));
+    msgpack::object_handle oh =
+        msgpack::unpack(sbuf.data(), sbuf.size());
+    EXPECT_EQ(size, oh.get().via.ext.size);
+    EXPECT_EQ(77, oh.get().via.ext.type());
+    EXPECT_TRUE(
+        std::equal(buf, buf + sizeof(buf), oh.get().via.ext.data()));
 }
 
 TEST(MSGPACK, simple_buffer_ext_convert)
 {
-  std::size_t const size = 65536;
-  msgpack::sbuffer sbuf;
-  msgpack::packer<msgpack::sbuffer> packer(sbuf);
-  char buf[size];
-  for (std::size_t i = 0; i != size; ++i) buf[i] = static_cast<char>(i);
-  packer.pack_ext(sizeof(buf), 77);
-  packer.pack_ext_body(buf, sizeof(buf));
+    std::size_t const size = 65536;
+    msgpack::sbuffer sbuf;
+    msgpack::packer<msgpack::sbuffer> packer(sbuf);
+    char buf[size];
+    for (std::size_t i = 0; i != size; ++i) buf[i] = static_cast<char>(i);
+    packer.pack_ext(sizeof(buf), 77);
+    packer.pack_ext_body(buf, sizeof(buf));
 
-  msgpack::unpacked ret;
-  msgpack::unpack(ret, sbuf.data(), sbuf.size());
-  msgpack::type::ext e;
-  ret.get().convert(e);
-  EXPECT_EQ(size, e.size());
-  EXPECT_EQ(77, e.type());
-  EXPECT_TRUE(
-      std::equal(buf, buf + sizeof(buf), e.data()));
+    msgpack::object_handle oh =
+        msgpack::unpack(sbuf.data(), sbuf.size());
+    msgpack::type::ext e;
+    oh.get().convert(e);
+    EXPECT_EQ(size, e.size());
+    EXPECT_EQ(77, e.type());
+    EXPECT_TRUE(
+        std::equal(buf, buf + sizeof(buf), e.data()));
 }
 
 TEST(MSGPACK, simple_buffer_ext_pack_convert)
 {
-  std::size_t const size = 65536;
-  msgpack::sbuffer sbuf;
-  msgpack::type::ext val1(77, size);
-  char* buf = val1.data();
-  for (std::size_t i = 0; i != size; ++i) buf[i] = static_cast<char>(i);
-  msgpack::pack(sbuf, val1);
+    std::size_t const size = 65536;
+    msgpack::sbuffer sbuf;
+    msgpack::type::ext val1(77, size);
+    char* buf = val1.data();
+    for (std::size_t i = 0; i != size; ++i) buf[i] = static_cast<char>(i);
+    msgpack::pack(sbuf, val1);
 
-  msgpack::unpacked ret;
-  msgpack::unpack(ret, sbuf.data(), sbuf.size());
-  msgpack::type::ext val2;
-  ret.get().convert(val2);
-  EXPECT_EQ(size, val2.size());
-  EXPECT_EQ(77, val2.type());
-  EXPECT_TRUE(
-      std::equal(buf, buf + sizeof(buf), val2.data()));
+    msgpack::object_handle oh =
+        msgpack::unpack(sbuf.data(), sbuf.size());
+    msgpack::type::ext val2;
+    oh.get().convert(val2);
+    EXPECT_EQ(size, val2.size());
+    EXPECT_EQ(77, val2.type());
+    EXPECT_TRUE(
+        std::equal(buf, buf + sizeof(buf), val2.data()));
 }
 
 TEST(MSGPACK, simple_buffer_ext_ref_convert)
 {
-  std::size_t const size = 65536;
-  msgpack::sbuffer sbuf;
-  msgpack::packer<msgpack::sbuffer> packer(sbuf);
-  char buf[size];
-  for (std::size_t i = 0; i != size; ++i) buf[i] = static_cast<char>(i);
-  packer.pack_ext(sizeof(buf), 77);
-  packer.pack_ext_body(buf, sizeof(buf));
+    std::size_t const size = 65536;
+    msgpack::sbuffer sbuf;
+    msgpack::packer<msgpack::sbuffer> packer(sbuf);
+    char buf[size];
+    for (std::size_t i = 0; i != size; ++i) buf[i] = static_cast<char>(i);
+    packer.pack_ext(sizeof(buf), 77);
+    packer.pack_ext_body(buf, sizeof(buf));
 
-  msgpack::unpacked ret;
-  msgpack::unpack(ret, sbuf.data(), sbuf.size());
-  msgpack::type::ext_ref er;
-  ret.get().convert(er);
-  EXPECT_EQ(size, er.size());
-  EXPECT_EQ(77, er.type());
-  EXPECT_TRUE(
-      std::equal(buf, buf + sizeof(buf), er.data()));
+    msgpack::object_handle oh =
+        msgpack::unpack(sbuf.data(), sbuf.size());
+    msgpack::type::ext_ref er;
+    oh.get().convert(er);
+    EXPECT_EQ(size, er.size());
+    EXPECT_EQ(77, er.type());
+    EXPECT_TRUE(
+        std::equal(buf, buf + sizeof(buf), er.data()));
 }
 
 TEST(MSGPACK, simple_buffer_ext_ref_pack_convert)
 {
-  std::size_t const buf_size = 65536;
-  std::size_t const data_size = buf_size - 1;
-  msgpack::sbuffer sbuf;
-  char buf[buf_size];
-  buf[0] = static_cast<char>(77);
-  for (std::size_t i = 0; i != data_size; ++i) buf[i + 1] = static_cast<char>(i);
-  msgpack::pack(sbuf, msgpack::type::ext_ref(buf, buf_size));
+    std::size_t const buf_size = 65536;
+    std::size_t const data_size = buf_size - 1;
+    msgpack::sbuffer sbuf;
+    char buf[buf_size];
+    buf[0] = static_cast<char>(77);
+    for (std::size_t i = 0; i != data_size; ++i) buf[i + 1] = static_cast<char>(i);
+    msgpack::pack(sbuf, msgpack::type::ext_ref(buf, buf_size));
 
-  msgpack::unpacked ret;
-  msgpack::unpack(ret, sbuf.data(), sbuf.size());
-  msgpack::type::ext_ref val2;
-  ret.get().convert(val2);
-  EXPECT_EQ(data_size, val2.size());
-  EXPECT_EQ(77, val2.type());
-  EXPECT_TRUE(
-      std::equal(&buf[1], &buf[buf_size], val2.data()));
+    msgpack::object_handle oh =
+        msgpack::unpack(sbuf.data(), sbuf.size());
+    msgpack::type::ext_ref val2;
+    oh.get().convert(val2);
+    EXPECT_EQ(data_size, val2.size());
+    EXPECT_EQ(77, val2.type());
+    EXPECT_TRUE(
+        std::equal(&buf[1], &buf[buf_size], val2.data()));
 }
 
 TEST(MSGPACK_STL, simple_buffer_string)
 {
-  for (unsigned int k = 0; k < kLoop; k++) {
-    string val1;
-    for (unsigned int i = 0; i < kElements; i++)
-      val1 += 'a' + rand() % 26;
-    msgpack::sbuffer sbuf;
-    msgpack::pack(sbuf, val1);
-    msgpack::unpacked ret;
-    msgpack::unpack(ret, sbuf.data(), sbuf.size());
-    EXPECT_EQ(ret.get().type, msgpack::type::STR);
-    string val2 = ret.get().as<string>();
-    EXPECT_EQ(val1.size(), val2.size());
-    EXPECT_EQ(val1, val2);
-  }
+    for (unsigned int k = 0; k < kLoop; k++) {
+        string val1;
+        for (unsigned int i = 0; i < kElements; i++)
+            val1 += 'a' + rand() % 26;
+        msgpack::sbuffer sbuf;
+        msgpack::pack(sbuf, val1);
+        msgpack::object_handle oh =
+            msgpack::unpack(sbuf.data(), sbuf.size());
+        EXPECT_EQ(oh.get().type, msgpack::type::STR);
+        string val2 = oh.get().as<string>();
+        EXPECT_EQ(val1.size(), val2.size());
+        EXPECT_EQ(val1, val2);
+    }
 }
 
 TEST(MSGPACK_STL, simple_buffer_cstring)
 {
-  for (unsigned int k = 0; k < kLoop; k++) {
-    string val1;
-    for (unsigned int i = 0; i < kElements; i++)
-      val1 += 'a' + rand() % 26;
-    msgpack::sbuffer sbuf;
-    msgpack::pack(sbuf, val1.c_str());
-    msgpack::unpacked ret;
-    msgpack::unpack(ret, sbuf.data(), sbuf.size());
-    EXPECT_EQ(ret.get().type, msgpack::type::STR);
-    string val2 = ret.get().as<string>();
-    EXPECT_EQ(val1.size(), val2.size());
-    EXPECT_EQ(val1, val2);
-  }
+    for (unsigned int k = 0; k < kLoop; k++) {
+        string val1;
+        for (unsigned int i = 0; i < kElements; i++)
+            val1 += 'a' + rand() % 26;
+        msgpack::sbuffer sbuf;
+        msgpack::pack(sbuf, val1.c_str());
+        msgpack::object_handle oh =
+            msgpack::unpack(sbuf.data(), sbuf.size());
+        EXPECT_EQ(oh.get().type, msgpack::type::STR);
+        string val2 = oh.get().as<string>();
+        EXPECT_EQ(val1.size(), val2.size());
+        EXPECT_EQ(val1, val2);
+    }
 }
 
 TEST(MSGPACK_STL, simple_buffer_non_const_cstring)
 {
-  for (unsigned int k = 0; k < kLoop; k++) {
-    string val1;
-    for (unsigned int i = 0; i < kElements; i++)
-      val1 += 'a' + rand() % 26;
-    msgpack::sbuffer sbuf;
-    char* s = new char[val1.size() + 1];
-    std::memcpy(s, val1.c_str(), val1.size() + 1);
-    msgpack::pack(sbuf, s);
-    delete [] s;
-    msgpack::unpacked ret;
-    msgpack::unpack(ret, sbuf.data(), sbuf.size());
-    EXPECT_EQ(ret.get().type, msgpack::type::STR);
-    string val2 = ret.get().as<string>();
-    EXPECT_EQ(val1.size(), val2.size());
-    EXPECT_EQ(val1, val2);
-  }
+    for (unsigned int k = 0; k < kLoop; k++) {
+        string val1;
+        for (unsigned int i = 0; i < kElements; i++)
+            val1 += 'a' + rand() % 26;
+        msgpack::sbuffer sbuf;
+        char* s = new char[val1.size() + 1];
+        std::memcpy(s, val1.c_str(), val1.size() + 1);
+        msgpack::pack(sbuf, s);
+        delete [] s;
+        msgpack::object_handle oh =
+            msgpack::unpack(sbuf.data(), sbuf.size());
+        EXPECT_EQ(oh.get().type, msgpack::type::STR);
+        string val2 = oh.get().as<string>();
+        EXPECT_EQ(val1.size(), val2.size());
+        EXPECT_EQ(val1, val2);
+    }
 }

--- a/test/msgpack_c.cpp
+++ b/test/msgpack_c.cpp
@@ -17,70 +17,70 @@ using namespace std;
 const unsigned int kLoop = 10000;
 const double kEPS = 1e-10;
 
-#define GEN_TEST_SIGNED(test_type, func_type)                   \
-  do {                                                          \
-    vector<test_type> v;                                        \
-    v.push_back(0);                                             \
-    v.push_back(1);                                             \
-    v.push_back(-1);                                            \
-    v.push_back(numeric_limits<test_type>::min());              \
-    v.push_back(numeric_limits<test_type>::max());              \
-    for (unsigned int i = 0; i < kLoop; i++)                    \
-      v.push_back(rand());                                      \
-    for (unsigned int i = 0; i < v.size() ; i++) {              \
-      test_type val = v[i];                                     \
-      msgpack_sbuffer sbuf;                                     \
-      msgpack_sbuffer_init(&sbuf);                              \
-      msgpack_packer pk;                                        \
-      msgpack_packer_init(&pk, &sbuf, msgpack_sbuffer_write);   \
-      msgpack_pack_##func_type(&pk, val);                       \
-      msgpack_zone z;                                           \
-      msgpack_zone_init(&z, 2048);                              \
-      msgpack_object obj;                                       \
-      msgpack_unpack_return ret =                               \
-        msgpack_unpack(sbuf.data, sbuf.size, NULL, &z, &obj);   \
-      EXPECT_EQ(MSGPACK_UNPACK_SUCCESS, ret);                   \
-      if (val < 0) {                                            \
-        EXPECT_EQ(MSGPACK_OBJECT_NEGATIVE_INTEGER, obj.type);   \
-        EXPECT_EQ(val, obj.via.i64);                            \
-      } else {                                                  \
-        EXPECT_EQ(MSGPACK_OBJECT_POSITIVE_INTEGER, obj.type);   \
-        EXPECT_EQ(static_cast<uint64_t>(val), obj.via.u64);     \
-      }                                                         \
-      msgpack_zone_destroy(&z);                                 \
-      msgpack_sbuffer_destroy(&sbuf);                           \
-    }                                                           \
-  } while(0)
+#define GEN_TEST_SIGNED(test_type, func_type)                           \
+    do {                                                                \
+        vector<test_type> v;                                            \
+        v.push_back(0);                                                 \
+        v.push_back(1);                                                 \
+        v.push_back(-1);                                                \
+        v.push_back(numeric_limits<test_type>::min());                  \
+        v.push_back(numeric_limits<test_type>::max());                  \
+        for (unsigned int i = 0; i < kLoop; i++)                        \
+            v.push_back(rand());                                        \
+        for (unsigned int i = 0; i < v.size() ; i++) {                  \
+            test_type val = v[i];                                       \
+            msgpack_sbuffer sbuf;                                       \
+            msgpack_sbuffer_init(&sbuf);                                \
+            msgpack_packer pk;                                          \
+            msgpack_packer_init(&pk, &sbuf, msgpack_sbuffer_write);     \
+            msgpack_pack_##func_type(&pk, val);                         \
+            msgpack_zone z;                                             \
+            msgpack_zone_init(&z, 2048);                                \
+            msgpack_object obj;                                         \
+            msgpack_unpack_return ret =                                 \
+                msgpack_unpack(sbuf.data, sbuf.size, NULL, &z, &obj);   \
+            EXPECT_EQ(MSGPACK_UNPACK_SUCCESS, ret);                     \
+            if (val < 0) {                                              \
+                EXPECT_EQ(MSGPACK_OBJECT_NEGATIVE_INTEGER, obj.type);   \
+                EXPECT_EQ(val, obj.via.i64);                            \
+            } else {                                                    \
+                EXPECT_EQ(MSGPACK_OBJECT_POSITIVE_INTEGER, obj.type);   \
+                EXPECT_EQ(static_cast<uint64_t>(val), obj.via.u64);     \
+            }                                                           \
+            msgpack_zone_destroy(&z);                                   \
+            msgpack_sbuffer_destroy(&sbuf);                             \
+        }                                                               \
+    } while(0)
 
-#define GEN_TEST_UNSIGNED(test_type, func_type)                 \
-  do {                                                          \
-    vector<test_type> v;                                        \
-    v.push_back(0);                                             \
-    v.push_back(1);                                             \
-    v.push_back(2);                                             \
-    v.push_back(numeric_limits<test_type>::min());              \
-    v.push_back(numeric_limits<test_type>::max());              \
-    for (unsigned int i = 0; i < kLoop; i++)                    \
-      v.push_back(rand());                                      \
-    for (unsigned int i = 0; i < v.size() ; i++) {              \
-      test_type val = v[i];                                     \
-      msgpack_sbuffer sbuf;                                     \
-      msgpack_sbuffer_init(&sbuf);                              \
-      msgpack_packer pk;                                        \
-      msgpack_packer_init(&pk, &sbuf, msgpack_sbuffer_write);   \
-      msgpack_pack_##func_type(&pk, val);                       \
-      msgpack_zone z;                                           \
-      msgpack_zone_init(&z, 2048);                              \
-      msgpack_object obj;                                       \
-      msgpack_unpack_return ret =                               \
-        msgpack_unpack(sbuf.data, sbuf.size, NULL, &z, &obj);   \
-      EXPECT_EQ(MSGPACK_UNPACK_SUCCESS, ret);                   \
-      EXPECT_EQ(MSGPACK_OBJECT_POSITIVE_INTEGER, obj.type);     \
-      EXPECT_EQ(val, obj.via.u64);                              \
-      msgpack_zone_destroy(&z);                                 \
-      msgpack_sbuffer_destroy(&sbuf);                           \
-    }                                                           \
-  } while(0)
+#define GEN_TEST_UNSIGNED(test_type, func_type)                         \
+    do {                                                                \
+        vector<test_type> v;                                            \
+        v.push_back(0);                                                 \
+        v.push_back(1);                                                 \
+        v.push_back(2);                                                 \
+        v.push_back(numeric_limits<test_type>::min());                  \
+        v.push_back(numeric_limits<test_type>::max());                  \
+        for (unsigned int i = 0; i < kLoop; i++)                        \
+            v.push_back(rand());                                        \
+        for (unsigned int i = 0; i < v.size() ; i++) {                  \
+            test_type val = v[i];                                       \
+            msgpack_sbuffer sbuf;                                       \
+            msgpack_sbuffer_init(&sbuf);                                \
+            msgpack_packer pk;                                          \
+            msgpack_packer_init(&pk, &sbuf, msgpack_sbuffer_write);     \
+            msgpack_pack_##func_type(&pk, val);                         \
+            msgpack_zone z;                                             \
+            msgpack_zone_init(&z, 2048);                                \
+            msgpack_object obj;                                         \
+            msgpack_unpack_return ret =                                 \
+                msgpack_unpack(sbuf.data, sbuf.size, NULL, &z, &obj);   \
+            EXPECT_EQ(MSGPACK_UNPACK_SUCCESS, ret);                     \
+            EXPECT_EQ(MSGPACK_OBJECT_POSITIVE_INTEGER, obj.type);       \
+            EXPECT_EQ(val, obj.via.u64);                                \
+            msgpack_zone_destroy(&z);                                   \
+            msgpack_sbuffer_destroy(&sbuf);                             \
+        }                                                               \
+    } while(0)
 
 TEST(MSGPACKC, simple_buffer_char)
 {
@@ -97,1159 +97,1159 @@ TEST(MSGPACKC, simple_buffer_char)
 
 TEST(MSGPACKC, simple_buffer_singed_char)
 {
-  GEN_TEST_SIGNED(signed char, signed_char);
+    GEN_TEST_SIGNED(signed char, signed_char);
 }
 
 TEST(MSGPACKC, simple_buffer_short)
 {
-  GEN_TEST_SIGNED(short, short);
+    GEN_TEST_SIGNED(short, short);
 }
 
 TEST(MSGPACKC, simple_buffer_int)
 {
-  GEN_TEST_SIGNED(int, int);
+    GEN_TEST_SIGNED(int, int);
 }
 
 TEST(MSGPACKC, simple_buffer_long)
 {
-  GEN_TEST_SIGNED(long, long);
+    GEN_TEST_SIGNED(long, long);
 }
 
 TEST(MSGPACKC, simple_buffer_long_long)
 {
-  GEN_TEST_SIGNED(long long, long_long);
+    GEN_TEST_SIGNED(long long, long_long);
 }
 
 TEST(MSGPACKC, simple_buffer_unsigned_char)
 {
-  GEN_TEST_UNSIGNED(unsigned char, unsigned_char);
+    GEN_TEST_UNSIGNED(unsigned char, unsigned_char);
 }
 
 TEST(MSGPACKC, simple_buffer_unsigned_short)
 {
-  GEN_TEST_UNSIGNED(unsigned short, unsigned_short);
+    GEN_TEST_UNSIGNED(unsigned short, unsigned_short);
 }
 
 TEST(MSGPACKC, simple_buffer_unsigned_int)
 {
-  GEN_TEST_UNSIGNED(unsigned int, unsigned_int);
+    GEN_TEST_UNSIGNED(unsigned int, unsigned_int);
 }
 
 TEST(MSGPACKC, simple_buffer_unsigned_long)
 {
-  GEN_TEST_UNSIGNED(unsigned long, unsigned_long);
+    GEN_TEST_UNSIGNED(unsigned long, unsigned_long);
 }
 
 TEST(MSGPACKC, simple_buffer_unsigned_long_long)
 {
-  GEN_TEST_UNSIGNED(unsigned long long, unsigned_long_long);
+    GEN_TEST_UNSIGNED(unsigned long long, unsigned_long_long);
 }
 
 TEST(MSGPACKC, simple_buffer_uint8)
 {
-  GEN_TEST_UNSIGNED(uint8_t, uint8);
+    GEN_TEST_UNSIGNED(uint8_t, uint8);
 }
 
 TEST(MSGPACKC, simple_buffer_uint16)
 {
-  GEN_TEST_UNSIGNED(uint16_t, uint16);
+    GEN_TEST_UNSIGNED(uint16_t, uint16);
 }
 
 TEST(MSGPACKC, simple_buffer_uint32)
 {
-  GEN_TEST_UNSIGNED(uint32_t, uint32);
+    GEN_TEST_UNSIGNED(uint32_t, uint32);
 }
 
 TEST(MSGPACKC, simple_buffer_uint64)
 {
-  GEN_TEST_UNSIGNED(uint64_t, uint64);
+    GEN_TEST_UNSIGNED(uint64_t, uint64);
 }
 
 TEST(MSGPACKC, simple_buffer_int8)
 {
-  GEN_TEST_SIGNED(int8_t, int8);
+    GEN_TEST_SIGNED(int8_t, int8);
 }
 
 TEST(MSGPACKC, simple_buffer_int16)
 {
-  GEN_TEST_SIGNED(int16_t, int16);
+    GEN_TEST_SIGNED(int16_t, int16);
 }
 
 TEST(MSGPACKC, simple_buffer_int32)
 {
-  GEN_TEST_SIGNED(int32_t, int32);
+    GEN_TEST_SIGNED(int32_t, int32);
 }
 
 TEST(MSGPACKC, simple_buffer_int64)
 {
-  GEN_TEST_SIGNED(int64_t, int64);
+    GEN_TEST_SIGNED(int64_t, int64);
 }
 
 TEST(MSGPACKC, simple_buffer_float)
 {
-  vector<float> v;
-  v.push_back(0.0);
-  v.push_back(1.0);
-  v.push_back(-1.0);
-  v.push_back(numeric_limits<float>::min());
-  v.push_back(numeric_limits<float>::max());
-  v.push_back(nanf("tag"));
-  if (numeric_limits<float>::has_infinity) {
-    v.push_back(numeric_limits<float>::infinity());
-    v.push_back(-numeric_limits<float>::infinity());
-  }
-  if (numeric_limits<float>::has_quiet_NaN) {
-    v.push_back(numeric_limits<float>::quiet_NaN());
-  }
-  if (numeric_limits<float>::has_signaling_NaN) {
-    v.push_back(numeric_limits<float>::signaling_NaN());
-  }
+    vector<float> v;
+    v.push_back(0.0);
+    v.push_back(1.0);
+    v.push_back(-1.0);
+    v.push_back(numeric_limits<float>::min());
+    v.push_back(numeric_limits<float>::max());
+    v.push_back(nanf("tag"));
+    if (numeric_limits<float>::has_infinity) {
+        v.push_back(numeric_limits<float>::infinity());
+        v.push_back(-numeric_limits<float>::infinity());
+    }
+    if (numeric_limits<float>::has_quiet_NaN) {
+        v.push_back(numeric_limits<float>::quiet_NaN());
+    }
+    if (numeric_limits<float>::has_signaling_NaN) {
+        v.push_back(numeric_limits<float>::signaling_NaN());
+    }
 
-  for (unsigned int i = 0; i < kLoop; i++) {
-    v.push_back(static_cast<float>(msgpack_rand()));
-    v.push_back(static_cast<float>(-msgpack_rand()));
-  }
+    for (unsigned int i = 0; i < kLoop; i++) {
+        v.push_back(static_cast<float>(msgpack_rand()));
+        v.push_back(static_cast<float>(-msgpack_rand()));
+    }
 
-  for (unsigned int i = 0; i < v.size() ; i++) {
-    float val = v[i];
-    msgpack_sbuffer sbuf;
-    msgpack_sbuffer_init(&sbuf);
-    msgpack_packer pk;
-    msgpack_packer_init(&pk, &sbuf, msgpack_sbuffer_write);
-    msgpack_pack_float(&pk, val);
-    msgpack_zone z;
-    msgpack_zone_init(&z, 2048);
-    msgpack_object obj;
-    msgpack_unpack_return ret =
-      msgpack_unpack(sbuf.data, sbuf.size, NULL, &z, &obj);
-    EXPECT_EQ(MSGPACK_UNPACK_SUCCESS, ret);
-    EXPECT_EQ(MSGPACK_OBJECT_FLOAT, obj.type);
+    for (unsigned int i = 0; i < v.size() ; i++) {
+        float val = v[i];
+        msgpack_sbuffer sbuf;
+        msgpack_sbuffer_init(&sbuf);
+        msgpack_packer pk;
+        msgpack_packer_init(&pk, &sbuf, msgpack_sbuffer_write);
+        msgpack_pack_float(&pk, val);
+        msgpack_zone z;
+        msgpack_zone_init(&z, 2048);
+        msgpack_object obj;
+        msgpack_unpack_return ret =
+            msgpack_unpack(sbuf.data, sbuf.size, NULL, &z, &obj);
+        EXPECT_EQ(MSGPACK_UNPACK_SUCCESS, ret);
+        EXPECT_EQ(MSGPACK_OBJECT_FLOAT, obj.type);
 #if defined(MSGPACK_USE_LEGACY_NAME_AS_FLOAT)
-    EXPECT_EQ(MSGPACK_OBJECT_DOUBLE, obj.type);
+        EXPECT_EQ(MSGPACK_OBJECT_DOUBLE, obj.type);
 #endif // MSGPACK_USE_LEGACY_NAME_AS_FLOAT
-    if (isnan(val)) {
-      EXPECT_TRUE(isnan(obj.via.f64));
+        if (isnan(val)) {
+            EXPECT_TRUE(isnan(obj.via.f64));
 #if defined(MSGPACK_USE_LEGACY_NAME_AS_FLOAT)
-      EXPECT_TRUE(isnan(obj.via.dec));
+            EXPECT_TRUE(isnan(obj.via.dec));
 #endif // MSGPACK_USE_LEGACY_NAME_AS_FLOAT
+        }
+        else if (isinf(val)) {
+            EXPECT_TRUE(isinf(obj.via.f64));
+#if defined(MSGPACK_USE_LEGACY_NAME_AS_FLOAT)
+            EXPECT_TRUE(isinf(obj.via.dec));
+#endif // MSGPACK_USE_LEGACY_NAME_AS_FLOAT
+        }
+        else {
+            EXPECT_TRUE(fabs(obj.via.f64 - val) <= kEPS);
+#if defined(MSGPACK_USE_LEGACY_NAME_AS_FLOAT)
+            EXPECT_TRUE(fabs(obj.via.dec - val) <= kEPS);
+#endif // MSGPACK_USE_LEGACY_NAME_AS_FLOAT
+        }
+        msgpack_zone_destroy(&z);
+        msgpack_sbuffer_destroy(&sbuf);
     }
-    else if (isinf(val)) {
-      EXPECT_TRUE(isinf(obj.via.f64));
-#if defined(MSGPACK_USE_LEGACY_NAME_AS_FLOAT)
-      EXPECT_TRUE(isinf(obj.via.dec));
-#endif // MSGPACK_USE_LEGACY_NAME_AS_FLOAT
-    }
-    else {
-      EXPECT_TRUE(fabs(obj.via.f64 - val) <= kEPS);
-#if defined(MSGPACK_USE_LEGACY_NAME_AS_FLOAT)
-      EXPECT_TRUE(fabs(obj.via.dec - val) <= kEPS);
-#endif // MSGPACK_USE_LEGACY_NAME_AS_FLOAT
-    }
-    msgpack_zone_destroy(&z);
-    msgpack_sbuffer_destroy(&sbuf);
-  }
 }
 
 TEST(MSGPACKC, simple_buffer_double)
 {
-  vector<double> v;
-  v.push_back(0.0);
-  v.push_back(-0.0);
-  v.push_back(1.0);
-  v.push_back(-1.0);
-  v.push_back(numeric_limits<double>::min());
-  v.push_back(numeric_limits<double>::max());
-  v.push_back(nan("tag"));
-  if (numeric_limits<double>::has_infinity) {
-    v.push_back(numeric_limits<double>::infinity());
-    v.push_back(-numeric_limits<double>::infinity());
-  }
-  if (numeric_limits<double>::has_quiet_NaN) {
-    v.push_back(numeric_limits<double>::quiet_NaN());
-  }
-  if (numeric_limits<double>::has_signaling_NaN) {
-    v.push_back(numeric_limits<double>::signaling_NaN());
-  }
-  for (unsigned int i = 0; i < kLoop; i++) {
-    v.push_back(msgpack_rand());
-    v.push_back(-msgpack_rand());
-  }
+    vector<double> v;
+    v.push_back(0.0);
+    v.push_back(-0.0);
+    v.push_back(1.0);
+    v.push_back(-1.0);
+    v.push_back(numeric_limits<double>::min());
+    v.push_back(numeric_limits<double>::max());
+    v.push_back(nan("tag"));
+    if (numeric_limits<double>::has_infinity) {
+        v.push_back(numeric_limits<double>::infinity());
+        v.push_back(-numeric_limits<double>::infinity());
+    }
+    if (numeric_limits<double>::has_quiet_NaN) {
+        v.push_back(numeric_limits<double>::quiet_NaN());
+    }
+    if (numeric_limits<double>::has_signaling_NaN) {
+        v.push_back(numeric_limits<double>::signaling_NaN());
+    }
+    for (unsigned int i = 0; i < kLoop; i++) {
+        v.push_back(msgpack_rand());
+        v.push_back(-msgpack_rand());
+    }
 
-  for (unsigned int i = 0; i < v.size() ; i++) {
-    double val = v[i];
-    msgpack_sbuffer sbuf;
-    msgpack_sbuffer_init(&sbuf);
-    msgpack_packer pk;
-    msgpack_packer_init(&pk, &sbuf, msgpack_sbuffer_write);
-    msgpack_pack_double(&pk, val);
-    msgpack_zone z;
-    msgpack_zone_init(&z, 2048);
-    msgpack_object obj;
-    msgpack_unpack_return ret =
-      msgpack_unpack(sbuf.data, sbuf.size, NULL, &z, &obj);
-    EXPECT_EQ(MSGPACK_UNPACK_SUCCESS, ret);
-    EXPECT_EQ(MSGPACK_OBJECT_FLOAT, obj.type);
+    for (unsigned int i = 0; i < v.size() ; i++) {
+        double val = v[i];
+        msgpack_sbuffer sbuf;
+        msgpack_sbuffer_init(&sbuf);
+        msgpack_packer pk;
+        msgpack_packer_init(&pk, &sbuf, msgpack_sbuffer_write);
+        msgpack_pack_double(&pk, val);
+        msgpack_zone z;
+        msgpack_zone_init(&z, 2048);
+        msgpack_object obj;
+        msgpack_unpack_return ret =
+            msgpack_unpack(sbuf.data, sbuf.size, NULL, &z, &obj);
+        EXPECT_EQ(MSGPACK_UNPACK_SUCCESS, ret);
+        EXPECT_EQ(MSGPACK_OBJECT_FLOAT, obj.type);
 #if defined(MSGPACK_USE_LEGACY_NAME_AS_FLOAT)
-    EXPECT_EQ(MSGPACK_OBJECT_DOUBLE, obj.type);
+        EXPECT_EQ(MSGPACK_OBJECT_DOUBLE, obj.type);
 #endif // MSGPACK_USE_LEGACY_NAME_AS_FLOAT
-    if (isnan(val)) {
-      EXPECT_TRUE(isnan(obj.via.f64));
+        if (isnan(val)) {
+            EXPECT_TRUE(isnan(obj.via.f64));
 #if defined(MSGPACK_USE_LEGACY_NAME_AS_FLOAT)
-      EXPECT_TRUE(isnan(obj.via.dec));
+            EXPECT_TRUE(isnan(obj.via.dec));
 #endif // MSGPACK_USE_LEGACY_NAME_AS_FLOAT
+        }
+        else if (isinf(val)) {
+            EXPECT_TRUE(isinf(obj.via.f64));
+#if defined(MSGPACK_USE_LEGACY_NAME_AS_FLOAT)
+            EXPECT_TRUE(isinf(obj.via.dec));
+#endif // MSGPACK_USE_LEGACY_NAME_AS_FLOAT
+        }
+        else {
+            EXPECT_TRUE(fabs(obj.via.f64 - val) <= kEPS);
+#if defined(MSGPACK_USE_LEGACY_NAME_AS_FLOAT)
+            EXPECT_TRUE(fabs(obj.via.dec - val) <= kEPS);
+#endif // MSGPACK_USE_LEGACY_NAME_AS_FLOAT
+        }
+        msgpack_zone_destroy(&z);
+        msgpack_sbuffer_destroy(&sbuf);
     }
-    else if (isinf(val)) {
-      EXPECT_TRUE(isinf(obj.via.f64));
-#if defined(MSGPACK_USE_LEGACY_NAME_AS_FLOAT)
-      EXPECT_TRUE(isinf(obj.via.dec));
-#endif // MSGPACK_USE_LEGACY_NAME_AS_FLOAT
-    }
-    else {
-      EXPECT_TRUE(fabs(obj.via.f64 - val) <= kEPS);
-#if defined(MSGPACK_USE_LEGACY_NAME_AS_FLOAT)
-      EXPECT_TRUE(fabs(obj.via.dec - val) <= kEPS);
-#endif // MSGPACK_USE_LEGACY_NAME_AS_FLOAT
-    }
-    msgpack_zone_destroy(&z);
-    msgpack_sbuffer_destroy(&sbuf);
-  }
 }
 
 TEST(MSGPACKC, simple_buffer_nil)
 {
-  msgpack_sbuffer sbuf;
-  msgpack_sbuffer_init(&sbuf);
-  msgpack_packer pk;
-  msgpack_packer_init(&pk, &sbuf, msgpack_sbuffer_write);
-  msgpack_pack_nil(&pk);
-  msgpack_zone z;
-  msgpack_zone_init(&z, 2048);
-  msgpack_object obj;
-  msgpack_unpack_return ret =
-    msgpack_unpack(sbuf.data, sbuf.size, NULL, &z, &obj);
-  EXPECT_EQ(MSGPACK_UNPACK_SUCCESS, ret);
-  EXPECT_EQ(MSGPACK_OBJECT_NIL, obj.type);
-  msgpack_zone_destroy(&z);
-  msgpack_sbuffer_destroy(&sbuf);
+    msgpack_sbuffer sbuf;
+    msgpack_sbuffer_init(&sbuf);
+    msgpack_packer pk;
+    msgpack_packer_init(&pk, &sbuf, msgpack_sbuffer_write);
+    msgpack_pack_nil(&pk);
+    msgpack_zone z;
+    msgpack_zone_init(&z, 2048);
+    msgpack_object obj;
+    msgpack_unpack_return ret =
+        msgpack_unpack(sbuf.data, sbuf.size, NULL, &z, &obj);
+    EXPECT_EQ(MSGPACK_UNPACK_SUCCESS, ret);
+    EXPECT_EQ(MSGPACK_OBJECT_NIL, obj.type);
+    msgpack_zone_destroy(&z);
+    msgpack_sbuffer_destroy(&sbuf);
 }
 
 TEST(MSGPACKC, simple_buffer_true)
 {
-  msgpack_sbuffer sbuf;
-  msgpack_sbuffer_init(&sbuf);
-  msgpack_packer pk;
-  msgpack_packer_init(&pk, &sbuf, msgpack_sbuffer_write);
-  msgpack_pack_true(&pk);
-  msgpack_zone z;
-  msgpack_zone_init(&z, 2048);
-  msgpack_object obj;
-  msgpack_unpack_return ret =
-    msgpack_unpack(sbuf.data, sbuf.size, NULL, &z, &obj);
-  EXPECT_EQ(MSGPACK_UNPACK_SUCCESS, ret);
-  EXPECT_EQ(MSGPACK_OBJECT_BOOLEAN, obj.type);
-  EXPECT_EQ(true, obj.via.boolean);
-  msgpack_zone_destroy(&z);
-  msgpack_sbuffer_destroy(&sbuf);
+    msgpack_sbuffer sbuf;
+    msgpack_sbuffer_init(&sbuf);
+    msgpack_packer pk;
+    msgpack_packer_init(&pk, &sbuf, msgpack_sbuffer_write);
+    msgpack_pack_true(&pk);
+    msgpack_zone z;
+    msgpack_zone_init(&z, 2048);
+    msgpack_object obj;
+    msgpack_unpack_return ret =
+        msgpack_unpack(sbuf.data, sbuf.size, NULL, &z, &obj);
+    EXPECT_EQ(MSGPACK_UNPACK_SUCCESS, ret);
+    EXPECT_EQ(MSGPACK_OBJECT_BOOLEAN, obj.type);
+    EXPECT_EQ(true, obj.via.boolean);
+    msgpack_zone_destroy(&z);
+    msgpack_sbuffer_destroy(&sbuf);
 }
 
 TEST(MSGPACKC, simple_buffer_false)
 {
-  msgpack_sbuffer sbuf;
-  msgpack_sbuffer_init(&sbuf);
-  msgpack_packer pk;
-  msgpack_packer_init(&pk, &sbuf, msgpack_sbuffer_write);
-  msgpack_pack_false(&pk);
-  msgpack_zone z;
-  msgpack_zone_init(&z, 2048);
-  msgpack_object obj;
-  msgpack_unpack_return ret =
-    msgpack_unpack(sbuf.data, sbuf.size, NULL, &z, &obj);
-  EXPECT_EQ(MSGPACK_UNPACK_SUCCESS, ret);
-  EXPECT_EQ(MSGPACK_OBJECT_BOOLEAN, obj.type);
-  EXPECT_EQ(false, obj.via.boolean);
-  msgpack_zone_destroy(&z);
-  msgpack_sbuffer_destroy(&sbuf);
+    msgpack_sbuffer sbuf;
+    msgpack_sbuffer_init(&sbuf);
+    msgpack_packer pk;
+    msgpack_packer_init(&pk, &sbuf, msgpack_sbuffer_write);
+    msgpack_pack_false(&pk);
+    msgpack_zone z;
+    msgpack_zone_init(&z, 2048);
+    msgpack_object obj;
+    msgpack_unpack_return ret =
+        msgpack_unpack(sbuf.data, sbuf.size, NULL, &z, &obj);
+    EXPECT_EQ(MSGPACK_UNPACK_SUCCESS, ret);
+    EXPECT_EQ(MSGPACK_OBJECT_BOOLEAN, obj.type);
+    EXPECT_EQ(false, obj.via.boolean);
+    msgpack_zone_destroy(&z);
+    msgpack_sbuffer_destroy(&sbuf);
 }
 
 TEST(MSGPACKC, simple_buffer_fixext1)
 {
-  msgpack_sbuffer sbuf;
-  msgpack_sbuffer_init(&sbuf);
-  msgpack_packer pk;
-  msgpack_packer_init(&pk, &sbuf, msgpack_sbuffer_write);
-  char const buf[] = { 2 };
+    msgpack_sbuffer sbuf;
+    msgpack_sbuffer_init(&sbuf);
+    msgpack_packer pk;
+    msgpack_packer_init(&pk, &sbuf, msgpack_sbuffer_write);
+    char const buf[] = { 2 };
 
-  msgpack_pack_ext(&pk, sizeof(buf), 1);
-  msgpack_pack_ext_body(&pk, buf, sizeof(buf));
-  msgpack_zone z;
-  msgpack_zone_init(&z, 2048);
-  msgpack_object obj;
-  msgpack_unpack_return ret =
-    msgpack_unpack(sbuf.data, sbuf.size, NULL, &z, &obj);
-  EXPECT_EQ(MSGPACK_UNPACK_SUCCESS, ret);
-  EXPECT_EQ(MSGPACK_OBJECT_EXT, obj.type);
-  EXPECT_EQ(1u, obj.via.ext.size);
-  EXPECT_EQ(1, obj.via.ext.type);
-  EXPECT_EQ(2, obj.via.ext.ptr[0]);
-  msgpack_zone_destroy(&z);
-  msgpack_sbuffer_destroy(&sbuf);
+    msgpack_pack_ext(&pk, sizeof(buf), 1);
+    msgpack_pack_ext_body(&pk, buf, sizeof(buf));
+    msgpack_zone z;
+    msgpack_zone_init(&z, 2048);
+    msgpack_object obj;
+    msgpack_unpack_return ret =
+        msgpack_unpack(sbuf.data, sbuf.size, NULL, &z, &obj);
+    EXPECT_EQ(MSGPACK_UNPACK_SUCCESS, ret);
+    EXPECT_EQ(MSGPACK_OBJECT_EXT, obj.type);
+    EXPECT_EQ(1u, obj.via.ext.size);
+    EXPECT_EQ(1, obj.via.ext.type);
+    EXPECT_EQ(2, obj.via.ext.ptr[0]);
+    msgpack_zone_destroy(&z);
+    msgpack_sbuffer_destroy(&sbuf);
 }
 
 TEST(MSGPACKC, simple_buffer_fixext2)
 {
-  msgpack_sbuffer sbuf;
-  msgpack_sbuffer_init(&sbuf);
-  msgpack_packer pk;
-  msgpack_packer_init(&pk, &sbuf, msgpack_sbuffer_write);
-  char const buf[] = { 2, 3 };
+    msgpack_sbuffer sbuf;
+    msgpack_sbuffer_init(&sbuf);
+    msgpack_packer pk;
+    msgpack_packer_init(&pk, &sbuf, msgpack_sbuffer_write);
+    char const buf[] = { 2, 3 };
 
-  msgpack_pack_ext(&pk, sizeof(buf), 0);
-  msgpack_pack_ext_body(&pk, buf, sizeof(buf));
-  msgpack_zone z;
-  msgpack_zone_init(&z, 2048);
-  msgpack_object obj;
-  msgpack_unpack_return ret =
-    msgpack_unpack(sbuf.data, sbuf.size, NULL, &z, &obj);
-  EXPECT_EQ(MSGPACK_UNPACK_SUCCESS, ret);
-  EXPECT_EQ(MSGPACK_OBJECT_EXT, obj.type);
-  EXPECT_EQ(2u, obj.via.ext.size);
-  EXPECT_EQ(0, obj.via.ext.type);
-  EXPECT_EQ(0, memcmp(buf, obj.via.ext.ptr, sizeof(buf)));
-  msgpack_zone_destroy(&z);
-  msgpack_sbuffer_destroy(&sbuf);
+    msgpack_pack_ext(&pk, sizeof(buf), 0);
+    msgpack_pack_ext_body(&pk, buf, sizeof(buf));
+    msgpack_zone z;
+    msgpack_zone_init(&z, 2048);
+    msgpack_object obj;
+    msgpack_unpack_return ret =
+        msgpack_unpack(sbuf.data, sbuf.size, NULL, &z, &obj);
+    EXPECT_EQ(MSGPACK_UNPACK_SUCCESS, ret);
+    EXPECT_EQ(MSGPACK_OBJECT_EXT, obj.type);
+    EXPECT_EQ(2u, obj.via.ext.size);
+    EXPECT_EQ(0, obj.via.ext.type);
+    EXPECT_EQ(0, memcmp(buf, obj.via.ext.ptr, sizeof(buf)));
+    msgpack_zone_destroy(&z);
+    msgpack_sbuffer_destroy(&sbuf);
 }
 
 TEST(MSGPACKC, simple_buffer_fixext4)
 {
-  msgpack_sbuffer sbuf;
-  msgpack_sbuffer_init(&sbuf);
-  msgpack_packer pk;
-  msgpack_packer_init(&pk, &sbuf, msgpack_sbuffer_write);
-  char const buf[] = { 2, 3, 4, 5 };
+    msgpack_sbuffer sbuf;
+    msgpack_sbuffer_init(&sbuf);
+    msgpack_packer pk;
+    msgpack_packer_init(&pk, &sbuf, msgpack_sbuffer_write);
+    char const buf[] = { 2, 3, 4, 5 };
 
-  msgpack_pack_ext(&pk, sizeof(buf), 1);
-  msgpack_pack_ext_body(&pk, buf, sizeof(buf));
-  msgpack_zone z;
-  msgpack_zone_init(&z, 2048);
-  msgpack_object obj;
-  msgpack_unpack_return ret =
-    msgpack_unpack(sbuf.data, sbuf.size, NULL, &z, &obj);
-  EXPECT_EQ(MSGPACK_UNPACK_SUCCESS, ret);
-  EXPECT_EQ(MSGPACK_OBJECT_EXT, obj.type);
-  EXPECT_EQ(4u, obj.via.ext.size);
-  EXPECT_EQ(1, obj.via.ext.type);
-  EXPECT_EQ(0, memcmp(buf, obj.via.ext.ptr, sizeof(buf)));
-  msgpack_zone_destroy(&z);
-  msgpack_sbuffer_destroy(&sbuf);
+    msgpack_pack_ext(&pk, sizeof(buf), 1);
+    msgpack_pack_ext_body(&pk, buf, sizeof(buf));
+    msgpack_zone z;
+    msgpack_zone_init(&z, 2048);
+    msgpack_object obj;
+    msgpack_unpack_return ret =
+        msgpack_unpack(sbuf.data, sbuf.size, NULL, &z, &obj);
+    EXPECT_EQ(MSGPACK_UNPACK_SUCCESS, ret);
+    EXPECT_EQ(MSGPACK_OBJECT_EXT, obj.type);
+    EXPECT_EQ(4u, obj.via.ext.size);
+    EXPECT_EQ(1, obj.via.ext.type);
+    EXPECT_EQ(0, memcmp(buf, obj.via.ext.ptr, sizeof(buf)));
+    msgpack_zone_destroy(&z);
+    msgpack_sbuffer_destroy(&sbuf);
 }
 
 TEST(MSGPACKC, simple_buffer_fixext8)
 {
-  msgpack_sbuffer sbuf;
-  msgpack_sbuffer_init(&sbuf);
-  msgpack_packer pk;
-  msgpack_packer_init(&pk, &sbuf, msgpack_sbuffer_write);
-  char const buf [] = { 2, 3, 4, 5, 6, 7, 8, 9 };
+    msgpack_sbuffer sbuf;
+    msgpack_sbuffer_init(&sbuf);
+    msgpack_packer pk;
+    msgpack_packer_init(&pk, &sbuf, msgpack_sbuffer_write);
+    char const buf [] = { 2, 3, 4, 5, 6, 7, 8, 9 };
 
-  msgpack_pack_ext(&pk, sizeof(buf), 1);
-  msgpack_pack_ext_body(&pk, buf, sizeof(buf));
-  msgpack_zone z;
-  msgpack_zone_init(&z, 2048);
-  msgpack_object obj;
-  msgpack_unpack_return ret =
-    msgpack_unpack(sbuf.data, sbuf.size, NULL, &z, &obj);
-  EXPECT_EQ(MSGPACK_UNPACK_SUCCESS, ret);
-  EXPECT_EQ(MSGPACK_OBJECT_EXT, obj.type);
-  EXPECT_EQ(8u, obj.via.ext.size);
-  EXPECT_EQ(1, obj.via.ext.type);
-  EXPECT_EQ(0, memcmp(buf, obj.via.ext.ptr, sizeof(buf)));
-  msgpack_zone_destroy(&z);
-  msgpack_sbuffer_destroy(&sbuf);
+    msgpack_pack_ext(&pk, sizeof(buf), 1);
+    msgpack_pack_ext_body(&pk, buf, sizeof(buf));
+    msgpack_zone z;
+    msgpack_zone_init(&z, 2048);
+    msgpack_object obj;
+    msgpack_unpack_return ret =
+        msgpack_unpack(sbuf.data, sbuf.size, NULL, &z, &obj);
+    EXPECT_EQ(MSGPACK_UNPACK_SUCCESS, ret);
+    EXPECT_EQ(MSGPACK_OBJECT_EXT, obj.type);
+    EXPECT_EQ(8u, obj.via.ext.size);
+    EXPECT_EQ(1, obj.via.ext.type);
+    EXPECT_EQ(0, memcmp(buf, obj.via.ext.ptr, sizeof(buf)));
+    msgpack_zone_destroy(&z);
+    msgpack_sbuffer_destroy(&sbuf);
 }
 
 TEST(MSGPACKC, simple_buffer_fixext16)
 {
-  msgpack_sbuffer sbuf;
-  msgpack_sbuffer_init(&sbuf);
-  msgpack_packer pk;
-  msgpack_packer_init(&pk, &sbuf, msgpack_sbuffer_write);
-  char const buf [] = { 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17 };
+    msgpack_sbuffer sbuf;
+    msgpack_sbuffer_init(&sbuf);
+    msgpack_packer pk;
+    msgpack_packer_init(&pk, &sbuf, msgpack_sbuffer_write);
+    char const buf [] = { 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17 };
 
-  msgpack_pack_ext(&pk, sizeof(buf), 1);
-  msgpack_pack_ext_body(&pk, buf, sizeof(buf));
-  msgpack_zone z;
-  msgpack_zone_init(&z, 2048);
-  msgpack_object obj;
-  msgpack_unpack_return ret =
-    msgpack_unpack(sbuf.data, sbuf.size, NULL, &z, &obj);
-  EXPECT_EQ(MSGPACK_UNPACK_SUCCESS, ret);
-  EXPECT_EQ(MSGPACK_OBJECT_EXT, obj.type);
-  EXPECT_EQ(16u, obj.via.ext.size);
-  EXPECT_EQ(1, obj.via.ext.type);
-  EXPECT_EQ(0, memcmp(buf, obj.via.ext.ptr, sizeof(buf)));
-  msgpack_zone_destroy(&z);
-  msgpack_sbuffer_destroy(&sbuf);
+    msgpack_pack_ext(&pk, sizeof(buf), 1);
+    msgpack_pack_ext_body(&pk, buf, sizeof(buf));
+    msgpack_zone z;
+    msgpack_zone_init(&z, 2048);
+    msgpack_object obj;
+    msgpack_unpack_return ret =
+        msgpack_unpack(sbuf.data, sbuf.size, NULL, &z, &obj);
+    EXPECT_EQ(MSGPACK_UNPACK_SUCCESS, ret);
+    EXPECT_EQ(MSGPACK_OBJECT_EXT, obj.type);
+    EXPECT_EQ(16u, obj.via.ext.size);
+    EXPECT_EQ(1, obj.via.ext.type);
+    EXPECT_EQ(0, memcmp(buf, obj.via.ext.ptr, sizeof(buf)));
+    msgpack_zone_destroy(&z);
+    msgpack_sbuffer_destroy(&sbuf);
 }
 
 TEST(MSGPACKC, simple_buffer_fixext_1byte_0)
 {
-  const size_t size = 0;
-  msgpack_sbuffer sbuf;
-  msgpack_sbuffer_init(&sbuf);
-  msgpack_packer pk;
-  msgpack_packer_init(&pk, &sbuf, msgpack_sbuffer_write);
+    const size_t size = 0;
+    msgpack_sbuffer sbuf;
+    msgpack_sbuffer_init(&sbuf);
+    msgpack_packer pk;
+    msgpack_packer_init(&pk, &sbuf, msgpack_sbuffer_write);
 
-  msgpack_pack_ext(&pk, size, 77);
-  // fprintf(stderr, "size: %u, data: \"", sbuf.size);
-  // for (size_t i = 0; i < sbuf.size; i++)
-  //   fprintf(stderr, "%02x ", (uint8_t)sbuf.data[i]);
-  // fprintf(stderr, "\"\n");
-  msgpack_zone z;
-  msgpack_zone_init(&z, 2048);
-  msgpack_object obj;
-  msgpack_unpack_return ret =
-    msgpack_unpack(sbuf.data, sbuf.size, NULL, &z, &obj);
-  EXPECT_EQ(MSGPACK_UNPACK_SUCCESS, ret);
-  EXPECT_EQ(MSGPACK_OBJECT_EXT, obj.type);
-  EXPECT_EQ(size, obj.via.ext.size);
-  EXPECT_EQ(77, obj.via.ext.type);
-  msgpack_zone_destroy(&z);
-  msgpack_sbuffer_destroy(&sbuf);
+    msgpack_pack_ext(&pk, size, 77);
+    // fprintf(stderr, "size: %u, data: \"", sbuf.size);
+    // for (size_t i = 0; i < sbuf.size; i++)
+    //   fprintf(stderr, "%02x ", (uint8_t)sbuf.data[i]);
+    // fprintf(stderr, "\"\n");
+    msgpack_zone z;
+    msgpack_zone_init(&z, 2048);
+    msgpack_object obj;
+    msgpack_unpack_return ret =
+        msgpack_unpack(sbuf.data, sbuf.size, NULL, &z, &obj);
+    EXPECT_EQ(MSGPACK_UNPACK_SUCCESS, ret);
+    EXPECT_EQ(MSGPACK_OBJECT_EXT, obj.type);
+    EXPECT_EQ(size, obj.via.ext.size);
+    EXPECT_EQ(77, obj.via.ext.type);
+    msgpack_zone_destroy(&z);
+    msgpack_sbuffer_destroy(&sbuf);
 }
 
 TEST(MSGPACKC, simple_buffer_fixext_1byte_255)
 {
-  const size_t size = 255;
-  char buf[size];
-  for (size_t i = 0; i != size; ++i) buf[i] = i;
+    const size_t size = 255;
+    char buf[size];
+    for (size_t i = 0; i != size; ++i) buf[i] = i;
 
-  msgpack_sbuffer sbuf;
-  msgpack_sbuffer_init(&sbuf);
-  msgpack_packer pk;
-  msgpack_packer_init(&pk, &sbuf, msgpack_sbuffer_write);
+    msgpack_sbuffer sbuf;
+    msgpack_sbuffer_init(&sbuf);
+    msgpack_packer pk;
+    msgpack_packer_init(&pk, &sbuf, msgpack_sbuffer_write);
 
-  msgpack_pack_ext(&pk, size, 78);
-  msgpack_pack_ext_body(&pk, buf, sizeof(buf));
-  msgpack_zone z;
-  msgpack_zone_init(&z, 2048);
-  msgpack_object obj;
-  msgpack_unpack_return ret =
-    msgpack_unpack(sbuf.data, sbuf.size, NULL, &z, &obj);
-  EXPECT_EQ(MSGPACK_UNPACK_SUCCESS, ret);
-  EXPECT_EQ(MSGPACK_OBJECT_EXT, obj.type);
-  EXPECT_EQ(size, obj.via.ext.size);
-  EXPECT_EQ(78, obj.via.ext.type);
-  EXPECT_EQ(0, memcmp(buf, obj.via.ext.ptr, sizeof(buf)));
-  msgpack_zone_destroy(&z);
-  msgpack_sbuffer_destroy(&sbuf);
+    msgpack_pack_ext(&pk, size, 78);
+    msgpack_pack_ext_body(&pk, buf, sizeof(buf));
+    msgpack_zone z;
+    msgpack_zone_init(&z, 2048);
+    msgpack_object obj;
+    msgpack_unpack_return ret =
+        msgpack_unpack(sbuf.data, sbuf.size, NULL, &z, &obj);
+    EXPECT_EQ(MSGPACK_UNPACK_SUCCESS, ret);
+    EXPECT_EQ(MSGPACK_OBJECT_EXT, obj.type);
+    EXPECT_EQ(size, obj.via.ext.size);
+    EXPECT_EQ(78, obj.via.ext.type);
+    EXPECT_EQ(0, memcmp(buf, obj.via.ext.ptr, sizeof(buf)));
+    msgpack_zone_destroy(&z);
+    msgpack_sbuffer_destroy(&sbuf);
 }
 
 TEST(MSGPACKC, simple_buffer_fixext_2byte_256)
 {
-  const size_t size = 256;
-  char buf[size];
-  for (size_t i = 0; i != size; ++i) buf[i] = i;
+    const size_t size = 256;
+    char buf[size];
+    for (size_t i = 0; i != size; ++i) buf[i] = i;
 
-  msgpack_sbuffer sbuf;
-  msgpack_sbuffer_init(&sbuf);
-  msgpack_packer pk;
-  msgpack_packer_init(&pk, &sbuf, msgpack_sbuffer_write);
+    msgpack_sbuffer sbuf;
+    msgpack_sbuffer_init(&sbuf);
+    msgpack_packer pk;
+    msgpack_packer_init(&pk, &sbuf, msgpack_sbuffer_write);
 
-  msgpack_pack_ext(&pk, size, 79);
-  msgpack_pack_ext_body(&pk, buf, sizeof(buf));
-  msgpack_zone z;
-  msgpack_zone_init(&z, 2048);
-  msgpack_object obj;
-  msgpack_unpack_return ret =
-    msgpack_unpack(sbuf.data, sbuf.size, NULL, &z, &obj);
-  EXPECT_EQ(MSGPACK_UNPACK_SUCCESS, ret);
-  EXPECT_EQ(MSGPACK_OBJECT_EXT, obj.type);
-  EXPECT_EQ(size, obj.via.ext.size);
-  EXPECT_EQ(79, obj.via.ext.type);
-  EXPECT_EQ(0, memcmp(buf, obj.via.ext.ptr, sizeof(buf)));
-  msgpack_zone_destroy(&z);
-  msgpack_sbuffer_destroy(&sbuf);
+    msgpack_pack_ext(&pk, size, 79);
+    msgpack_pack_ext_body(&pk, buf, sizeof(buf));
+    msgpack_zone z;
+    msgpack_zone_init(&z, 2048);
+    msgpack_object obj;
+    msgpack_unpack_return ret =
+        msgpack_unpack(sbuf.data, sbuf.size, NULL, &z, &obj);
+    EXPECT_EQ(MSGPACK_UNPACK_SUCCESS, ret);
+    EXPECT_EQ(MSGPACK_OBJECT_EXT, obj.type);
+    EXPECT_EQ(size, obj.via.ext.size);
+    EXPECT_EQ(79, obj.via.ext.type);
+    EXPECT_EQ(0, memcmp(buf, obj.via.ext.ptr, sizeof(buf)));
+    msgpack_zone_destroy(&z);
+    msgpack_sbuffer_destroy(&sbuf);
 }
 
 TEST(MSGPACKC, simple_buffer_fixext_2byte_65535)
 {
-  const size_t size = 65535;
-  char buf[size];
-  for (size_t i = 0; i != size; ++i) buf[i] = i;
+    const size_t size = 65535;
+    char buf[size];
+    for (size_t i = 0; i != size; ++i) buf[i] = i;
 
-  msgpack_sbuffer sbuf;
-  msgpack_sbuffer_init(&sbuf);
-  msgpack_packer pk;
-  msgpack_packer_init(&pk, &sbuf, msgpack_sbuffer_write);
+    msgpack_sbuffer sbuf;
+    msgpack_sbuffer_init(&sbuf);
+    msgpack_packer pk;
+    msgpack_packer_init(&pk, &sbuf, msgpack_sbuffer_write);
 
-  msgpack_pack_ext(&pk, size, 80);
-  msgpack_pack_ext_body(&pk, buf, sizeof(buf));
-  msgpack_zone z;
-  msgpack_zone_init(&z, 2048);
-  msgpack_object obj;
-  msgpack_unpack_return ret =
-    msgpack_unpack(sbuf.data, sbuf.size, NULL, &z, &obj);
-  EXPECT_EQ(MSGPACK_UNPACK_SUCCESS, ret);
-  EXPECT_EQ(MSGPACK_OBJECT_EXT, obj.type);
-  EXPECT_EQ(size, obj.via.ext.size);
-  EXPECT_EQ(80, obj.via.ext.type);
-  EXPECT_EQ(0, memcmp(buf, obj.via.ext.ptr, sizeof(buf)));
-  msgpack_zone_destroy(&z);
-  msgpack_sbuffer_destroy(&sbuf);
+    msgpack_pack_ext(&pk, size, 80);
+    msgpack_pack_ext_body(&pk, buf, sizeof(buf));
+    msgpack_zone z;
+    msgpack_zone_init(&z, 2048);
+    msgpack_object obj;
+    msgpack_unpack_return ret =
+        msgpack_unpack(sbuf.data, sbuf.size, NULL, &z, &obj);
+    EXPECT_EQ(MSGPACK_UNPACK_SUCCESS, ret);
+    EXPECT_EQ(MSGPACK_OBJECT_EXT, obj.type);
+    EXPECT_EQ(size, obj.via.ext.size);
+    EXPECT_EQ(80, obj.via.ext.type);
+    EXPECT_EQ(0, memcmp(buf, obj.via.ext.ptr, sizeof(buf)));
+    msgpack_zone_destroy(&z);
+    msgpack_sbuffer_destroy(&sbuf);
 }
 
 TEST(MSGPACKC, simple_buffer_fixext_4byte_65536)
 {
-  const size_t size = 65536;
-  char buf[size];
-  for (size_t i = 0; i != size; ++i) buf[i] = i;
+    const size_t size = 65536;
+    char buf[size];
+    for (size_t i = 0; i != size; ++i) buf[i] = i;
 
-  msgpack_sbuffer sbuf;
-  msgpack_sbuffer_init(&sbuf);
-  msgpack_packer pk;
-  msgpack_packer_init(&pk, &sbuf, msgpack_sbuffer_write);
+    msgpack_sbuffer sbuf;
+    msgpack_sbuffer_init(&sbuf);
+    msgpack_packer pk;
+    msgpack_packer_init(&pk, &sbuf, msgpack_sbuffer_write);
 
-  msgpack_pack_ext(&pk, size, 81);
-  msgpack_pack_ext_body(&pk, buf, sizeof(buf));
-  msgpack_zone z;
-  msgpack_zone_init(&z, 2048);
-  msgpack_object obj;
-  msgpack_unpack_return ret =
-    msgpack_unpack(sbuf.data, sbuf.size, NULL, &z, &obj);
-  EXPECT_EQ(MSGPACK_UNPACK_SUCCESS, ret);
-  EXPECT_EQ(MSGPACK_OBJECT_EXT, obj.type);
-  EXPECT_EQ(size, obj.via.ext.size);
-  EXPECT_EQ(81, obj.via.ext.type);
-  EXPECT_EQ(0, memcmp(buf, obj.via.ext.ptr, sizeof(buf)));
-  msgpack_zone_destroy(&z);
-  msgpack_sbuffer_destroy(&sbuf);
+    msgpack_pack_ext(&pk, size, 81);
+    msgpack_pack_ext_body(&pk, buf, sizeof(buf));
+    msgpack_zone z;
+    msgpack_zone_init(&z, 2048);
+    msgpack_object obj;
+    msgpack_unpack_return ret =
+        msgpack_unpack(sbuf.data, sbuf.size, NULL, &z, &obj);
+    EXPECT_EQ(MSGPACK_UNPACK_SUCCESS, ret);
+    EXPECT_EQ(MSGPACK_OBJECT_EXT, obj.type);
+    EXPECT_EQ(size, obj.via.ext.size);
+    EXPECT_EQ(81, obj.via.ext.type);
+    EXPECT_EQ(0, memcmp(buf, obj.via.ext.ptr, sizeof(buf)));
+    msgpack_zone_destroy(&z);
+    msgpack_sbuffer_destroy(&sbuf);
 }
 
 TEST(MSGPACKC, simple_buffer_array)
 {
-  unsigned int array_size = 5;
+    unsigned int array_size = 5;
 
-  msgpack_sbuffer sbuf;
-  msgpack_sbuffer_init(&sbuf);
-  msgpack_packer pk;
-  msgpack_packer_init(&pk, &sbuf, msgpack_sbuffer_write);
-  msgpack_pack_array(&pk, array_size);
-  msgpack_pack_nil(&pk);
-  msgpack_pack_true(&pk);
-  msgpack_pack_false(&pk);
-  msgpack_pack_int(&pk, 10);
-  msgpack_pack_int(&pk, -10);
+    msgpack_sbuffer sbuf;
+    msgpack_sbuffer_init(&sbuf);
+    msgpack_packer pk;
+    msgpack_packer_init(&pk, &sbuf, msgpack_sbuffer_write);
+    msgpack_pack_array(&pk, array_size);
+    msgpack_pack_nil(&pk);
+    msgpack_pack_true(&pk);
+    msgpack_pack_false(&pk);
+    msgpack_pack_int(&pk, 10);
+    msgpack_pack_int(&pk, -10);
 
-  msgpack_zone z;
-  msgpack_zone_init(&z, 2048);
-  msgpack_object obj;
-  msgpack_unpack_return ret;
-  ret = msgpack_unpack(sbuf.data, sbuf.size, NULL, &z, &obj);
-  EXPECT_EQ(MSGPACK_UNPACK_SUCCESS, ret);
-  EXPECT_EQ(MSGPACK_OBJECT_ARRAY, obj.type);
-  EXPECT_EQ(array_size, obj.via.array.size);
+    msgpack_zone z;
+    msgpack_zone_init(&z, 2048);
+    msgpack_object obj;
+    msgpack_unpack_return ret;
+    ret = msgpack_unpack(sbuf.data, sbuf.size, NULL, &z, &obj);
+    EXPECT_EQ(MSGPACK_UNPACK_SUCCESS, ret);
+    EXPECT_EQ(MSGPACK_OBJECT_ARRAY, obj.type);
+    EXPECT_EQ(array_size, obj.via.array.size);
 
-  for (unsigned int i = 0; i < obj.via.array.size; i++) {
-    msgpack_object o = obj.via.array.ptr[i];
-    switch (i) {
-    case 0:
-      EXPECT_EQ(MSGPACK_OBJECT_NIL, o.type);
-      break;
-    case 1:
-      EXPECT_EQ(MSGPACK_OBJECT_BOOLEAN, o.type);
-      EXPECT_EQ(true, o.via.boolean);
-      break;
-    case 2:
-      EXPECT_EQ(MSGPACK_OBJECT_BOOLEAN, o.type);
-      EXPECT_EQ(false, o.via.boolean);
-      break;
-    case 3:
-      EXPECT_EQ(MSGPACK_OBJECT_POSITIVE_INTEGER, o.type);
-      EXPECT_EQ(10u, o.via.u64);
-      break;
-    case 4:
-      EXPECT_EQ(MSGPACK_OBJECT_NEGATIVE_INTEGER, o.type);
-      EXPECT_EQ(-10, o.via.i64);
-      break;
+    for (unsigned int i = 0; i < obj.via.array.size; i++) {
+        msgpack_object o = obj.via.array.ptr[i];
+        switch (i) {
+        case 0:
+            EXPECT_EQ(MSGPACK_OBJECT_NIL, o.type);
+            break;
+        case 1:
+            EXPECT_EQ(MSGPACK_OBJECT_BOOLEAN, o.type);
+            EXPECT_EQ(true, o.via.boolean);
+            break;
+        case 2:
+            EXPECT_EQ(MSGPACK_OBJECT_BOOLEAN, o.type);
+            EXPECT_EQ(false, o.via.boolean);
+            break;
+        case 3:
+            EXPECT_EQ(MSGPACK_OBJECT_POSITIVE_INTEGER, o.type);
+            EXPECT_EQ(10u, o.via.u64);
+            break;
+        case 4:
+            EXPECT_EQ(MSGPACK_OBJECT_NEGATIVE_INTEGER, o.type);
+            EXPECT_EQ(-10, o.via.i64);
+            break;
+        }
     }
-  }
 
-  msgpack_zone_destroy(&z);
-  msgpack_sbuffer_destroy(&sbuf);
+    msgpack_zone_destroy(&z);
+    msgpack_sbuffer_destroy(&sbuf);
 }
 
 TEST(MSGPACKC, simple_buffer_map)
 {
-  unsigned int map_size = 2;
+    unsigned int map_size = 2;
 
-  msgpack_sbuffer sbuf;
-  msgpack_sbuffer_init(&sbuf);
-  msgpack_packer pk;
-  msgpack_packer_init(&pk, &sbuf, msgpack_sbuffer_write);
-  msgpack_pack_map(&pk, map_size);
-  msgpack_pack_true(&pk);
-  msgpack_pack_false(&pk);
-  msgpack_pack_int(&pk, 10);
-  msgpack_pack_int(&pk, -10);
+    msgpack_sbuffer sbuf;
+    msgpack_sbuffer_init(&sbuf);
+    msgpack_packer pk;
+    msgpack_packer_init(&pk, &sbuf, msgpack_sbuffer_write);
+    msgpack_pack_map(&pk, map_size);
+    msgpack_pack_true(&pk);
+    msgpack_pack_false(&pk);
+    msgpack_pack_int(&pk, 10);
+    msgpack_pack_int(&pk, -10);
 
-  msgpack_zone z;
-  msgpack_zone_init(&z, 2048);
-  msgpack_object obj;
-  msgpack_unpack_return ret;
-  ret = msgpack_unpack(sbuf.data, sbuf.size, NULL, &z, &obj);
-  EXPECT_EQ(MSGPACK_UNPACK_SUCCESS, ret);
-  EXPECT_EQ(MSGPACK_OBJECT_MAP, obj.type);
-  EXPECT_EQ(map_size, obj.via.map.size);
+    msgpack_zone z;
+    msgpack_zone_init(&z, 2048);
+    msgpack_object obj;
+    msgpack_unpack_return ret;
+    ret = msgpack_unpack(sbuf.data, sbuf.size, NULL, &z, &obj);
+    EXPECT_EQ(MSGPACK_UNPACK_SUCCESS, ret);
+    EXPECT_EQ(MSGPACK_OBJECT_MAP, obj.type);
+    EXPECT_EQ(map_size, obj.via.map.size);
 
-  for (unsigned int i = 0; i < map_size; i++) {
-    msgpack_object key = obj.via.map.ptr[i].key;
-    msgpack_object val = obj.via.map.ptr[i].val;
-    switch (i) {
-    case 0:
-      EXPECT_EQ(MSGPACK_OBJECT_BOOLEAN, key.type);
-      EXPECT_EQ(true, key.via.boolean);
-      EXPECT_EQ(MSGPACK_OBJECT_BOOLEAN, val.type);
-      EXPECT_EQ(false, val.via.boolean);
-      break;
-    case 1:
-      EXPECT_EQ(MSGPACK_OBJECT_POSITIVE_INTEGER, key.type);
-      EXPECT_EQ(10u, key.via.u64);
-      EXPECT_EQ(MSGPACK_OBJECT_NEGATIVE_INTEGER, val.type);
-      EXPECT_EQ(-10, val.via.i64);
-      break;
+    for (unsigned int i = 0; i < map_size; i++) {
+        msgpack_object key = obj.via.map.ptr[i].key;
+        msgpack_object val = obj.via.map.ptr[i].val;
+        switch (i) {
+        case 0:
+            EXPECT_EQ(MSGPACK_OBJECT_BOOLEAN, key.type);
+            EXPECT_EQ(true, key.via.boolean);
+            EXPECT_EQ(MSGPACK_OBJECT_BOOLEAN, val.type);
+            EXPECT_EQ(false, val.via.boolean);
+            break;
+        case 1:
+            EXPECT_EQ(MSGPACK_OBJECT_POSITIVE_INTEGER, key.type);
+            EXPECT_EQ(10u, key.via.u64);
+            EXPECT_EQ(MSGPACK_OBJECT_NEGATIVE_INTEGER, val.type);
+            EXPECT_EQ(-10, val.via.i64);
+            break;
+        }
     }
-  }
 
-  msgpack_zone_destroy(&z);
-  msgpack_sbuffer_destroy(&sbuf);
+    msgpack_zone_destroy(&z);
+    msgpack_sbuffer_destroy(&sbuf);
 }
 
 TEST(MSGPACKC, simple_buffer_str)
 {
-  unsigned int str_size = 7;
+    unsigned int str_size = 7;
 
-  msgpack_sbuffer sbuf;
-  msgpack_sbuffer_init(&sbuf);
-  msgpack_packer pk;
-  msgpack_packer_init(&pk, &sbuf, msgpack_sbuffer_write);
-  msgpack_pack_str(&pk, str_size);
-  msgpack_pack_str_body(&pk, "fr", 2);
-  msgpack_pack_str_body(&pk, "syuki", 5);
-  // invalid data
-  msgpack_pack_str_body(&pk, "", 0);
-  msgpack_pack_str_body(&pk, "kzk", 0);
+    msgpack_sbuffer sbuf;
+    msgpack_sbuffer_init(&sbuf);
+    msgpack_packer pk;
+    msgpack_packer_init(&pk, &sbuf, msgpack_sbuffer_write);
+    msgpack_pack_str(&pk, str_size);
+    msgpack_pack_str_body(&pk, "fr", 2);
+    msgpack_pack_str_body(&pk, "syuki", 5);
+    // invalid data
+    msgpack_pack_str_body(&pk, "", 0);
+    msgpack_pack_str_body(&pk, "kzk", 0);
 
-  msgpack_zone z;
-  msgpack_zone_init(&z, 2048);
-  msgpack_object obj;
-  msgpack_unpack_return ret;
-  ret = msgpack_unpack(sbuf.data, sbuf.size, NULL, &z, &obj);
-  EXPECT_EQ(MSGPACK_UNPACK_SUCCESS, ret);
-  EXPECT_EQ(MSGPACK_OBJECT_STR, obj.type);
-  EXPECT_EQ(str_size, obj.via.str.size);
-  EXPECT_EQ(0, memcmp("frsyuki", obj.via.str.ptr, str_size));
+    msgpack_zone z;
+    msgpack_zone_init(&z, 2048);
+    msgpack_object obj;
+    msgpack_unpack_return ret;
+    ret = msgpack_unpack(sbuf.data, sbuf.size, NULL, &z, &obj);
+    EXPECT_EQ(MSGPACK_UNPACK_SUCCESS, ret);
+    EXPECT_EQ(MSGPACK_OBJECT_STR, obj.type);
+    EXPECT_EQ(str_size, obj.via.str.size);
+    EXPECT_EQ(0, memcmp("frsyuki", obj.via.str.ptr, str_size));
 
-  msgpack_zone_destroy(&z);
-  msgpack_sbuffer_destroy(&sbuf);
+    msgpack_zone_destroy(&z);
+    msgpack_sbuffer_destroy(&sbuf);
 }
 
 TEST(MSGPACKC, simple_buffer_str_fix_l)
 {
-  char const* str = NULL;
-  unsigned int str_size = 0;
-  msgpack_sbuffer sbuf;
-  msgpack_sbuffer_init(&sbuf);
-  msgpack_packer pk;
-  msgpack_packer_init(&pk, &sbuf, msgpack_sbuffer_write);
-  msgpack_pack_str(&pk, str_size);
-  msgpack_pack_str_body(&pk, str, str_size);
-  EXPECT_EQ(sbuf.size, 0x01u);
-  EXPECT_EQ(sbuf.data[0], static_cast<char>(0xa0u));
+    char const* str = NULL;
+    unsigned int str_size = 0;
+    msgpack_sbuffer sbuf;
+    msgpack_sbuffer_init(&sbuf);
+    msgpack_packer pk;
+    msgpack_packer_init(&pk, &sbuf, msgpack_sbuffer_write);
+    msgpack_pack_str(&pk, str_size);
+    msgpack_pack_str_body(&pk, str, str_size);
+    EXPECT_EQ(sbuf.size, 0x01u);
+    EXPECT_EQ(sbuf.data[0], static_cast<char>(0xa0u));
 
-  msgpack_zone z;
-  msgpack_zone_init(&z, 2048);
-  msgpack_object obj;
-  msgpack_unpack_return ret;
-  ret = msgpack_unpack(sbuf.data, sbuf.size, NULL, &z, &obj);
-  EXPECT_EQ(MSGPACK_UNPACK_SUCCESS, ret);
-  EXPECT_EQ(MSGPACK_OBJECT_STR, obj.type);
-  EXPECT_EQ(str_size, obj.via.str.size);
-  EXPECT_EQ(0, memcmp(str, obj.via.str.ptr, str_size));
+    msgpack_zone z;
+    msgpack_zone_init(&z, 2048);
+    msgpack_object obj;
+    msgpack_unpack_return ret;
+    ret = msgpack_unpack(sbuf.data, sbuf.size, NULL, &z, &obj);
+    EXPECT_EQ(MSGPACK_UNPACK_SUCCESS, ret);
+    EXPECT_EQ(MSGPACK_OBJECT_STR, obj.type);
+    EXPECT_EQ(str_size, obj.via.str.size);
+    EXPECT_EQ(0, memcmp(str, obj.via.str.ptr, str_size));
 
-  msgpack_zone_destroy(&z);
-  msgpack_sbuffer_destroy(&sbuf);
+    msgpack_zone_destroy(&z);
+    msgpack_sbuffer_destroy(&sbuf);
 }
 
 TEST(MSGPACKC, simple_buffer_str_fix_h)
 {
-  char str[0x1f] = {'0'};
-  unsigned int str_size = sizeof(str);
-  msgpack_sbuffer sbuf;
-  msgpack_sbuffer_init(&sbuf);
-  msgpack_packer pk;
-  msgpack_packer_init(&pk, &sbuf, msgpack_sbuffer_write);
-  msgpack_pack_str(&pk, str_size);
-  msgpack_pack_str_body(&pk, str, str_size);
-  EXPECT_EQ(sbuf.size, 0x1f+1u);
-  EXPECT_EQ(sbuf.data[0], static_cast<char>(0xbfu));
+    char str[0x1f] = {'0'};
+    unsigned int str_size = sizeof(str);
+    msgpack_sbuffer sbuf;
+    msgpack_sbuffer_init(&sbuf);
+    msgpack_packer pk;
+    msgpack_packer_init(&pk, &sbuf, msgpack_sbuffer_write);
+    msgpack_pack_str(&pk, str_size);
+    msgpack_pack_str_body(&pk, str, str_size);
+    EXPECT_EQ(sbuf.size, 0x1f+1u);
+    EXPECT_EQ(sbuf.data[0], static_cast<char>(0xbfu));
 
-  msgpack_zone z;
-  msgpack_zone_init(&z, 2048);
-  msgpack_object obj;
-  msgpack_unpack_return ret;
-  ret = msgpack_unpack(sbuf.data, sbuf.size, NULL, &z, &obj);
-  EXPECT_EQ(MSGPACK_UNPACK_SUCCESS, ret);
-  EXPECT_EQ(MSGPACK_OBJECT_STR, obj.type);
-  EXPECT_EQ(str_size, obj.via.str.size);
-  EXPECT_EQ(0, memcmp(str, obj.via.str.ptr, str_size));
+    msgpack_zone z;
+    msgpack_zone_init(&z, 2048);
+    msgpack_object obj;
+    msgpack_unpack_return ret;
+    ret = msgpack_unpack(sbuf.data, sbuf.size, NULL, &z, &obj);
+    EXPECT_EQ(MSGPACK_UNPACK_SUCCESS, ret);
+    EXPECT_EQ(MSGPACK_OBJECT_STR, obj.type);
+    EXPECT_EQ(str_size, obj.via.str.size);
+    EXPECT_EQ(0, memcmp(str, obj.via.str.ptr, str_size));
 
-  msgpack_zone_destroy(&z);
-  msgpack_sbuffer_destroy(&sbuf);
+    msgpack_zone_destroy(&z);
+    msgpack_sbuffer_destroy(&sbuf);
 }
 
 TEST(MSGPACKC, simple_buffer_str_8_l)
 {
-  char str[0x1f+1] = {'0'};
-  unsigned int str_size = sizeof(str);
-  msgpack_sbuffer sbuf;
-  msgpack_sbuffer_init(&sbuf);
-  msgpack_packer pk;
-  msgpack_packer_init(&pk, &sbuf, msgpack_sbuffer_write);
-  msgpack_pack_str(&pk, str_size);
-  msgpack_pack_str_body(&pk, str, str_size);
-  EXPECT_EQ(sbuf.size, 0x1f+1+2u);
-  EXPECT_EQ(sbuf.data[0], static_cast<char>(0xd9u));
-  EXPECT_EQ(sbuf.data[1], static_cast<char>(0x20u));
+    char str[0x1f+1] = {'0'};
+    unsigned int str_size = sizeof(str);
+    msgpack_sbuffer sbuf;
+    msgpack_sbuffer_init(&sbuf);
+    msgpack_packer pk;
+    msgpack_packer_init(&pk, &sbuf, msgpack_sbuffer_write);
+    msgpack_pack_str(&pk, str_size);
+    msgpack_pack_str_body(&pk, str, str_size);
+    EXPECT_EQ(sbuf.size, 0x1f+1+2u);
+    EXPECT_EQ(sbuf.data[0], static_cast<char>(0xd9u));
+    EXPECT_EQ(sbuf.data[1], static_cast<char>(0x20u));
 
-  msgpack_zone z;
-  msgpack_zone_init(&z, 2048);
-  msgpack_object obj;
-  msgpack_unpack_return ret;
-  ret = msgpack_unpack(sbuf.data, sbuf.size, NULL, &z, &obj);
-  EXPECT_EQ(MSGPACK_UNPACK_SUCCESS, ret);
-  EXPECT_EQ(MSGPACK_OBJECT_STR, obj.type);
-  EXPECT_EQ(str_size, obj.via.str.size);
-  EXPECT_EQ(0, memcmp(str, obj.via.str.ptr, str_size));
+    msgpack_zone z;
+    msgpack_zone_init(&z, 2048);
+    msgpack_object obj;
+    msgpack_unpack_return ret;
+    ret = msgpack_unpack(sbuf.data, sbuf.size, NULL, &z, &obj);
+    EXPECT_EQ(MSGPACK_UNPACK_SUCCESS, ret);
+    EXPECT_EQ(MSGPACK_OBJECT_STR, obj.type);
+    EXPECT_EQ(str_size, obj.via.str.size);
+    EXPECT_EQ(0, memcmp(str, obj.via.str.ptr, str_size));
 
-  msgpack_zone_destroy(&z);
-  msgpack_sbuffer_destroy(&sbuf);
+    msgpack_zone_destroy(&z);
+    msgpack_sbuffer_destroy(&sbuf);
 }
 
 TEST(MSGPACKC, simple_buffer_str_8_h)
 {
-  char str[0xff] = {'0'};
-  unsigned int str_size = sizeof(str);
-  msgpack_sbuffer sbuf;
-  msgpack_sbuffer_init(&sbuf);
-  msgpack_packer pk;
-  msgpack_packer_init(&pk, &sbuf, msgpack_sbuffer_write);
-  msgpack_pack_str(&pk, str_size);
-  msgpack_pack_str_body(&pk, str, str_size);
-  EXPECT_EQ(sbuf.size, 0xff+2u);
-  EXPECT_EQ(sbuf.data[0], static_cast<char>(0xd9u));
-  EXPECT_EQ(sbuf.data[1], static_cast<char>(0xffu));
+    char str[0xff] = {'0'};
+    unsigned int str_size = sizeof(str);
+    msgpack_sbuffer sbuf;
+    msgpack_sbuffer_init(&sbuf);
+    msgpack_packer pk;
+    msgpack_packer_init(&pk, &sbuf, msgpack_sbuffer_write);
+    msgpack_pack_str(&pk, str_size);
+    msgpack_pack_str_body(&pk, str, str_size);
+    EXPECT_EQ(sbuf.size, 0xff+2u);
+    EXPECT_EQ(sbuf.data[0], static_cast<char>(0xd9u));
+    EXPECT_EQ(sbuf.data[1], static_cast<char>(0xffu));
 
-  msgpack_zone z;
-  msgpack_zone_init(&z, 2048);
-  msgpack_object obj;
-  msgpack_unpack_return ret;
-  ret = msgpack_unpack(sbuf.data, sbuf.size, NULL, &z, &obj);
-  EXPECT_EQ(MSGPACK_UNPACK_SUCCESS, ret);
-  EXPECT_EQ(MSGPACK_OBJECT_STR, obj.type);
-  EXPECT_EQ(str_size, obj.via.str.size);
-  EXPECT_EQ(0, memcmp(str, obj.via.str.ptr, str_size));
+    msgpack_zone z;
+    msgpack_zone_init(&z, 2048);
+    msgpack_object obj;
+    msgpack_unpack_return ret;
+    ret = msgpack_unpack(sbuf.data, sbuf.size, NULL, &z, &obj);
+    EXPECT_EQ(MSGPACK_UNPACK_SUCCESS, ret);
+    EXPECT_EQ(MSGPACK_OBJECT_STR, obj.type);
+    EXPECT_EQ(str_size, obj.via.str.size);
+    EXPECT_EQ(0, memcmp(str, obj.via.str.ptr, str_size));
 
-  msgpack_zone_destroy(&z);
-  msgpack_sbuffer_destroy(&sbuf);
+    msgpack_zone_destroy(&z);
+    msgpack_sbuffer_destroy(&sbuf);
 }
 
 TEST(MSGPACKC, simple_buffer_str_16_l)
 {
-  char str[0xff+1] = {'0'};
-  unsigned int str_size = sizeof(str);
-  msgpack_sbuffer sbuf;
-  msgpack_sbuffer_init(&sbuf);
-  msgpack_packer pk;
-  msgpack_packer_init(&pk, &sbuf, msgpack_sbuffer_write);
-  msgpack_pack_str(&pk, str_size);
-  msgpack_pack_str_body(&pk, str, str_size);
-  EXPECT_EQ(sbuf.size, 0xff+1+3u);
-  EXPECT_EQ(sbuf.data[0], static_cast<char>(0xdau));
-  EXPECT_EQ(sbuf.data[1], static_cast<char>(0x01u));
-  EXPECT_EQ(sbuf.data[2], static_cast<char>(0x00u));
+    char str[0xff+1] = {'0'};
+    unsigned int str_size = sizeof(str);
+    msgpack_sbuffer sbuf;
+    msgpack_sbuffer_init(&sbuf);
+    msgpack_packer pk;
+    msgpack_packer_init(&pk, &sbuf, msgpack_sbuffer_write);
+    msgpack_pack_str(&pk, str_size);
+    msgpack_pack_str_body(&pk, str, str_size);
+    EXPECT_EQ(sbuf.size, 0xff+1+3u);
+    EXPECT_EQ(sbuf.data[0], static_cast<char>(0xdau));
+    EXPECT_EQ(sbuf.data[1], static_cast<char>(0x01u));
+    EXPECT_EQ(sbuf.data[2], static_cast<char>(0x00u));
 
-  msgpack_zone z;
-  msgpack_zone_init(&z, 2048);
-  msgpack_object obj;
-  msgpack_unpack_return ret;
-  ret = msgpack_unpack(sbuf.data, sbuf.size, NULL, &z, &obj);
-  EXPECT_EQ(MSGPACK_UNPACK_SUCCESS, ret);
-  EXPECT_EQ(MSGPACK_OBJECT_STR, obj.type);
-  EXPECT_EQ(str_size, obj.via.str.size);
-  EXPECT_EQ(0, memcmp(str, obj.via.str.ptr, str_size));
+    msgpack_zone z;
+    msgpack_zone_init(&z, 2048);
+    msgpack_object obj;
+    msgpack_unpack_return ret;
+    ret = msgpack_unpack(sbuf.data, sbuf.size, NULL, &z, &obj);
+    EXPECT_EQ(MSGPACK_UNPACK_SUCCESS, ret);
+    EXPECT_EQ(MSGPACK_OBJECT_STR, obj.type);
+    EXPECT_EQ(str_size, obj.via.str.size);
+    EXPECT_EQ(0, memcmp(str, obj.via.str.ptr, str_size));
 
-  msgpack_zone_destroy(&z);
-  msgpack_sbuffer_destroy(&sbuf);
+    msgpack_zone_destroy(&z);
+    msgpack_sbuffer_destroy(&sbuf);
 }
 
 TEST(MSGPACKC, simple_buffer_str_16_h)
 {
-  char str[0xffff] = {'0'};
-  unsigned int str_size = sizeof(str);
-  msgpack_sbuffer sbuf;
-  msgpack_sbuffer_init(&sbuf);
-  msgpack_packer pk;
-  msgpack_packer_init(&pk, &sbuf, msgpack_sbuffer_write);
-  msgpack_pack_str(&pk, str_size);
-  msgpack_pack_str_body(&pk, str, str_size);
-  EXPECT_EQ(sbuf.size, 0xffff+3u);
-  EXPECT_EQ(sbuf.data[0], static_cast<char>(0xdau));
-  EXPECT_EQ(sbuf.data[1], static_cast<char>(0xffu));
-  EXPECT_EQ(sbuf.data[2], static_cast<char>(0xffu));
+    char str[0xffff] = {'0'};
+    unsigned int str_size = sizeof(str);
+    msgpack_sbuffer sbuf;
+    msgpack_sbuffer_init(&sbuf);
+    msgpack_packer pk;
+    msgpack_packer_init(&pk, &sbuf, msgpack_sbuffer_write);
+    msgpack_pack_str(&pk, str_size);
+    msgpack_pack_str_body(&pk, str, str_size);
+    EXPECT_EQ(sbuf.size, 0xffff+3u);
+    EXPECT_EQ(sbuf.data[0], static_cast<char>(0xdau));
+    EXPECT_EQ(sbuf.data[1], static_cast<char>(0xffu));
+    EXPECT_EQ(sbuf.data[2], static_cast<char>(0xffu));
 
-  msgpack_zone z;
-  msgpack_zone_init(&z, 2048);
-  msgpack_object obj;
-  msgpack_unpack_return ret;
-  ret = msgpack_unpack(sbuf.data, sbuf.size, NULL, &z, &obj);
-  EXPECT_EQ(MSGPACK_UNPACK_SUCCESS, ret);
-  EXPECT_EQ(MSGPACK_OBJECT_STR, obj.type);
-  EXPECT_EQ(str_size, obj.via.str.size);
-  EXPECT_EQ(0, memcmp(str, obj.via.str.ptr, str_size));
+    msgpack_zone z;
+    msgpack_zone_init(&z, 2048);
+    msgpack_object obj;
+    msgpack_unpack_return ret;
+    ret = msgpack_unpack(sbuf.data, sbuf.size, NULL, &z, &obj);
+    EXPECT_EQ(MSGPACK_UNPACK_SUCCESS, ret);
+    EXPECT_EQ(MSGPACK_OBJECT_STR, obj.type);
+    EXPECT_EQ(str_size, obj.via.str.size);
+    EXPECT_EQ(0, memcmp(str, obj.via.str.ptr, str_size));
 
-  msgpack_zone_destroy(&z);
-  msgpack_sbuffer_destroy(&sbuf);
+    msgpack_zone_destroy(&z);
+    msgpack_sbuffer_destroy(&sbuf);
 }
 
 TEST(MSGPACKC, simple_buffer_str_32_l)
 {
-  char str[0xffff+1] = {'0'};
-  unsigned int str_size = sizeof(str);
-  msgpack_sbuffer sbuf;
-  msgpack_sbuffer_init(&sbuf);
-  msgpack_packer pk;
-  msgpack_packer_init(&pk, &sbuf, msgpack_sbuffer_write);
-  msgpack_pack_str(&pk, str_size);
-  msgpack_pack_str_body(&pk, str, str_size);
-  EXPECT_EQ(sbuf.size, 0xffff+1+5u);
-  EXPECT_EQ(sbuf.data[0], static_cast<char>(0xdbu));
-  EXPECT_EQ(sbuf.data[1], static_cast<char>(0x00u));
-  EXPECT_EQ(sbuf.data[2], static_cast<char>(0x01u));
-  EXPECT_EQ(sbuf.data[3], static_cast<char>(0x00u));
-  EXPECT_EQ(sbuf.data[4], static_cast<char>(0x00u));
+    char str[0xffff+1] = {'0'};
+    unsigned int str_size = sizeof(str);
+    msgpack_sbuffer sbuf;
+    msgpack_sbuffer_init(&sbuf);
+    msgpack_packer pk;
+    msgpack_packer_init(&pk, &sbuf, msgpack_sbuffer_write);
+    msgpack_pack_str(&pk, str_size);
+    msgpack_pack_str_body(&pk, str, str_size);
+    EXPECT_EQ(sbuf.size, 0xffff+1+5u);
+    EXPECT_EQ(sbuf.data[0], static_cast<char>(0xdbu));
+    EXPECT_EQ(sbuf.data[1], static_cast<char>(0x00u));
+    EXPECT_EQ(sbuf.data[2], static_cast<char>(0x01u));
+    EXPECT_EQ(sbuf.data[3], static_cast<char>(0x00u));
+    EXPECT_EQ(sbuf.data[4], static_cast<char>(0x00u));
 
-  msgpack_zone z;
-  msgpack_zone_init(&z, 2048);
-  msgpack_object obj;
-  msgpack_unpack_return ret;
-  ret = msgpack_unpack(sbuf.data, sbuf.size, NULL, &z, &obj);
-  EXPECT_EQ(MSGPACK_UNPACK_SUCCESS, ret);
-  EXPECT_EQ(MSGPACK_OBJECT_STR, obj.type);
-  EXPECT_EQ(str_size, obj.via.str.size);
-  EXPECT_EQ(0, memcmp(str, obj.via.str.ptr, str_size));
+    msgpack_zone z;
+    msgpack_zone_init(&z, 2048);
+    msgpack_object obj;
+    msgpack_unpack_return ret;
+    ret = msgpack_unpack(sbuf.data, sbuf.size, NULL, &z, &obj);
+    EXPECT_EQ(MSGPACK_UNPACK_SUCCESS, ret);
+    EXPECT_EQ(MSGPACK_OBJECT_STR, obj.type);
+    EXPECT_EQ(str_size, obj.via.str.size);
+    EXPECT_EQ(0, memcmp(str, obj.via.str.ptr, str_size));
 
-  msgpack_zone_destroy(&z);
-  msgpack_sbuffer_destroy(&sbuf);
+    msgpack_zone_destroy(&z);
+    msgpack_sbuffer_destroy(&sbuf);
 }
 
 TEST(MSGPACKC, simple_buffer_v4raw_fix_l)
 {
-  char const* str = NULL;
-  unsigned int str_size = 0;
-  msgpack_sbuffer sbuf;
-  msgpack_sbuffer_init(&sbuf);
-  msgpack_packer pk;
-  msgpack_packer_init(&pk, &sbuf, msgpack_sbuffer_write);
-  msgpack_pack_v4raw(&pk, str_size);
-  msgpack_pack_v4raw_body(&pk, str, str_size);
-  EXPECT_EQ(sbuf.size, 0x01u);
-  EXPECT_EQ(sbuf.data[0], static_cast<char>(0xa0u));
+    char const* str = NULL;
+    unsigned int str_size = 0;
+    msgpack_sbuffer sbuf;
+    msgpack_sbuffer_init(&sbuf);
+    msgpack_packer pk;
+    msgpack_packer_init(&pk, &sbuf, msgpack_sbuffer_write);
+    msgpack_pack_v4raw(&pk, str_size);
+    msgpack_pack_v4raw_body(&pk, str, str_size);
+    EXPECT_EQ(sbuf.size, 0x01u);
+    EXPECT_EQ(sbuf.data[0], static_cast<char>(0xa0u));
 
-  msgpack_zone z;
-  msgpack_zone_init(&z, 2048);
-  msgpack_object obj;
-  msgpack_unpack_return ret;
-  ret = msgpack_unpack(sbuf.data, sbuf.size, NULL, &z, &obj);
-  EXPECT_EQ(MSGPACK_UNPACK_SUCCESS, ret);
-  EXPECT_EQ(MSGPACK_OBJECT_STR, obj.type);
-  EXPECT_EQ(str_size, obj.via.str.size);
-  EXPECT_EQ(0, memcmp(str, obj.via.str.ptr, str_size));
+    msgpack_zone z;
+    msgpack_zone_init(&z, 2048);
+    msgpack_object obj;
+    msgpack_unpack_return ret;
+    ret = msgpack_unpack(sbuf.data, sbuf.size, NULL, &z, &obj);
+    EXPECT_EQ(MSGPACK_UNPACK_SUCCESS, ret);
+    EXPECT_EQ(MSGPACK_OBJECT_STR, obj.type);
+    EXPECT_EQ(str_size, obj.via.str.size);
+    EXPECT_EQ(0, memcmp(str, obj.via.str.ptr, str_size));
 
-  msgpack_zone_destroy(&z);
-  msgpack_sbuffer_destroy(&sbuf);
+    msgpack_zone_destroy(&z);
+    msgpack_sbuffer_destroy(&sbuf);
 }
 
 TEST(MSGPACKC, simple_buffer_v4raw_fix_h)
 {
-  char str[0x1f] = {'0'};
-  unsigned int str_size = sizeof(str);
-  msgpack_sbuffer sbuf;
-  msgpack_sbuffer_init(&sbuf);
-  msgpack_packer pk;
-  msgpack_packer_init(&pk, &sbuf, msgpack_sbuffer_write);
-  msgpack_pack_v4raw(&pk, str_size);
-  msgpack_pack_v4raw_body(&pk, str, str_size);
-  EXPECT_EQ(sbuf.size, 0x1f+1u);
-  EXPECT_EQ(sbuf.data[0], static_cast<char>(0xbfu));
+    char str[0x1f] = {'0'};
+    unsigned int str_size = sizeof(str);
+    msgpack_sbuffer sbuf;
+    msgpack_sbuffer_init(&sbuf);
+    msgpack_packer pk;
+    msgpack_packer_init(&pk, &sbuf, msgpack_sbuffer_write);
+    msgpack_pack_v4raw(&pk, str_size);
+    msgpack_pack_v4raw_body(&pk, str, str_size);
+    EXPECT_EQ(sbuf.size, 0x1f+1u);
+    EXPECT_EQ(sbuf.data[0], static_cast<char>(0xbfu));
 
-  msgpack_zone z;
-  msgpack_zone_init(&z, 2048);
-  msgpack_object obj;
-  msgpack_unpack_return ret;
-  ret = msgpack_unpack(sbuf.data, sbuf.size, NULL, &z, &obj);
-  EXPECT_EQ(MSGPACK_UNPACK_SUCCESS, ret);
-  EXPECT_EQ(MSGPACK_OBJECT_STR, obj.type);
-  EXPECT_EQ(str_size, obj.via.str.size);
-  EXPECT_EQ(0, memcmp(str, obj.via.str.ptr, str_size));
+    msgpack_zone z;
+    msgpack_zone_init(&z, 2048);
+    msgpack_object obj;
+    msgpack_unpack_return ret;
+    ret = msgpack_unpack(sbuf.data, sbuf.size, NULL, &z, &obj);
+    EXPECT_EQ(MSGPACK_UNPACK_SUCCESS, ret);
+    EXPECT_EQ(MSGPACK_OBJECT_STR, obj.type);
+    EXPECT_EQ(str_size, obj.via.str.size);
+    EXPECT_EQ(0, memcmp(str, obj.via.str.ptr, str_size));
 
-  msgpack_zone_destroy(&z);
-  msgpack_sbuffer_destroy(&sbuf);
+    msgpack_zone_destroy(&z);
+    msgpack_sbuffer_destroy(&sbuf);
 }
 
 TEST(MSGPACKC, simple_buffer_v4raw_16_l)
 {
-  char str[0x1f+1] = {'0'};
-  unsigned int str_size = sizeof(str);
-  msgpack_sbuffer sbuf;
-  msgpack_sbuffer_init(&sbuf);
-  msgpack_packer pk;
-  msgpack_packer_init(&pk, &sbuf, msgpack_sbuffer_write);
-  msgpack_pack_v4raw(&pk, str_size);
-  msgpack_pack_v4raw_body(&pk, str, str_size);
-  EXPECT_EQ(sbuf.size, 0x1f+1+3u);
-  EXPECT_EQ(sbuf.data[0], static_cast<char>(0xdau));
-  EXPECT_EQ(sbuf.data[1], static_cast<char>(0x00u));
-  EXPECT_EQ(sbuf.data[2], static_cast<char>(0x20u));
+    char str[0x1f+1] = {'0'};
+    unsigned int str_size = sizeof(str);
+    msgpack_sbuffer sbuf;
+    msgpack_sbuffer_init(&sbuf);
+    msgpack_packer pk;
+    msgpack_packer_init(&pk, &sbuf, msgpack_sbuffer_write);
+    msgpack_pack_v4raw(&pk, str_size);
+    msgpack_pack_v4raw_body(&pk, str, str_size);
+    EXPECT_EQ(sbuf.size, 0x1f+1+3u);
+    EXPECT_EQ(sbuf.data[0], static_cast<char>(0xdau));
+    EXPECT_EQ(sbuf.data[1], static_cast<char>(0x00u));
+    EXPECT_EQ(sbuf.data[2], static_cast<char>(0x20u));
 
-  msgpack_zone z;
-  msgpack_zone_init(&z, 2048);
-  msgpack_object obj;
-  msgpack_unpack_return ret;
-  ret = msgpack_unpack(sbuf.data, sbuf.size, NULL, &z, &obj);
-  EXPECT_EQ(MSGPACK_UNPACK_SUCCESS, ret);
-  EXPECT_EQ(MSGPACK_OBJECT_STR, obj.type);
-  EXPECT_EQ(str_size, obj.via.str.size);
-  EXPECT_EQ(0, memcmp(str, obj.via.str.ptr, str_size));
+    msgpack_zone z;
+    msgpack_zone_init(&z, 2048);
+    msgpack_object obj;
+    msgpack_unpack_return ret;
+    ret = msgpack_unpack(sbuf.data, sbuf.size, NULL, &z, &obj);
+    EXPECT_EQ(MSGPACK_UNPACK_SUCCESS, ret);
+    EXPECT_EQ(MSGPACK_OBJECT_STR, obj.type);
+    EXPECT_EQ(str_size, obj.via.str.size);
+    EXPECT_EQ(0, memcmp(str, obj.via.str.ptr, str_size));
 
-  msgpack_zone_destroy(&z);
-  msgpack_sbuffer_destroy(&sbuf);
+    msgpack_zone_destroy(&z);
+    msgpack_sbuffer_destroy(&sbuf);
 }
 
 TEST(MSGPACKC, simple_buffer_v4raw_16_h)
 {
-  char str[0xffff] = {'0'};
-  unsigned int str_size = sizeof(str);
-  msgpack_sbuffer sbuf;
-  msgpack_sbuffer_init(&sbuf);
-  msgpack_packer pk;
-  msgpack_packer_init(&pk, &sbuf, msgpack_sbuffer_write);
-  msgpack_pack_v4raw(&pk, str_size);
-  msgpack_pack_v4raw_body(&pk, str, str_size);
-  EXPECT_EQ(sbuf.size, 0xffff+3u);
-  EXPECT_EQ(sbuf.data[0], static_cast<char>(0xdau));
-  EXPECT_EQ(sbuf.data[1], static_cast<char>(0xffu));
-  EXPECT_EQ(sbuf.data[2], static_cast<char>(0xffu));
+    char str[0xffff] = {'0'};
+    unsigned int str_size = sizeof(str);
+    msgpack_sbuffer sbuf;
+    msgpack_sbuffer_init(&sbuf);
+    msgpack_packer pk;
+    msgpack_packer_init(&pk, &sbuf, msgpack_sbuffer_write);
+    msgpack_pack_v4raw(&pk, str_size);
+    msgpack_pack_v4raw_body(&pk, str, str_size);
+    EXPECT_EQ(sbuf.size, 0xffff+3u);
+    EXPECT_EQ(sbuf.data[0], static_cast<char>(0xdau));
+    EXPECT_EQ(sbuf.data[1], static_cast<char>(0xffu));
+    EXPECT_EQ(sbuf.data[2], static_cast<char>(0xffu));
 
-  msgpack_zone z;
-  msgpack_zone_init(&z, 2048);
-  msgpack_object obj;
-  msgpack_unpack_return ret;
-  ret = msgpack_unpack(sbuf.data, sbuf.size, NULL, &z, &obj);
-  EXPECT_EQ(MSGPACK_UNPACK_SUCCESS, ret);
-  EXPECT_EQ(MSGPACK_OBJECT_STR, obj.type);
-  EXPECT_EQ(str_size, obj.via.str.size);
-  EXPECT_EQ(0, memcmp(str, obj.via.str.ptr, str_size));
+    msgpack_zone z;
+    msgpack_zone_init(&z, 2048);
+    msgpack_object obj;
+    msgpack_unpack_return ret;
+    ret = msgpack_unpack(sbuf.data, sbuf.size, NULL, &z, &obj);
+    EXPECT_EQ(MSGPACK_UNPACK_SUCCESS, ret);
+    EXPECT_EQ(MSGPACK_OBJECT_STR, obj.type);
+    EXPECT_EQ(str_size, obj.via.str.size);
+    EXPECT_EQ(0, memcmp(str, obj.via.str.ptr, str_size));
 
-  msgpack_zone_destroy(&z);
-  msgpack_sbuffer_destroy(&sbuf);
+    msgpack_zone_destroy(&z);
+    msgpack_sbuffer_destroy(&sbuf);
 }
 
 TEST(MSGPACKC, simple_buffer_v4raw_32_l)
 {
-  char str[0xffff+1] = {'0'};
-  unsigned int str_size = sizeof(str);
-  msgpack_sbuffer sbuf;
-  msgpack_sbuffer_init(&sbuf);
-  msgpack_packer pk;
-  msgpack_packer_init(&pk, &sbuf, msgpack_sbuffer_write);
-  msgpack_pack_v4raw(&pk, str_size);
-  msgpack_pack_v4raw_body(&pk, str, str_size);
-  EXPECT_EQ(sbuf.size, 0xffff+1+5u);
-  EXPECT_EQ(sbuf.data[0], static_cast<char>(0xdbu));
-  EXPECT_EQ(sbuf.data[1], static_cast<char>(0x00u));
-  EXPECT_EQ(sbuf.data[2], static_cast<char>(0x01u));
-  EXPECT_EQ(sbuf.data[3], static_cast<char>(0x00u));
-  EXPECT_EQ(sbuf.data[4], static_cast<char>(0x00u));
+    char str[0xffff+1] = {'0'};
+    unsigned int str_size = sizeof(str);
+    msgpack_sbuffer sbuf;
+    msgpack_sbuffer_init(&sbuf);
+    msgpack_packer pk;
+    msgpack_packer_init(&pk, &sbuf, msgpack_sbuffer_write);
+    msgpack_pack_v4raw(&pk, str_size);
+    msgpack_pack_v4raw_body(&pk, str, str_size);
+    EXPECT_EQ(sbuf.size, 0xffff+1+5u);
+    EXPECT_EQ(sbuf.data[0], static_cast<char>(0xdbu));
+    EXPECT_EQ(sbuf.data[1], static_cast<char>(0x00u));
+    EXPECT_EQ(sbuf.data[2], static_cast<char>(0x01u));
+    EXPECT_EQ(sbuf.data[3], static_cast<char>(0x00u));
+    EXPECT_EQ(sbuf.data[4], static_cast<char>(0x00u));
 
-  msgpack_zone z;
-  msgpack_zone_init(&z, 2048);
-  msgpack_object obj;
-  msgpack_unpack_return ret;
-  ret = msgpack_unpack(sbuf.data, sbuf.size, NULL, &z, &obj);
-  EXPECT_EQ(MSGPACK_UNPACK_SUCCESS, ret);
-  EXPECT_EQ(MSGPACK_OBJECT_STR, obj.type);
-  EXPECT_EQ(str_size, obj.via.str.size);
-  EXPECT_EQ(0, memcmp(str, obj.via.str.ptr, str_size));
+    msgpack_zone z;
+    msgpack_zone_init(&z, 2048);
+    msgpack_object obj;
+    msgpack_unpack_return ret;
+    ret = msgpack_unpack(sbuf.data, sbuf.size, NULL, &z, &obj);
+    EXPECT_EQ(MSGPACK_UNPACK_SUCCESS, ret);
+    EXPECT_EQ(MSGPACK_OBJECT_STR, obj.type);
+    EXPECT_EQ(str_size, obj.via.str.size);
+    EXPECT_EQ(0, memcmp(str, obj.via.str.ptr, str_size));
 
-  msgpack_zone_destroy(&z);
-  msgpack_sbuffer_destroy(&sbuf);
+    msgpack_zone_destroy(&z);
+    msgpack_sbuffer_destroy(&sbuf);
 }
 
 
 TEST(MSGPACKC, unpack_fixstr)
 {
-  size_t str_size = 7;
-  const char buf[] = {
-    (char)0xa7, 'f', 'r', 's', 'y', 'u', 'k', 'i'
-  };
+    size_t str_size = 7;
+    const char buf[] = {
+        (char)0xa7, 'f', 'r', 's', 'y', 'u', 'k', 'i'
+    };
 
-  msgpack_zone z;
-  msgpack_zone_init(&z, 2048);
-  msgpack_object obj;
-  msgpack_unpack_return ret;
-  ret = msgpack_unpack(buf, sizeof(buf), NULL, &z, &obj);
-  EXPECT_EQ(MSGPACK_UNPACK_SUCCESS, ret);
-  EXPECT_EQ(MSGPACK_OBJECT_STR, obj.type);
-  EXPECT_EQ(str_size, obj.via.str.size);
-  EXPECT_EQ(0, memcmp("frsyuki", obj.via.str.ptr, str_size));
+    msgpack_zone z;
+    msgpack_zone_init(&z, 2048);
+    msgpack_object obj;
+    msgpack_unpack_return ret;
+    ret = msgpack_unpack(buf, sizeof(buf), NULL, &z, &obj);
+    EXPECT_EQ(MSGPACK_UNPACK_SUCCESS, ret);
+    EXPECT_EQ(MSGPACK_OBJECT_STR, obj.type);
+    EXPECT_EQ(str_size, obj.via.str.size);
+    EXPECT_EQ(0, memcmp("frsyuki", obj.via.str.ptr, str_size));
 
-  msgpack_zone_destroy(&z);
+    msgpack_zone_destroy(&z);
 }
 
 TEST(MSGPACKC, unpack_str8)
 {
-  size_t str_size = 7;
-  const char buf[] = {
-    (char)0xd9, 7, 'f', 'r', 's', 'y', 'u', 'k', 'i'
-  };
+    size_t str_size = 7;
+    const char buf[] = {
+        (char)0xd9, 7, 'f', 'r', 's', 'y', 'u', 'k', 'i'
+    };
 
-  msgpack_zone z;
-  msgpack_zone_init(&z, 2048);
-  msgpack_object obj;
-  msgpack_unpack_return ret;
-  ret = msgpack_unpack(buf, sizeof(buf), NULL, &z, &obj);
-  EXPECT_EQ(MSGPACK_UNPACK_SUCCESS, ret);
-  EXPECT_EQ(MSGPACK_OBJECT_STR, obj.type);
-  EXPECT_EQ(str_size, obj.via.str.size);
-  EXPECT_EQ(0, memcmp("frsyuki", obj.via.str.ptr, str_size));
+    msgpack_zone z;
+    msgpack_zone_init(&z, 2048);
+    msgpack_object obj;
+    msgpack_unpack_return ret;
+    ret = msgpack_unpack(buf, sizeof(buf), NULL, &z, &obj);
+    EXPECT_EQ(MSGPACK_UNPACK_SUCCESS, ret);
+    EXPECT_EQ(MSGPACK_OBJECT_STR, obj.type);
+    EXPECT_EQ(str_size, obj.via.str.size);
+    EXPECT_EQ(0, memcmp("frsyuki", obj.via.str.ptr, str_size));
 
-  msgpack_zone_destroy(&z);
+    msgpack_zone_destroy(&z);
 }
 
 TEST(MSGPACKC, unpack_str16)
 {
-  size_t str_size = 7;
-  const char buf[] = {
-      (char)0xda, 0, 7, 'f', 'r', 's', 'y', 'u', 'k', 'i'
-  };
+    size_t str_size = 7;
+    const char buf[] = {
+        (char)0xda, 0, 7, 'f', 'r', 's', 'y', 'u', 'k', 'i'
+    };
 
-  msgpack_zone z;
-  msgpack_zone_init(&z, 2048);
-  msgpack_object obj;
-  msgpack_unpack_return ret;
-  ret = msgpack_unpack(buf, sizeof(buf), NULL, &z, &obj);
-  EXPECT_EQ(MSGPACK_UNPACK_SUCCESS, ret);
-  EXPECT_EQ(MSGPACK_OBJECT_STR, obj.type);
-  EXPECT_EQ(str_size, obj.via.str.size);
-  EXPECT_EQ(0, memcmp("frsyuki", obj.via.str.ptr, str_size));
+    msgpack_zone z;
+    msgpack_zone_init(&z, 2048);
+    msgpack_object obj;
+    msgpack_unpack_return ret;
+    ret = msgpack_unpack(buf, sizeof(buf), NULL, &z, &obj);
+    EXPECT_EQ(MSGPACK_UNPACK_SUCCESS, ret);
+    EXPECT_EQ(MSGPACK_OBJECT_STR, obj.type);
+    EXPECT_EQ(str_size, obj.via.str.size);
+    EXPECT_EQ(0, memcmp("frsyuki", obj.via.str.ptr, str_size));
 
-  msgpack_zone_destroy(&z);
+    msgpack_zone_destroy(&z);
 }
 
 TEST(MSGPACKC, unpack_str32)
 {
-  size_t str_size = 7;
-  const char buf[] = {
-      (char)0xdb, 0, 0, 0, 7, 'f', 'r', 's', 'y', 'u', 'k', 'i'
-  };
+    size_t str_size = 7;
+    const char buf[] = {
+        (char)0xdb, 0, 0, 0, 7, 'f', 'r', 's', 'y', 'u', 'k', 'i'
+    };
 
-  msgpack_zone z;
-  msgpack_zone_init(&z, 2048);
-  msgpack_object obj;
-  msgpack_unpack_return ret;
-  ret = msgpack_unpack(buf, sizeof(buf), NULL, &z, &obj);
-  EXPECT_EQ(MSGPACK_UNPACK_SUCCESS, ret);
-  EXPECT_EQ(MSGPACK_OBJECT_STR, obj.type);
-  EXPECT_EQ(str_size, obj.via.str.size);
-  EXPECT_EQ(0, memcmp("frsyuki", obj.via.str.ptr, str_size));
+    msgpack_zone z;
+    msgpack_zone_init(&z, 2048);
+    msgpack_object obj;
+    msgpack_unpack_return ret;
+    ret = msgpack_unpack(buf, sizeof(buf), NULL, &z, &obj);
+    EXPECT_EQ(MSGPACK_UNPACK_SUCCESS, ret);
+    EXPECT_EQ(MSGPACK_OBJECT_STR, obj.type);
+    EXPECT_EQ(str_size, obj.via.str.size);
+    EXPECT_EQ(0, memcmp("frsyuki", obj.via.str.ptr, str_size));
 
-  msgpack_zone_destroy(&z);
+    msgpack_zone_destroy(&z);
 }
 
 TEST(MSGPACKC, unpack_bin8)
 {
-  size_t bin_size = 7;
-  const char buf[] = {
-    (char)0xc4, 7, 'f', 'r', 's', 'y', 'u', 'k', 'i'
-  };
+    size_t bin_size = 7;
+    const char buf[] = {
+        (char)0xc4, 7, 'f', 'r', 's', 'y', 'u', 'k', 'i'
+    };
 
-  msgpack_zone z;
-  msgpack_zone_init(&z, 2048);
-  msgpack_object obj;
-  msgpack_unpack_return ret;
-  ret = msgpack_unpack(buf, sizeof(buf), NULL, &z, &obj);
-  EXPECT_EQ(MSGPACK_UNPACK_SUCCESS, ret);
-  EXPECT_EQ(MSGPACK_OBJECT_BIN, obj.type);
-  EXPECT_EQ(bin_size, obj.via.bin.size);
-  EXPECT_EQ(0, memcmp("frsyuki", obj.via.bin.ptr, bin_size));
+    msgpack_zone z;
+    msgpack_zone_init(&z, 2048);
+    msgpack_object obj;
+    msgpack_unpack_return ret;
+    ret = msgpack_unpack(buf, sizeof(buf), NULL, &z, &obj);
+    EXPECT_EQ(MSGPACK_UNPACK_SUCCESS, ret);
+    EXPECT_EQ(MSGPACK_OBJECT_BIN, obj.type);
+    EXPECT_EQ(bin_size, obj.via.bin.size);
+    EXPECT_EQ(0, memcmp("frsyuki", obj.via.bin.ptr, bin_size));
 
-  msgpack_zone_destroy(&z);
+    msgpack_zone_destroy(&z);
 }
 
 TEST(MSGPACKC, unpack_bin16)
 {
-  size_t bin_size = 7;
-  const char buf[] = {
-    (char)0xc5, 0, 7, 'f', 'r', 's', 'y', 'u', 'k', 'i'
-  };
+    size_t bin_size = 7;
+    const char buf[] = {
+        (char)0xc5, 0, 7, 'f', 'r', 's', 'y', 'u', 'k', 'i'
+    };
 
-  msgpack_zone z;
-  msgpack_zone_init(&z, 2048);
-  msgpack_object obj;
-  msgpack_unpack_return ret;
-  ret = msgpack_unpack(buf, sizeof(buf), NULL, &z, &obj);
-  EXPECT_EQ(MSGPACK_UNPACK_SUCCESS, ret);
-  EXPECT_EQ(MSGPACK_OBJECT_BIN, obj.type);
-  EXPECT_EQ(bin_size, obj.via.bin.size);
-  EXPECT_EQ(0, memcmp("frsyuki", obj.via.bin.ptr, bin_size));
+    msgpack_zone z;
+    msgpack_zone_init(&z, 2048);
+    msgpack_object obj;
+    msgpack_unpack_return ret;
+    ret = msgpack_unpack(buf, sizeof(buf), NULL, &z, &obj);
+    EXPECT_EQ(MSGPACK_UNPACK_SUCCESS, ret);
+    EXPECT_EQ(MSGPACK_OBJECT_BIN, obj.type);
+    EXPECT_EQ(bin_size, obj.via.bin.size);
+    EXPECT_EQ(0, memcmp("frsyuki", obj.via.bin.ptr, bin_size));
 
-  msgpack_zone_destroy(&z);
+    msgpack_zone_destroy(&z);
 }
 
 TEST(MSGPACKC, unpack_bin32)
 {
-  size_t bin_size = 7;
-  const char buf[] = {
-    (char)0xc6, 0, 0, 0, 7, 'f', 'r', 's', 'y', 'u', 'k', 'i'
-  };
+    size_t bin_size = 7;
+    const char buf[] = {
+        (char)0xc6, 0, 0, 0, 7, 'f', 'r', 's', 'y', 'u', 'k', 'i'
+    };
 
-  msgpack_zone z;
-  msgpack_zone_init(&z, 2048);
-  msgpack_object obj;
-  msgpack_unpack_return ret;
-  ret = msgpack_unpack(buf, sizeof(buf), NULL, &z, &obj);
-  EXPECT_EQ(MSGPACK_UNPACK_SUCCESS, ret);
-  EXPECT_EQ(MSGPACK_OBJECT_BIN, obj.type);
-  EXPECT_EQ(bin_size, obj.via.bin.size);
-  EXPECT_EQ(0, memcmp("frsyuki", obj.via.bin.ptr, bin_size));
+    msgpack_zone z;
+    msgpack_zone_init(&z, 2048);
+    msgpack_object obj;
+    msgpack_unpack_return ret;
+    ret = msgpack_unpack(buf, sizeof(buf), NULL, &z, &obj);
+    EXPECT_EQ(MSGPACK_UNPACK_SUCCESS, ret);
+    EXPECT_EQ(MSGPACK_OBJECT_BIN, obj.type);
+    EXPECT_EQ(bin_size, obj.via.bin.size);
+    EXPECT_EQ(0, memcmp("frsyuki", obj.via.bin.ptr, bin_size));
 
-  msgpack_zone_destroy(&z);
+    msgpack_zone_destroy(&z);
 }
 
 TEST(MSGPACKC, unpack_array_uint64)
 {
-  const char buf[] = {
-    (char)0x91, (char)0xcf, (char)0xff, (char)0xf0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01
-  };
-  msgpack_zone z;
-  msgpack_zone_init(&z, 2048);
-  msgpack_object obj;
-  msgpack_unpack_return ret;
-  ret = msgpack_unpack(buf, sizeof(buf), NULL, &z, &obj);
-  EXPECT_EQ(MSGPACK_UNPACK_SUCCESS, ret);
-  EXPECT_EQ(MSGPACK_OBJECT_ARRAY, obj.type);
-  EXPECT_EQ(1u, obj.via.array.size);
-  EXPECT_EQ(MSGPACK_OBJECT_POSITIVE_INTEGER, obj.via.array.ptr[0].type);
-  EXPECT_EQ(0xFFF0000000000001LL, obj.via.array.ptr[0].via.u64);
-  msgpack_zone_destroy(&z);
+    const char buf[] = {
+        (char)0x91, (char)0xcf, (char)0xff, (char)0xf0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01
+    };
+    msgpack_zone z;
+    msgpack_zone_init(&z, 2048);
+    msgpack_object obj;
+    msgpack_unpack_return ret;
+    ret = msgpack_unpack(buf, sizeof(buf), NULL, &z, &obj);
+    EXPECT_EQ(MSGPACK_UNPACK_SUCCESS, ret);
+    EXPECT_EQ(MSGPACK_OBJECT_ARRAY, obj.type);
+    EXPECT_EQ(1u, obj.via.array.size);
+    EXPECT_EQ(MSGPACK_OBJECT_POSITIVE_INTEGER, obj.via.array.ptr[0].type);
+    EXPECT_EQ(0xFFF0000000000001LL, obj.via.array.ptr[0].via.u64);
+    msgpack_zone_destroy(&z);
 }

--- a/test/msgpack_container.cpp
+++ b/test/msgpack_container.cpp
@@ -45,10 +45,10 @@ TEST(MSGPACK_STL, simple_buffer_vector)
             val1.push_back(rand());
         msgpack::sbuffer sbuf;
         msgpack::pack(sbuf, val1);
-        msgpack::unpacked ret;
-        msgpack::unpack(ret, sbuf.data(), sbuf.size());
-        EXPECT_EQ(ret.get().type, msgpack::type::ARRAY);
-        type const& val2 = ret.get().as<type>();
+        msgpack::object_handle oh =
+            msgpack::unpack(sbuf.data(), sbuf.size());
+        EXPECT_EQ(oh.get().type, msgpack::type::ARRAY);
+        type const& val2 = oh.get().as<type>();
         EXPECT_EQ(val1.size(), val2.size());
         EXPECT_TRUE(equal(val1.begin(), val1.end(), val2.begin()));
     }
@@ -60,10 +60,10 @@ TEST(MSGPACK_STL, simple_buffer_vector_empty)
     type val1;
     msgpack::sbuffer sbuf;
     msgpack::pack(sbuf, val1);
-    msgpack::unpacked ret;
-    msgpack::unpack(ret, sbuf.data(), sbuf.size());
-    EXPECT_EQ(ret.get().type, msgpack::type::ARRAY);
-    type const& val2 = ret.get().as<type>();
+    msgpack::object_handle oh =
+        msgpack::unpack(sbuf.data(), sbuf.size());
+    EXPECT_EQ(oh.get().type, msgpack::type::ARRAY);
+    type const& val2 = oh.get().as<type>();
     EXPECT_EQ(val1.size(), val2.size());
     EXPECT_TRUE(equal(val1.begin(), val1.end(), val2.begin()));
 }
@@ -77,10 +77,10 @@ TEST(MSGPACK_STL, simple_buffer_vector_char)
             val1.push_back(rand());
         msgpack::sbuffer sbuf;
         msgpack::pack(sbuf, val1);
-        msgpack::unpacked ret;
-        msgpack::unpack(ret, sbuf.data(), sbuf.size());
-        EXPECT_EQ(ret.get().type, msgpack::type::BIN);
-        type const& val2 = ret.get().as<type>();
+        msgpack::object_handle oh =
+            msgpack::unpack(sbuf.data(), sbuf.size());
+        EXPECT_EQ(oh.get().type, msgpack::type::BIN);
+        type const& val2 = oh.get().as<type>();
         EXPECT_EQ(val1.size(), val2.size());
         EXPECT_TRUE(equal(val1.begin(), val1.end(), val2.begin()));
     }
@@ -92,10 +92,10 @@ TEST(MSGPACK_STL, simple_buffer_vector_char_empty)
     type val1;
     msgpack::sbuffer sbuf;
     msgpack::pack(sbuf, val1);
-    msgpack::unpacked ret;
-    msgpack::unpack(ret, sbuf.data(), sbuf.size());
-    EXPECT_EQ(ret.get().type, msgpack::type::BIN);
-    type const& val2 = ret.get().as<type>();
+    msgpack::object_handle oh =
+        msgpack::unpack(sbuf.data(), sbuf.size());
+    EXPECT_EQ(oh.get().type, msgpack::type::BIN);
+    type const& val2 = oh.get().as<type>();
     EXPECT_EQ(val1.size(), val2.size());
     EXPECT_TRUE(equal(val1.begin(), val1.end(), val2.begin()));
 }
@@ -109,10 +109,10 @@ TEST(MSGPACK_STL, simple_buffer_vector_unsigned_char)
             val1.push_back(rand());
         msgpack::sbuffer sbuf;
         msgpack::pack(sbuf, val1);
-        msgpack::unpacked ret;
-        msgpack::unpack(ret, sbuf.data(), sbuf.size());
-        EXPECT_EQ(ret.get().type, msgpack::type::BIN);
-        type const& val2 = ret.get().as<type>();
+        msgpack::object_handle oh =
+            msgpack::unpack(sbuf.data(), sbuf.size());
+        EXPECT_EQ(oh.get().type, msgpack::type::BIN);
+        type const& val2 = oh.get().as<type>();
         EXPECT_EQ(val1.size(), val2.size());
         EXPECT_TRUE(equal(val1.begin(), val1.end(), val2.begin()));
     }
@@ -124,10 +124,10 @@ TEST(MSGPACK_STL, simple_buffer_vector_unsigned_char_empty)
     type val1;
     msgpack::sbuffer sbuf;
     msgpack::pack(sbuf, val1);
-    msgpack::unpacked ret;
-    msgpack::unpack(ret, sbuf.data(), sbuf.size());
-    EXPECT_EQ(ret.get().type, msgpack::type::BIN);
-    type const& val2 = ret.get().as<type>();
+    msgpack::object_handle oh =
+        msgpack::unpack(sbuf.data(), sbuf.size());
+    EXPECT_EQ(oh.get().type, msgpack::type::BIN);
+    type const& val2 = oh.get().as<type>();
     EXPECT_EQ(val1.size(), val2.size());
     EXPECT_TRUE(equal(val1.begin(), val1.end(), val2.begin()));
 }
@@ -142,10 +142,10 @@ TEST(MSGPACK_STL, simple_buffer_vector_uint8_t)
             val1.push_back(rand());
         msgpack::sbuffer sbuf;
         msgpack::pack(sbuf, val1);
-        msgpack::unpacked ret;
-        msgpack::unpack(ret, sbuf.data(), sbuf.size());
-        EXPECT_EQ(ret.get().type, msgpack::type::BIN);
-        type const& val2 = ret.get().as<type>();
+        msgpack::object_handle oh =
+            msgpack::unpack(sbuf.data(), sbuf.size());
+        EXPECT_EQ(oh.get().type, msgpack::type::BIN);
+        type const& val2 = oh.get().as<type>();
         EXPECT_EQ(val1.size(), val2.size());
         EXPECT_TRUE(equal(val1.begin(), val1.end(), val2.begin()));
     }
@@ -158,10 +158,10 @@ TEST(MSGPACK_STL, simple_buffer_vector_uint8_t_empty)
     type val1;
     msgpack::sbuffer sbuf;
     msgpack::pack(sbuf, val1);
-    msgpack::unpacked ret;
-    msgpack::unpack(ret, sbuf.data(), sbuf.size());
-    EXPECT_EQ(ret.get().type, msgpack::type::BIN);
-    type const& val2 = ret.get().as<type>();
+    msgpack::object_handle oh =
+        msgpack::unpack(sbuf.data(), sbuf.size());
+    EXPECT_EQ(oh.get().type, msgpack::type::BIN);
+    type const& val2 = oh.get().as<type>();
     EXPECT_EQ(val1.size(), val2.size());
     EXPECT_TRUE(equal(val1.begin(), val1.end(), val2.begin()));
 }
@@ -174,10 +174,10 @@ TEST(MSGPACK_STL, simple_buffer_vector_bool)
         val1.push_back(i % 2 ? false : true);
     msgpack::sbuffer sbuf;
     msgpack::pack(sbuf, val1);
-    msgpack::unpacked ret;
-    msgpack::unpack(ret, sbuf.data(), sbuf.size());
-    EXPECT_EQ(ret.get().type, msgpack::type::ARRAY);
-    type const& val2 = ret.get().as<type>();
+    msgpack::object_handle oh =
+        msgpack::unpack(sbuf.data(), sbuf.size());
+    EXPECT_EQ(oh.get().type, msgpack::type::ARRAY);
+    type const& val2 = oh.get().as<type>();
     EXPECT_EQ(val1.size(), val2.size());
     EXPECT_TRUE(equal(val1.begin(), val1.end(), val2.begin()));
 }
@@ -188,10 +188,10 @@ TEST(MSGPACK_STL, simple_buffer_vector_bool_empty)
     type val1;
     msgpack::sbuffer sbuf;
     msgpack::pack(sbuf, val1);
-    msgpack::unpacked ret;
-    msgpack::unpack(ret, sbuf.data(), sbuf.size());
-    EXPECT_EQ(ret.get().type, msgpack::type::ARRAY);
-    type const& val2 = ret.get().as<type>();
+    msgpack::object_handle oh =
+        msgpack::unpack(sbuf.data(), sbuf.size());
+    EXPECT_EQ(oh.get().type, msgpack::type::ARRAY);
+    type const& val2 = oh.get().as<type>();
     EXPECT_EQ(val1.size(), val2.size());
     EXPECT_TRUE(equal(val1.begin(), val1.end(), val2.begin()));
 }
@@ -207,9 +207,9 @@ TEST(MSGPACK_STL, simple_buffer_assoc_vector)
         val1.push_back(std::make_pair(5, 6));
         msgpack::sbuffer sbuf;
         msgpack::pack(sbuf, val1);
-        msgpack::unpacked ret;
-        msgpack::unpack(ret, sbuf.data(), sbuf.size());
-        type const& val2 = ret.get().as<type>();
+        msgpack::object_handle oh =
+            msgpack::unpack(sbuf.data(), sbuf.size());
+        type const& val2 = oh.get().as<type>();
         EXPECT_EQ(val1.size(), val2.size());
         EXPECT_TRUE(equal(val1.begin(), val1.end(), val2.begin()));
     }
@@ -221,9 +221,9 @@ TEST(MSGPACK_STL, simple_buffer_assoc_vector_empty)
     type val1;
     msgpack::sbuffer sbuf;
     msgpack::pack(sbuf, val1);
-    msgpack::unpacked ret;
-    msgpack::unpack(ret, sbuf.data(), sbuf.size());
-    type const& val2 = ret.get().as<type>();
+    msgpack::object_handle oh =
+        msgpack::unpack(sbuf.data(), sbuf.size());
+    type const& val2 = oh.get().as<type>();
     EXPECT_EQ(val1.size(), val2.size());
     EXPECT_TRUE(equal(val1.begin(), val1.end(), val2.begin()));
 }
@@ -237,9 +237,9 @@ TEST(MSGPACK_STL, simple_buffer_map)
             val1[rand()] = rand();
         msgpack::sbuffer sbuf;
         msgpack::pack(sbuf, val1);
-        msgpack::unpacked ret;
-        msgpack::unpack(ret, sbuf.data(), sbuf.size());
-        type const& val2 = ret.get().as<type>();
+        msgpack::object_handle oh =
+            msgpack::unpack(sbuf.data(), sbuf.size());
+        type const& val2 = oh.get().as<type>();
         EXPECT_EQ(val1.size(), val2.size());
         EXPECT_TRUE(equal(val1.begin(), val1.end(), val2.begin()));
     }
@@ -251,9 +251,9 @@ TEST(MSGPACK_STL, simple_buffer_map_empty)
     type val1;
     msgpack::sbuffer sbuf;
     msgpack::pack(sbuf, val1);
-    msgpack::unpacked ret;
-    msgpack::unpack(ret, sbuf.data(), sbuf.size());
-    type const& val2 = ret.get().as<type>();
+    msgpack::object_handle oh =
+        msgpack::unpack(sbuf.data(), sbuf.size());
+    type const& val2 = oh.get().as<type>();
     EXPECT_EQ(val1.size(), val2.size());
     EXPECT_TRUE(equal(val1.begin(), val1.end(), val2.begin()));
 }
@@ -267,9 +267,9 @@ TEST(MSGPACK_STL, simple_buffer_deque)
             val1.push_back(rand());
         msgpack::sbuffer sbuf;
         msgpack::pack(sbuf, val1);
-        msgpack::unpacked ret;
-        msgpack::unpack(ret, sbuf.data(), sbuf.size());
-        type const& val2 = ret.get().as<type>();
+        msgpack::object_handle oh =
+            msgpack::unpack(sbuf.data(), sbuf.size());
+        type const& val2 = oh.get().as<type>();
         EXPECT_EQ(val1.size(), val2.size());
         EXPECT_TRUE(equal(val1.begin(), val1.end(), val2.begin()));
     }
@@ -281,9 +281,9 @@ TEST(MSGPACK_STL, simple_buffer_deque_empty)
     type val1;
     msgpack::sbuffer sbuf;
     msgpack::pack(sbuf, val1);
-    msgpack::unpacked ret;
-    msgpack::unpack(ret, sbuf.data(), sbuf.size());
-    type const& val2 = ret.get().as<type>();
+    msgpack::object_handle oh =
+        msgpack::unpack(sbuf.data(), sbuf.size());
+    type const& val2 = oh.get().as<type>();
     EXPECT_EQ(val1.size(), val2.size());
     EXPECT_TRUE(equal(val1.begin(), val1.end(), val2.begin()));
 }
@@ -297,9 +297,9 @@ TEST(MSGPACK_STL, simple_buffer_list)
             val1.push_back(rand());
         msgpack::sbuffer sbuf;
         msgpack::pack(sbuf, val1);
-        msgpack::unpacked ret;
-        msgpack::unpack(ret, sbuf.data(), sbuf.size());
-        type const& val2 = ret.get().as<type>();
+        msgpack::object_handle oh =
+            msgpack::unpack(sbuf.data(), sbuf.size());
+        type const& val2 = oh.get().as<type>();
         EXPECT_EQ(val1.size(), val2.size());
         EXPECT_TRUE(equal(val1.begin(), val1.end(), val2.begin()));
     }
@@ -311,9 +311,9 @@ TEST(MSGPACK_STL, simple_buffer_list_empty)
     type val1;
     msgpack::sbuffer sbuf;
     msgpack::pack(sbuf, val1);
-    msgpack::unpacked ret;
-    msgpack::unpack(ret, sbuf.data(), sbuf.size());
-    type const& val2 = ret.get().as<type>();
+    msgpack::object_handle oh =
+        msgpack::unpack(sbuf.data(), sbuf.size());
+    type const& val2 = oh.get().as<type>();
     EXPECT_EQ(val1.size(), val2.size());
     EXPECT_TRUE(equal(val1.begin(), val1.end(), val2.begin()));
 }
@@ -327,9 +327,9 @@ TEST(MSGPACK_STL, simple_buffer_set)
             val1.insert(rand());
         msgpack::sbuffer sbuf;
         msgpack::pack(sbuf, val1);
-        msgpack::unpacked ret;
-        msgpack::unpack(ret, sbuf.data(), sbuf.size());
-        type val2 = ret.get().as<type>();
+        msgpack::object_handle oh =
+            msgpack::unpack(sbuf.data(), sbuf.size());
+        type val2 = oh.get().as<type>();
         EXPECT_EQ(val1.size(), val2.size());
         EXPECT_TRUE(equal(val1.begin(), val1.end(), val2.begin()));
     }
@@ -341,9 +341,9 @@ TEST(MSGPACK_STL, simple_buffer_set_empty)
     type val1;
     msgpack::sbuffer sbuf;
     msgpack::pack(sbuf, val1);
-    msgpack::unpacked ret;
-    msgpack::unpack(ret, sbuf.data(), sbuf.size());
-    type val2 = ret.get().as<type>();
+    msgpack::object_handle oh =
+        msgpack::unpack(sbuf.data(), sbuf.size());
+    type val2 = oh.get().as<type>();
     EXPECT_EQ(val1.size(), val2.size());
     EXPECT_TRUE(equal(val1.begin(), val1.end(), val2.begin()));
 }
@@ -354,9 +354,9 @@ TEST(MSGPACK_STL, simple_buffer_pair)
         pair<int, int> val1 = make_pair(rand(), rand());
         msgpack::sbuffer sbuf;
         msgpack::pack(sbuf, val1);
-        msgpack::unpacked ret;
-        msgpack::unpack(ret, sbuf.data(), sbuf.size());
-        pair<int, int> val2 = ret.get().as<pair<int, int> >();
+        msgpack::object_handle oh =
+            msgpack::unpack(sbuf.data(), sbuf.size());
+        pair<int, int> val2 = oh.get().as<pair<int, int> >();
         EXPECT_EQ(val1.first, val2.first);
         EXPECT_EQ(val1.second, val2.second);
     }
@@ -374,9 +374,9 @@ TEST(MSGPACK_STL, simple_buffer_multimap)
         }
         msgpack::sbuffer sbuf;
         msgpack::pack(sbuf, val1);
-        msgpack::unpacked ret;
-        msgpack::unpack(ret, sbuf.data(), sbuf.size());
-        type val2 = ret.get().as<type>();
+        msgpack::object_handle oh =
+            msgpack::unpack(sbuf.data(), sbuf.size());
+        type val2 = oh.get().as<type>();
 
         vector<pair<int, int> > v1, v2;
         type::const_iterator it;
@@ -398,9 +398,9 @@ TEST(MSGPACK_STL, simple_buffer_multimap_empty)
     type val1;
     msgpack::sbuffer sbuf;
     msgpack::pack(sbuf, val1);
-    msgpack::unpacked ret;
-    msgpack::unpack(ret, sbuf.data(), sbuf.size());
-    type val2 = ret.get().as<type>();
+    msgpack::object_handle oh =
+        msgpack::unpack(sbuf.data(), sbuf.size());
+    type val2 = oh.get().as<type>();
     EXPECT_EQ(val1.size(), val2.size());
 }
 
@@ -413,9 +413,9 @@ TEST(MSGPACK_STL, simple_buffer_multiset)
             val1.insert(rand());
         msgpack::sbuffer sbuf;
         msgpack::pack(sbuf, val1);
-        msgpack::unpacked ret;
-        msgpack::unpack(ret, sbuf.data(), sbuf.size());
-        type val2 = ret.get().as<type>();
+        msgpack::object_handle oh =
+            msgpack::unpack(sbuf.data(), sbuf.size());
+        type val2 = oh.get().as<type>();
 
         vector<int> v1, v2;
         type::const_iterator it;
@@ -437,9 +437,9 @@ TEST(MSGPACK_STL, simple_buffer_multiset_empty)
     type val1;
     msgpack::sbuffer sbuf;
     msgpack::pack(sbuf, val1);
-    msgpack::unpacked ret;
-    msgpack::unpack(ret, sbuf.data(), sbuf.size());
-    type val2 = ret.get().as<type>();
+    msgpack::object_handle oh =
+        msgpack::unpack(sbuf.data(), sbuf.size());
+    type val2 = oh.get().as<type>();
     EXPECT_EQ(val1.size(), val2.size());
 }
 
@@ -448,11 +448,11 @@ TEST(MSGPACK_TUPLE, simple_tuple)
     msgpack::sbuffer sbuf;
     msgpack::type::tuple<bool, std::string, double> val1(true, "kzk", 12.3);
     msgpack::pack(sbuf, val1);
-    msgpack::unpacked ret;
-    msgpack::unpack(ret, sbuf.data(), sbuf.size());
+    msgpack::object_handle oh =
+        msgpack::unpack(sbuf.data(), sbuf.size());
     msgpack::type::tuple<bool, std::string, double> val2
-        = ret.get().as<msgpack::type::tuple<bool, std::string, double> >();
-    EXPECT_EQ(ret.get().via.array.size, 3u);
+        = oh.get().as<msgpack::type::tuple<bool, std::string, double> >();
+    EXPECT_EQ(oh.get().via.array.size, 3u);
     EXPECT_EQ(val1.get<0>(), val2.get<0>());
     EXPECT_EQ(val1.get<1>(), val2.get<1>());
     EXPECT_EQ(val1.get<2>(), val2.get<2>());
@@ -463,10 +463,10 @@ TEST(MSGPACK_TUPLE, simple_tuple_empty)
     msgpack::sbuffer sbuf;
     msgpack::type::tuple<> val1;
     msgpack::pack(sbuf, val1);
-    msgpack::unpacked ret;
-    msgpack::unpack(ret, sbuf.data(), sbuf.size());
-    ret.get().as<msgpack::type::tuple<> >();
-    EXPECT_EQ(ret.get().via.array.size, 0u);
+    msgpack::object_handle oh =
+        msgpack::unpack(sbuf.data(), sbuf.size());
+    oh.get().as<msgpack::type::tuple<> >();
+    EXPECT_EQ(oh.get().via.array.size, 0u);
 }
 
 
@@ -498,9 +498,9 @@ TEST(MSGPACK_TR1, simple_buffer_tr1_unordered_map)
             val1[rand()] = rand();
         msgpack::sbuffer sbuf;
         msgpack::pack(sbuf, val1);
-        msgpack::unpacked ret;
-        msgpack::unpack(ret, sbuf.data(), sbuf.size());
-        type val2 = ret.get().as<type>();
+        msgpack::object_handle oh =
+            msgpack::unpack(sbuf.data(), sbuf.size());
+        type val2 = oh.get().as<type>();
         EXPECT_EQ(val1.size(), val2.size());
         type::const_iterator it;
         for (it = val1.begin(); it != val1.end(); ++it) {
@@ -516,9 +516,9 @@ TEST(MSGPACK_TR1, simple_buffer_tr1_unordered_map_empty)
     type val1;
     msgpack::sbuffer sbuf;
     msgpack::pack(sbuf, val1);
-    msgpack::unpacked ret;
-    msgpack::unpack(ret, sbuf.data(), sbuf.size());
-    type val2 = ret.get().as<type>();
+    msgpack::object_handle oh =
+        msgpack::unpack(sbuf.data(), sbuf.size());
+    type val2 = oh.get().as<type>();
     EXPECT_EQ(val1.size(), val2.size());
 }
 
@@ -534,9 +534,9 @@ TEST(MSGPACK_TR1, simple_buffer_tr1_unordered_multimap)
         }
         msgpack::sbuffer sbuf;
         msgpack::pack(sbuf, val1);
-        msgpack::unpacked ret;
-        msgpack::unpack(ret, sbuf.data(), sbuf.size());
-        type val2 = ret.get().as<type>();
+        msgpack::object_handle oh =
+            msgpack::unpack(sbuf.data(), sbuf.size());
+        type val2 = oh.get().as<type>();
 
         vector<pair<int, int> > v1, v2;
         type::const_iterator it;
@@ -558,9 +558,9 @@ TEST(MSGPACK_TR1, simple_buffer_tr1_unordered_multimap_empty)
     type val1;
     msgpack::sbuffer sbuf;
     msgpack::pack(sbuf, val1);
-    msgpack::unpacked ret;
-    msgpack::unpack(ret, sbuf.data(), sbuf.size());
-    type val2 = ret.get().as<type>();
+    msgpack::object_handle oh =
+        msgpack::unpack(sbuf.data(), sbuf.size());
+    type val2 = oh.get().as<type>();
     EXPECT_EQ(val1.size(), val2.size());
 }
 
@@ -578,9 +578,9 @@ TEST(MSGPACK_TR1, simple_buffer_tr1_unordered_set)
             val1.insert(rand());
         msgpack::sbuffer sbuf;
         msgpack::pack(sbuf, val1);
-        msgpack::unpacked ret;
-        msgpack::unpack(ret, sbuf.data(), sbuf.size());
-        type val2 = ret.get().as<type>();
+        msgpack::object_handle oh =
+            msgpack::unpack(sbuf.data(), sbuf.size());
+        type val2 = oh.get().as<type>();
         EXPECT_EQ(val1.size(), val2.size());
         type::const_iterator it;
         for (it = val1.begin(); it != val1.end(); ++it)
@@ -594,9 +594,9 @@ TEST(MSGPACK_TR1, simple_buffer_tr1_unordered_set_empty)
     type val1;
     msgpack::sbuffer sbuf;
     msgpack::pack(sbuf, val1);
-    msgpack::unpacked ret;
-    msgpack::unpack(ret, sbuf.data(), sbuf.size());
-    type val2 = ret.get().as<type>();
+    msgpack::object_handle oh =
+        msgpack::unpack(sbuf.data(), sbuf.size());
+    type val2 = oh.get().as<type>();
     EXPECT_EQ(val1.size(), val2.size());
 }
 
@@ -609,9 +609,9 @@ TEST(MSGPACK_TR1, simple_buffer_tr1_unordered_multiset)
             val1.insert(rand());
         msgpack::sbuffer sbuf;
         msgpack::pack(sbuf, val1);
-        msgpack::unpacked ret;
-        msgpack::unpack(ret, sbuf.data(), sbuf.size());
-        type val2 = ret.get().as<type>();
+        msgpack::object_handle oh =
+            msgpack::unpack(sbuf.data(), sbuf.size());
+        type val2 = oh.get().as<type>();
 
         vector<int> v1, v2;
         type::const_iterator it;
@@ -633,9 +633,9 @@ TEST(MSGPACK_TR1, simple_buffer_tr1_unordered_multiset_empty)
     type val1;
     msgpack::sbuffer sbuf;
     msgpack::pack(sbuf, val1);
-    msgpack::unpacked ret;
-    msgpack::unpack(ret, sbuf.data(), sbuf.size());
-    type val2 = ret.get().as<type>();
+    msgpack::object_handle oh =
+        msgpack::unpack(sbuf.data(), sbuf.size());
+    type val2 = oh.get().as<type>();
     EXPECT_EQ(val1.size(), val2.size());
 }
 
@@ -667,9 +667,9 @@ TEST(MSGPACK_TR1, simple_buffer_unordered_map)
             val1[rand()] = rand();
         msgpack::sbuffer sbuf;
         msgpack::pack(sbuf, val1);
-        msgpack::unpacked ret;
-        msgpack::unpack(ret, sbuf.data(), sbuf.size());
-        type val2 = ret.get().as<type>();
+        msgpack::object_handle oh =
+            msgpack::unpack(sbuf.data(), sbuf.size());
+        type val2 = oh.get().as<type>();
         EXPECT_EQ(val1.size(), val2.size());
         type::const_iterator it;
         for (it = val1.begin(); it != val1.end(); ++it) {
@@ -685,9 +685,9 @@ TEST(MSGPACK_TR1, simple_buffer_unordered_map_empty)
     type val1;
     msgpack::sbuffer sbuf;
     msgpack::pack(sbuf, val1);
-    msgpack::unpacked ret;
-    msgpack::unpack(ret, sbuf.data(), sbuf.size());
-    type val2 = ret.get().as<type>();
+    msgpack::object_handle oh =
+        msgpack::unpack(sbuf.data(), sbuf.size());
+    type val2 = oh.get().as<type>();
     EXPECT_EQ(val1.size(), val2.size());
 }
 
@@ -703,9 +703,9 @@ TEST(MSGPACK_TR1, simple_buffer_unordered_multimap)
         }
         msgpack::sbuffer sbuf;
         msgpack::pack(sbuf, val1);
-        msgpack::unpacked ret;
-        msgpack::unpack(ret, sbuf.data(), sbuf.size());
-        type val2 = ret.get().as<type>();
+        msgpack::object_handle oh =
+            msgpack::unpack(sbuf.data(), sbuf.size());
+        type val2 = oh.get().as<type>();
 
         vector<pair<int, int> > v1, v2;
         type::const_iterator it;
@@ -727,9 +727,9 @@ TEST(MSGPACK_TR1, simple_buffer_unordered_multimap_empty)
     type val1;
     msgpack::sbuffer sbuf;
     msgpack::pack(sbuf, val1);
-    msgpack::unpacked ret;
-    msgpack::unpack(ret, sbuf.data(), sbuf.size());
-    type val2 = ret.get().as<type>();
+    msgpack::object_handle oh =
+        msgpack::unpack(sbuf.data(), sbuf.size());
+    type val2 = oh.get().as<type>();
     EXPECT_EQ(val1.size(), val2.size());
 }
 
@@ -748,9 +748,9 @@ TEST(MSGPACK_TR1, simple_buffer_unordered_set)
             val1.insert(rand());
         msgpack::sbuffer sbuf;
         msgpack::pack(sbuf, val1);
-        msgpack::unpacked ret;
-        msgpack::unpack(ret, sbuf.data(), sbuf.size());
-        type val2 = ret.get().as<type>();
+        msgpack::object_handle oh =
+            msgpack::unpack(sbuf.data(), sbuf.size());
+        type val2 = oh.get().as<type>();
         EXPECT_EQ(val1.size(), val2.size());
         type::const_iterator it;
         for (it = val1.begin(); it != val1.end(); ++it)
@@ -764,9 +764,9 @@ TEST(MSGPACK_TR1, simple_buffer_unordered_set_empty)
     type val1;
     msgpack::sbuffer sbuf;
     msgpack::pack(sbuf, val1);
-    msgpack::unpacked ret;
-    msgpack::unpack(ret, sbuf.data(), sbuf.size());
-    type val2 = ret.get().as<type>();
+    msgpack::object_handle oh =
+        msgpack::unpack(sbuf.data(), sbuf.size());
+    type val2 = oh.get().as<type>();
     EXPECT_EQ(val1.size(), val2.size());
 }
 
@@ -779,9 +779,9 @@ TEST(MSGPACK_TR1, simple_buffer_unordered_multiset)
             val1.insert(rand());
         msgpack::sbuffer sbuf;
         msgpack::pack(sbuf, val1);
-        msgpack::unpacked ret;
-        msgpack::unpack(ret, sbuf.data(), sbuf.size());
-        type val2 = ret.get().as<type>();
+        msgpack::object_handle oh =
+            msgpack::unpack(sbuf.data(), sbuf.size());
+        type val2 = oh.get().as<type>();
 
         vector<int> v1, v2;
         type::const_iterator it;
@@ -803,9 +803,9 @@ TEST(MSGPACK_TR1, simple_buffer_unordered_multiset_empty)
     type val1;
     msgpack::sbuffer sbuf;
     msgpack::pack(sbuf, val1);
-    msgpack::unpacked ret;
-    msgpack::unpack(ret, sbuf.data(), sbuf.size());
-    type val2 = ret.get().as<type>();
+    msgpack::object_handle oh =
+        msgpack::unpack(sbuf.data(), sbuf.size());
+    type val2 = oh.get().as<type>();
     EXPECT_EQ(val1.size(), val2.size());
 }
 

--- a/test/msgpack_cpp11.cpp
+++ b/test/msgpack_cpp11.cpp
@@ -42,9 +42,9 @@ TEST(MSGPACK_CPP11, simple_tuple)
     msgpack::sbuffer sbuf;
     std::tuple<bool, std::string, double> val1(true, "kzk", 12.3);
     msgpack::pack(sbuf, val1);
-    msgpack::unpacked ret;
-    msgpack::unpack(ret, sbuf.data(), sbuf.size());
-    std::tuple<bool, std::string, double> val2 = ret.get().as<std::tuple<bool, std::string, double> >();
+    msgpack::object_handle oh =
+        msgpack::unpack(sbuf.data(), sbuf.size());
+    std::tuple<bool, std::string, double> val2 = oh.get().as<std::tuple<bool, std::string, double> >();
     EXPECT_EQ(val1, val2);
 }
 
@@ -53,9 +53,9 @@ TEST(MSGPACK_CPP11, simple_tuple_empty)
     msgpack::sbuffer sbuf;
     std::tuple<> val1;
     msgpack::pack(sbuf, val1);
-    msgpack::unpacked ret;
-    msgpack::unpack(ret, sbuf.data(), sbuf.size());
-    std::tuple<> val2 = ret.get().as<std::tuple<> >();
+    msgpack::object_handle oh =
+        msgpack::unpack(sbuf.data(), sbuf.size());
+    std::tuple<> val2 = oh.get().as<std::tuple<> >();
     EXPECT_EQ(val1, val2);
 }
 
@@ -67,10 +67,10 @@ TEST(MSGPACK_CPP11, simple_array)
             val1[i] = rand();
         msgpack::sbuffer sbuf;
         msgpack::pack(sbuf, val1);
-        msgpack::unpacked ret;
-        msgpack::unpack(ret, sbuf.data(), sbuf.size());
-        EXPECT_EQ(ret.get().type, msgpack::type::ARRAY);
-        array<int, kElements> val2 = ret.get().as<array<int, kElements> >();
+        msgpack::object_handle oh =
+            msgpack::unpack(sbuf.data(), sbuf.size());
+        EXPECT_EQ(oh.get().type, msgpack::type::ARRAY);
+        array<int, kElements> val2 = oh.get().as<array<int, kElements> >();
         EXPECT_EQ(val1.size(), val2.size());
         EXPECT_TRUE(equal(val1.begin(), val1.end(), val2.begin()));
     }
@@ -81,10 +81,10 @@ TEST(MSGPACK_CPP11, simple_array_empty)
     array<int, 0> val1;
     msgpack::sbuffer sbuf;
     msgpack::pack(sbuf, val1);
-    msgpack::unpacked ret;
-    msgpack::unpack(ret, sbuf.data(), sbuf.size());
-    EXPECT_EQ(ret.get().type, msgpack::type::ARRAY);
-    array<int, 0> val2 = ret.get().as<array<int, 0> >();
+    msgpack::object_handle oh =
+        msgpack::unpack(sbuf.data(), sbuf.size());
+    EXPECT_EQ(oh.get().type, msgpack::type::ARRAY);
+    array<int, 0> val2 = oh.get().as<array<int, 0> >();
     EXPECT_EQ(val1.size(), val2.size());
     EXPECT_TRUE(equal(val1.begin(), val1.end(), val2.begin()));
 }
@@ -97,10 +97,10 @@ TEST(MSGPACK_CPP11, simple_buffer_array_char)
             val1[i] = rand();
         msgpack::sbuffer sbuf;
         msgpack::pack(sbuf, val1);
-        msgpack::unpacked ret;
-        msgpack::unpack(ret, sbuf.data(), sbuf.size());
-        EXPECT_EQ(ret.get().type, msgpack::type::BIN);
-        array<char, kElements> val2 = ret.get().as<array<char, kElements> >();
+        msgpack::object_handle oh =
+            msgpack::unpack(sbuf.data(), sbuf.size());
+        EXPECT_EQ(oh.get().type, msgpack::type::BIN);
+        array<char, kElements> val2 = oh.get().as<array<char, kElements> >();
         EXPECT_EQ(val1.size(), val2.size());
         EXPECT_TRUE(equal(val1.begin(), val1.end(), val2.begin()));
     }
@@ -111,10 +111,10 @@ TEST(MSGPACK_CPP11, simple_buffer_array_char_empty)
     array<char, 0> val1;
     msgpack::sbuffer sbuf;
     msgpack::pack(sbuf, val1);
-    msgpack::unpacked ret;
-    msgpack::unpack(ret, sbuf.data(), sbuf.size());
-    EXPECT_EQ(ret.get().type, msgpack::type::BIN);
-    array<char, 0> val2 = ret.get().as<array<char, 0> >();
+    msgpack::object_handle oh =
+        msgpack::unpack(sbuf.data(), sbuf.size());
+    EXPECT_EQ(oh.get().type, msgpack::type::BIN);
+    array<char, 0> val2 = oh.get().as<array<char, 0> >();
     EXPECT_EQ(val1.size(), val2.size());
     EXPECT_TRUE(equal(val1.begin(), val1.end(), val2.begin()));
 }
@@ -128,10 +128,10 @@ TEST(MSGPACK_CPP11, simple_buffer_array_unsigned_char)
             val1[i] = rand();
         msgpack::sbuffer sbuf;
         msgpack::pack(sbuf, val1);
-        msgpack::unpacked ret;
-        msgpack::unpack(ret, sbuf.data(), sbuf.size());
-        EXPECT_EQ(ret.get().type, msgpack::type::BIN);
-        array<unsigned char, kElements> val2 = ret.get().as<array<unsigned char, kElements> >();
+        msgpack::object_handle oh =
+            msgpack::unpack(sbuf.data(), sbuf.size());
+        EXPECT_EQ(oh.get().type, msgpack::type::BIN);
+        array<unsigned char, kElements> val2 = oh.get().as<array<unsigned char, kElements> >();
         EXPECT_EQ(val1.size(), val2.size());
         EXPECT_TRUE(equal(val1.begin(), val1.end(), val2.begin()));
     }
@@ -143,10 +143,10 @@ TEST(MSGPACK_CPP11, simple_buffer_array_unsigned_char_empty)
     array<unsigned char, 0> val1;
     msgpack::sbuffer sbuf;
     msgpack::pack(sbuf, val1);
-    msgpack::unpacked ret;
-    msgpack::unpack(ret, sbuf.data(), sbuf.size());
-    EXPECT_EQ(ret.get().type, msgpack::type::BIN);
-    array<unsigned char, 0> val2 = ret.get().as<array<unsigned char, 0> >();
+    msgpack::object_handle oh =
+        msgpack::unpack(sbuf.data(), sbuf.size());
+    EXPECT_EQ(oh.get().type, msgpack::type::BIN);
+    array<unsigned char, 0> val2 = oh.get().as<array<unsigned char, 0> >();
     EXPECT_EQ(val1.size(), val2.size());
     EXPECT_TRUE(equal(val1.begin(), val1.end(), val2.begin()));
 }
@@ -191,9 +191,9 @@ TEST(MSGPACK_STL, simple_buffer_forward_list)
             val1.push_front(rand());
         msgpack::sbuffer sbuf;
         msgpack::pack(sbuf, val1);
-        msgpack::unpacked ret;
-        msgpack::unpack(ret, sbuf.data(), sbuf.size());
-        type val2 = ret.get().as<type >();
+        msgpack::object_handle oh =
+            msgpack::unpack(sbuf.data(), sbuf.size());
+        type val2 = oh.get().as<type >();
         EXPECT_EQ(val1, val2);
     }
 }
@@ -204,9 +204,9 @@ TEST(MSGPACK_STL, simple_buffer_forward_list_empty)
     type val1;
     msgpack::sbuffer sbuf;
     msgpack::pack(sbuf, val1);
-    msgpack::unpacked ret;
-    msgpack::unpack(ret, sbuf.data(), sbuf.size());
-    type val2 = ret.get().as<type >();
+    msgpack::object_handle oh =
+        msgpack::unpack(sbuf.data(), sbuf.size());
+    type val2 = oh.get().as<type >();
     EXPECT_EQ(val1, val2);
 }
 
@@ -219,9 +219,9 @@ TEST(MSGPACK_STL, simple_buffer_unordered_map)
             val1[rand()] = rand();
         msgpack::sbuffer sbuf;
         msgpack::pack(sbuf, val1);
-        msgpack::unpacked ret;
-        msgpack::unpack(ret, sbuf.data(), sbuf.size());
-        type val2 = ret.get().as<type >();
+        msgpack::object_handle oh =
+            msgpack::unpack(sbuf.data(), sbuf.size());
+        type val2 = oh.get().as<type >();
         EXPECT_EQ(val1, val2);
     }
 }
@@ -232,9 +232,9 @@ TEST(MSGPACK_STL, simple_buffer_unordered_map_empty)
     type val1;
     msgpack::sbuffer sbuf;
     msgpack::pack(sbuf, val1);
-    msgpack::unpacked ret;
-    msgpack::unpack(ret, sbuf.data(), sbuf.size());
-    type val2 = ret.get().as<type >();
+    msgpack::object_handle oh =
+        msgpack::unpack(sbuf.data(), sbuf.size());
+    type val2 = oh.get().as<type >();
     EXPECT_EQ(val1, val2);
 }
 
@@ -250,9 +250,9 @@ TEST(MSGPACK_STL, simple_buffer_unordered_multimap)
         }
         msgpack::sbuffer sbuf;
         msgpack::pack(sbuf, val1);
-        msgpack::unpacked ret;
-        msgpack::unpack(ret, sbuf.data(), sbuf.size());
-        type val2 = ret.get().as<type >();
+        msgpack::object_handle oh =
+            msgpack::unpack(sbuf.data(), sbuf.size());
+        type val2 = oh.get().as<type >();
 
         EXPECT_EQ(val1, val2);
     }
@@ -264,9 +264,9 @@ TEST(MSGPACK_STL, simple_buffer_unordered_multimap_empty)
     type val1;
     msgpack::sbuffer sbuf;
     msgpack::pack(sbuf, val1);
-    msgpack::unpacked ret;
-    msgpack::unpack(ret, sbuf.data(), sbuf.size());
-    type val2 = ret.get().as<type >();
+    msgpack::object_handle oh =
+        msgpack::unpack(sbuf.data(), sbuf.size());
+    type val2 = oh.get().as<type >();
 
     EXPECT_EQ(val1, val2);
 }
@@ -280,9 +280,9 @@ TEST(MSGPACK_STL, simple_buffer_unordered_set)
             val1.insert(rand());
         msgpack::sbuffer sbuf;
         msgpack::pack(sbuf, val1);
-        msgpack::unpacked ret;
-        msgpack::unpack(ret, sbuf.data(), sbuf.size());
-        type val2 = ret.get().as<type>();
+        msgpack::object_handle oh =
+            msgpack::unpack(sbuf.data(), sbuf.size());
+        type val2 = oh.get().as<type>();
         EXPECT_EQ(val1, val2);
     }
 }
@@ -293,9 +293,9 @@ TEST(MSGPACK_STL, simple_buffer_unordered_set_empty)
     type val1;
     msgpack::sbuffer sbuf;
     msgpack::pack(sbuf, val1);
-    msgpack::unpacked ret;
-    msgpack::unpack(ret, sbuf.data(), sbuf.size());
-    type val2 = ret.get().as<type>();
+    msgpack::object_handle oh =
+        msgpack::unpack(sbuf.data(), sbuf.size());
+    type val2 = oh.get().as<type>();
     EXPECT_EQ(val1, val2);
 }
 
@@ -308,9 +308,9 @@ TEST(MSGPACK_STL, simple_buffer_unordered_multiset)
             val1.insert(rand());
         msgpack::sbuffer sbuf;
         msgpack::pack(sbuf, val1);
-        msgpack::unpacked ret;
-        msgpack::unpack(ret, sbuf.data(), sbuf.size());
-        type val2 = ret.get().as<type >();
+        msgpack::object_handle oh =
+            msgpack::unpack(sbuf.data(), sbuf.size());
+        type val2 = oh.get().as<type >();
         EXPECT_EQ(val1, val2);
     }
 }
@@ -321,9 +321,9 @@ TEST(MSGPACK_STL, simple_buffer_unordered_multiset_empty)
     type val1;
     msgpack::sbuffer sbuf;
     msgpack::pack(sbuf, val1);
-    msgpack::unpacked ret;
-    msgpack::unpack(ret, sbuf.data(), sbuf.size());
-    type val2 = ret.get().as<type >();
+    msgpack::object_handle oh =
+        msgpack::unpack(sbuf.data(), sbuf.size());
+    type val2 = oh.get().as<type >();
     EXPECT_EQ(val1, val2);
 }
 
@@ -332,9 +332,9 @@ TEST(MSGPACK_USER_DEFINED, simple_buffer_enum_class_member)
     TestEnumClassMemberClass val1;
     msgpack::sbuffer sbuf;
     msgpack::pack(sbuf, val1);
-    msgpack::unpacked ret;
-    msgpack::unpack(ret, sbuf.data(), sbuf.size());
-    TestEnumClassMemberClass val2 = ret.get().as<TestEnumClassMemberClass>();
+    msgpack::object_handle oh =
+        msgpack::unpack(sbuf.data(), sbuf.size());
+    TestEnumClassMemberClass val2 = oh.get().as<TestEnumClassMemberClass>();
     EXPECT_EQ(val1.t1, val2.t1);
     EXPECT_EQ(val1.t2, val2.t2);
     EXPECT_EQ(val1.t3, val2.t3);
@@ -387,10 +387,10 @@ TEST(MSGPACK_NO_DEF_CON, simple_buffer)
     no_def_con val1(42);
     msgpack::sbuffer sbuf;
     msgpack::pack(sbuf, val1);
-    msgpack::unpacked ret;
-    msgpack::unpack(ret, sbuf.data(), sbuf.size());
+    msgpack::object_handle oh =
+        msgpack::unpack(sbuf.data(), sbuf.size());
 
-    no_def_con val2 = ret.get().as<no_def_con>();
+    no_def_con val2 = oh.get().as<no_def_con>();
     EXPECT_EQ(val1, val2);
 }
 
@@ -434,9 +434,9 @@ TEST(MSGPACK_NO_DEF_CON_COMPOSITE, simple_buffer)
     no_def_con_composite val1(42);
     msgpack::sbuffer sbuf;
     msgpack::pack(sbuf, val1);
-    msgpack::unpacked ret;
-    msgpack::unpack(ret, sbuf.data(), sbuf.size());
-    no_def_con_composite val2 = ret.get().as<no_def_con_composite>();
+    msgpack::object_handle oh =
+        msgpack::unpack(sbuf.data(), sbuf.size());
+    no_def_con_composite val2 = oh.get().as<no_def_con_composite>();
     EXPECT_EQ(val1, val2);
 }
 
@@ -466,9 +466,9 @@ TEST(MSGPACK_NO_DEF_CON_INHERIT, simple_buffer)
     no_def_con_inherit val1(42);
     msgpack::sbuffer sbuf;
     msgpack::pack(sbuf, val1);
-    msgpack::unpacked ret;
-    msgpack::unpack(ret, sbuf.data(), sbuf.size());
-    no_def_con_inherit val2 = ret.get().as<no_def_con_inherit>();
+    msgpack::object_handle oh =
+        msgpack::unpack(sbuf.data(), sbuf.size());
+    no_def_con_inherit val2 = oh.get().as<no_def_con_inherit>();
     EXPECT_EQ(val1, val2);
 }
 
@@ -477,9 +477,9 @@ TEST(MSGPACK_NO_DEF_CON_VECTOR, simple_buffer)
     std::vector<no_def_con> val1 { 1, 2, 3 };
     msgpack::sbuffer sbuf;
     msgpack::pack(sbuf, val1);
-    msgpack::unpacked ret;
-    msgpack::unpack(ret, sbuf.data(), sbuf.size());
-    std::vector<no_def_con> val2 = ret.get().as<std::vector<no_def_con>>();
+    msgpack::object_handle oh =
+        msgpack::unpack(sbuf.data(), sbuf.size());
+    std::vector<no_def_con> val2 = oh.get().as<std::vector<no_def_con>>();
     EXPECT_EQ(val1, val2);
 }
 
@@ -488,9 +488,9 @@ TEST(MSGPACK_NO_DEF_CON_LIST, simple_buffer)
     std::list<no_def_con> val1 { 1, 2, 3 };
     msgpack::sbuffer sbuf;
     msgpack::pack(sbuf, val1);
-    msgpack::unpacked ret;
-    msgpack::unpack(ret, sbuf.data(), sbuf.size());
-    std::list<no_def_con> val2 = ret.get().as<std::list<no_def_con>>();
+    msgpack::object_handle oh =
+        msgpack::unpack(sbuf.data(), sbuf.size());
+    std::list<no_def_con> val2 = oh.get().as<std::list<no_def_con>>();
     EXPECT_EQ(val1, val2);
 }
 
@@ -499,9 +499,9 @@ TEST(MSGPACK_NO_DEF_CON_SET, simple_buffer)
     std::set<no_def_con> val1 { 1, 2, 3 };
     msgpack::sbuffer sbuf;
     msgpack::pack(sbuf, val1);
-    msgpack::unpacked ret;
-    msgpack::unpack(ret, sbuf.data(), sbuf.size());
-    std::set<no_def_con> val2 = ret.get().as<std::set<no_def_con>>();
+    msgpack::object_handle oh =
+        msgpack::unpack(sbuf.data(), sbuf.size());
+    std::set<no_def_con> val2 = oh.get().as<std::set<no_def_con>>();
     EXPECT_EQ(val1, val2);
 }
 
@@ -510,9 +510,9 @@ TEST(MSGPACK_NO_DEF_CON_MULTISET, simple_buffer)
     std::multiset<no_def_con> val1 { 1, 2, 3 };
     msgpack::sbuffer sbuf;
     msgpack::pack(sbuf, val1);
-    msgpack::unpacked ret;
-    msgpack::unpack(ret, sbuf.data(), sbuf.size());
-    std::multiset<no_def_con> val2 = ret.get().as<std::multiset<no_def_con>>();
+    msgpack::object_handle oh =
+        msgpack::unpack(sbuf.data(), sbuf.size());
+    std::multiset<no_def_con> val2 = oh.get().as<std::multiset<no_def_con>>();
     EXPECT_EQ(val1, val2);
 }
 
@@ -521,10 +521,10 @@ TEST(MSGPACK_NO_DEF_CON_ASSOC_VECTOR, simple_buffer)
     msgpack::type::assoc_vector<no_def_con, no_def_con_composite> val1 { {1, 2}, {3, 4}, {5, 6}};
     msgpack::sbuffer sbuf;
     msgpack::pack(sbuf, val1);
-    msgpack::unpacked ret;
-    msgpack::unpack(ret, sbuf.data(), sbuf.size());
+    msgpack::object_handle oh =
+        msgpack::unpack(sbuf.data(), sbuf.size());
     msgpack::type::assoc_vector<no_def_con, no_def_con_composite> val2
-        = ret.get().as<msgpack::type::assoc_vector<no_def_con, no_def_con_composite>>();
+        = oh.get().as<msgpack::type::assoc_vector<no_def_con, no_def_con_composite>>();
     EXPECT_EQ(val1, val2);
 }
 
@@ -533,10 +533,10 @@ TEST(MSGPACK_NO_DEF_CON_MAP, simple_buffer)
     std::map<no_def_con, no_def_con_composite> val1 { {1, 2}, {3, 4}, {5, 6}};
     msgpack::sbuffer sbuf;
     msgpack::pack(sbuf, val1);
-    msgpack::unpacked ret;
-    msgpack::unpack(ret, sbuf.data(), sbuf.size());
+    msgpack::object_handle oh =
+        msgpack::unpack(sbuf.data(), sbuf.size());
     std::map<no_def_con, no_def_con_composite> val2
-        = ret.get().as<std::map<no_def_con, no_def_con_composite>>();
+        = oh.get().as<std::map<no_def_con, no_def_con_composite>>();
     EXPECT_EQ(val1, val2);
 }
 
@@ -545,10 +545,10 @@ TEST(MSGPACK_NO_DEF_CON_MULTIMAP, simple_buffer)
     std::multimap<no_def_con, no_def_con_composite> val1 { {1, 2}, {3, 4}, {5, 6}};
     msgpack::sbuffer sbuf;
     msgpack::pack(sbuf, val1);
-    msgpack::unpacked ret;
-    msgpack::unpack(ret, sbuf.data(), sbuf.size());
+    msgpack::object_handle oh =
+        msgpack::unpack(sbuf.data(), sbuf.size());
     std::multimap<no_def_con, no_def_con_composite> val2
-        = ret.get().as<std::multimap<no_def_con, no_def_con_composite>>();
+        = oh.get().as<std::multimap<no_def_con, no_def_con_composite>>();
     EXPECT_EQ(val1, val2);
 }
 
@@ -557,9 +557,9 @@ TEST(MSGPACK_NO_DEF_CON_DEQUE, simple_buffer)
     std::deque<no_def_con> val1 { 1, 2, 3 };
     msgpack::sbuffer sbuf;
     msgpack::pack(sbuf, val1);
-    msgpack::unpacked ret;
-    msgpack::unpack(ret, sbuf.data(), sbuf.size());
-    std::deque<no_def_con> val2 = ret.get().as<std::deque<no_def_con>>();
+    msgpack::object_handle oh =
+        msgpack::unpack(sbuf.data(), sbuf.size());
+    std::deque<no_def_con> val2 = oh.get().as<std::deque<no_def_con>>();
     EXPECT_EQ(val1, val2);
 }
 
@@ -568,10 +568,10 @@ TEST(MSGPACK_NO_DEF_CON_PAIR, simple_buffer)
     std::pair<no_def_con, no_def_con_composite> val1 {1, 2};
     msgpack::sbuffer sbuf;
     msgpack::pack(sbuf, val1);
-    msgpack::unpacked ret;
-    msgpack::unpack(ret, sbuf.data(), sbuf.size());
+    msgpack::object_handle oh =
+        msgpack::unpack(sbuf.data(), sbuf.size());
     std::pair<no_def_con, no_def_con_composite> val2
-        = ret.get().as<std::pair<no_def_con, no_def_con_composite>>();
+        = oh.get().as<std::pair<no_def_con, no_def_con_composite>>();
     EXPECT_EQ(val1, val2);
 }
 
@@ -587,10 +587,10 @@ TEST(MSGPACK_NO_DEF_CON_TUPLE, simple_buffer)
     std::tuple<no_def_con, no_def_con, no_def_con_composite> val1 {1, 2, 3};
     msgpack::sbuffer sbuf;
     msgpack::pack(sbuf, val1);
-    msgpack::unpacked ret;
-    msgpack::unpack(ret, sbuf.data(), sbuf.size());
+    msgpack::object_handle oh =
+        msgpack::unpack(sbuf.data(), sbuf.size());
     std::tuple<no_def_con, no_def_con, no_def_con_composite> val2
-        = ret.get().as<std::tuple<no_def_con, no_def_con, no_def_con_composite>>();
+        = oh.get().as<std::tuple<no_def_con, no_def_con, no_def_con_composite>>();
     EXPECT_EQ(val1, val2);
 }
 
@@ -599,10 +599,10 @@ TEST(MSGPACK_NO_DEF_CON_MSGPACK_TUPLE, simple_buffer)
     msgpack::type::tuple<no_def_con, no_def_con, no_def_con_composite> val1 {1, 2, 3};
     msgpack::sbuffer sbuf;
     msgpack::pack(sbuf, val1);
-    msgpack::unpacked ret;
-    msgpack::unpack(ret, sbuf.data(), sbuf.size());
+    msgpack::object_handle oh =
+        msgpack::unpack(sbuf.data(), sbuf.size());
     msgpack::type::tuple<no_def_con, no_def_con, no_def_con_composite> val2
-        = ret.get().as<msgpack::type::tuple<no_def_con, no_def_con, no_def_con_composite>>();
+        = oh.get().as<msgpack::type::tuple<no_def_con, no_def_con, no_def_con_composite>>();
     EXPECT_EQ(val1, val2);
 }
 
@@ -613,9 +613,9 @@ TEST(MSGPACK_NO_DEF_FORWARD_LIST, simple_buffer)
     std::forward_list<no_def_con> val1 { 1, 2, 3 };
     msgpack::sbuffer sbuf;
     msgpack::pack(sbuf, val1);
-    msgpack::unpacked ret;
-    msgpack::unpack(ret, sbuf.data(), sbuf.size());
-    std::forward_list<no_def_con> val2 = ret.get().as<std::forward_list<no_def_con>>();
+    msgpack::object_handle oh =
+        msgpack::unpack(sbuf.data(), sbuf.size());
+    std::forward_list<no_def_con> val2 = oh.get().as<std::forward_list<no_def_con>>();
     EXPECT_TRUE(val1 == val2);
 }
 
@@ -624,9 +624,9 @@ TEST(MSGPACK_NO_DEF_CON_UNORDERED_SET, simple_buffer)
     std::unordered_set<no_def_con> val1 { 1, 2, 3 };
     msgpack::sbuffer sbuf;
     msgpack::pack(sbuf, val1);
-    msgpack::unpacked ret;
-    msgpack::unpack(ret, sbuf.data(), sbuf.size());
-    std::unordered_set<no_def_con> val2 = ret.get().as<std::unordered_set<no_def_con>>();
+    msgpack::object_handle oh =
+        msgpack::unpack(sbuf.data(), sbuf.size());
+    std::unordered_set<no_def_con> val2 = oh.get().as<std::unordered_set<no_def_con>>();
     EXPECT_EQ(val1, val2);
 }
 
@@ -635,9 +635,9 @@ TEST(MSGPACK_NO_DEF_CON_UNORDERED_MULTISET, simple_buffer)
     std::unordered_multiset<no_def_con> val1 { 1, 2, 3 };
     msgpack::sbuffer sbuf;
     msgpack::pack(sbuf, val1);
-    msgpack::unpacked ret;
-    msgpack::unpack(ret, sbuf.data(), sbuf.size());
-    std::unordered_multiset<no_def_con> val2 = ret.get().as<std::unordered_multiset<no_def_con>>();
+    msgpack::object_handle oh =
+        msgpack::unpack(sbuf.data(), sbuf.size());
+    std::unordered_multiset<no_def_con> val2 = oh.get().as<std::unordered_multiset<no_def_con>>();
     EXPECT_EQ(val1, val2);
 }
 
@@ -646,10 +646,10 @@ TEST(MSGPACK_NO_DEF_CON_UNORDERED_MAP, simple_buffer)
     std::unordered_map<no_def_con, no_def_con_composite> val1 { {1, 2}, {3, 4}, {5, 6}};
     msgpack::sbuffer sbuf;
     msgpack::pack(sbuf, val1);
-    msgpack::unpacked ret;
-    msgpack::unpack(ret, sbuf.data(), sbuf.size());
+    msgpack::object_handle oh =
+        msgpack::unpack(sbuf.data(), sbuf.size());
     std::unordered_map<no_def_con, no_def_con_composite> val2
-        = ret.get().as<std::unordered_map<no_def_con, no_def_con_composite>>();
+        = oh.get().as<std::unordered_map<no_def_con, no_def_con_composite>>();
     EXPECT_EQ(val1, val2);
 }
 
@@ -658,10 +658,10 @@ TEST(MSGPACK_NO_DEF_CON_UNORDERED_MULTIMAP, simple_buffer)
     std::unordered_multimap<no_def_con, no_def_con_composite> val1 { {1, 2}, {3, 4}, {5, 6}};
     msgpack::sbuffer sbuf;
     msgpack::pack(sbuf, val1);
-    msgpack::unpacked ret;
-    msgpack::unpack(ret, sbuf.data(), sbuf.size());
+    msgpack::object_handle oh =
+        msgpack::unpack(sbuf.data(), sbuf.size());
     std::unordered_multimap<no_def_con, no_def_con_composite> val2
-        = ret.get().as<std::unordered_multimap<no_def_con, no_def_con_composite>>();
+        = oh.get().as<std::unordered_multimap<no_def_con, no_def_con_composite>>();
     EXPECT_EQ(val1, val2);
 }
 
@@ -670,9 +670,9 @@ TEST(MSGPACK_NO_DEF_CON_ARRAY, simple_buffer)
     std::array<no_def_con, 3> val1 { { 1, 2, 3 } };
     msgpack::sbuffer sbuf;
     msgpack::pack(sbuf, val1);
-    msgpack::unpacked ret;
-    msgpack::unpack(ret, sbuf.data(), sbuf.size());
-    std::array<no_def_con, 3> val2 = ret.get().as<std::array<no_def_con, 3>>();
+    msgpack::object_handle oh =
+        msgpack::unpack(sbuf.data(), sbuf.size());
+    std::array<no_def_con, 3> val2 = oh.get().as<std::array<no_def_con, 3>>();
     EXPECT_EQ(val1, val2);
 }
 

--- a/test/msgpack_stream.cpp
+++ b/test/msgpack_stream.cpp
@@ -21,131 +21,131 @@ const unsigned int kLoop = 1000;
 
 
 #define GEN_TEST_STREAM(test_type)                                      \
-  for (unsigned int k = 0; k < kLoop; k++) {                            \
-    msgpack::sbuffer sbuf;                                              \
-    msgpack::packer<msgpack::sbuffer> pk(sbuf);                         \
-    typedef std::vector<test_type> vec_type;                            \
-    vec_type vec;                                                       \
-    for(unsigned int i = 0; i < rand() % kLoop; ++i) {                  \
-      vec_type::value_type r = rand();                                  \
-      vec.push_back(r);                                                 \
-      pk.pack(r);                                                       \
-    }                                                                   \
-    msgpack::unpacker pac;                                              \
-    vec_type::const_iterator it = vec.begin();                          \
-    const char *p = sbuf.data();                                        \
-    const char * const pend = p + sbuf.size();                          \
-    while (p < pend) {                                                  \
-      const size_t sz = std::min<size_t>(pend - p, rand() % 128);       \
-      pac.reserve_buffer(sz);                                           \
-      memcpy(pac.buffer(), p, sz);                                      \
-      pac.buffer_consumed(sz);                                          \
-      msgpack::unpacked result;                                         \
-      while (pac.next(result)) {                                        \
-        if (it == vec.end()) goto out;                                  \
-        msgpack::object obj = result.get();                             \
-        vec_type::value_type val;                                       \
-        obj.convert(val);                                               \
-        EXPECT_EQ(*it, val);                                            \
-        ++it;                                                           \
-      }                                                                 \
-      p += sz;                                                          \
-    }                                                                   \
-  out:                                                                  \
-    ;                                                                   \
-  }
+    for (unsigned int k = 0; k < kLoop; k++) {                          \
+        msgpack::sbuffer sbuf;                                          \
+        msgpack::packer<msgpack::sbuffer> pk(sbuf);                     \
+        typedef std::vector<test_type> vec_type;                        \
+        vec_type vec;                                                   \
+        for(unsigned int i = 0; i < rand() % kLoop; ++i) {              \
+            vec_type::value_type r = rand();                            \
+            vec.push_back(r);                                           \
+            pk.pack(r);                                                 \
+        }                                                               \
+        msgpack::unpacker pac;                                          \
+        vec_type::const_iterator it = vec.begin();                      \
+        const char *p = sbuf.data();                                    \
+        const char * const pend = p + sbuf.size();                      \
+        while (p < pend) {                                              \
+            const size_t sz = std::min<size_t>(pend - p, rand() % 128); \
+            pac.reserve_buffer(sz);                                     \
+            memcpy(pac.buffer(), p, sz);                                \
+            pac.buffer_consumed(sz);                                    \
+            msgpack::object_handle oh;                                  \
+            while (pac.next(oh)) {                                      \
+                if (it == vec.end()) goto out;                          \
+                msgpack::object obj = oh.get();                         \
+                vec_type::value_type val;                               \
+                obj.convert(val);                                       \
+                EXPECT_EQ(*it, val);                                    \
+                ++it;                                                   \
+            }                                                           \
+            p += sz;                                                    \
+        }                                                               \
+    out:                                                                \
+        ;                                                               \
+    }
 
 TEST(MSGPACK, stream_char)
 {
-  GEN_TEST_STREAM(char);
+    GEN_TEST_STREAM(char);
 }
 
 TEST(MSGPACK, stream_signed_char)
 {
-  GEN_TEST_STREAM(signed char);
+    GEN_TEST_STREAM(signed char);
 }
 
 TEST(MSGPACK, stream_unsigned_char)
 {
-  GEN_TEST_STREAM(unsigned char);
+    GEN_TEST_STREAM(unsigned char);
 }
 
 TEST(MSGPACK, stream_short)
 {
-  GEN_TEST_STREAM(short);
+    GEN_TEST_STREAM(short);
 }
 
 TEST(MSGPACK, stream_int)
 {
-  GEN_TEST_STREAM(int);
+    GEN_TEST_STREAM(int);
 }
 
 TEST(MSGPACK, stream_long)
 {
-  GEN_TEST_STREAM(long);
+    GEN_TEST_STREAM(long);
 }
 
 TEST(MSGPACK, stream_long_long)
 {
-  GEN_TEST_STREAM(long long);
+    GEN_TEST_STREAM(long long);
 }
 
 TEST(MSGPACK, stream_unsigned_short)
 {
-  GEN_TEST_STREAM(unsigned short);
+    GEN_TEST_STREAM(unsigned short);
 }
 
 TEST(MSGPACK, stream_unsigned_int)
 {
-  GEN_TEST_STREAM(unsigned int);
+    GEN_TEST_STREAM(unsigned int);
 }
 
 TEST(MSGPACK, stream_unsigned_long)
 {
-  GEN_TEST_STREAM(unsigned long);
+    GEN_TEST_STREAM(unsigned long);
 }
 
 TEST(MSGPACK, stream_unsigned_long_long)
 {
-  GEN_TEST_STREAM(unsigned long long);
+    GEN_TEST_STREAM(unsigned long long);
 }
 
 TEST(MSGPACK, stream_uint8)
 {
-  GEN_TEST_STREAM(uint8_t);
+    GEN_TEST_STREAM(uint8_t);
 }
 
 TEST(MSGPACK, stream_uint16)
 {
-  GEN_TEST_STREAM(uint16_t);
+    GEN_TEST_STREAM(uint16_t);
 }
 
 TEST(MSGPACK, stream_uint32)
 {
-  GEN_TEST_STREAM(uint32_t);
+    GEN_TEST_STREAM(uint32_t);
 }
 
 TEST(MSGPACK, stream_uint64)
 {
-  GEN_TEST_STREAM(uint64_t);
+    GEN_TEST_STREAM(uint64_t);
 }
 
 TEST(MSGPACK, stream_int8)
 {
-  GEN_TEST_STREAM(int8_t);
+    GEN_TEST_STREAM(int8_t);
 }
 
 TEST(MSGPACK, stream_int16)
 {
-  GEN_TEST_STREAM(int16_t);
+    GEN_TEST_STREAM(int16_t);
 }
 
 TEST(MSGPACK, stream_int32)
 {
-  GEN_TEST_STREAM(int32_t);
+    GEN_TEST_STREAM(int32_t);
 }
 
 TEST(MSGPACK, stream_int64)
 {
-  GEN_TEST_STREAM(int64_t);
+    GEN_TEST_STREAM(int64_t);
 }

--- a/test/msgpack_vref.cpp
+++ b/test/msgpack_vref.cpp
@@ -18,249 +18,249 @@
 using namespace std;
 
 #define GEN_TEST_VREF(test_type, vbuf)                                  \
-  do {                                                                  \
-    vector<test_type> v;                                                \
-    v.push_back(0);                                                     \
-    for (unsigned int i = 0; i < v.size(); i++) {                       \
-      test_type val1 = v[i];                                            \
-      msgpack::pack(vbuf, val1);                                        \
-      msgpack::sbuffer sbuf;                                            \
-      const struct iovec* cur = vbuf.vector();                          \
-      const struct iovec* end = cur + vbuf.vector_size();               \
-      for(; cur != end; ++cur)                                          \
-        sbuf.write((const char*)cur->iov_base, cur->iov_len);           \
-      msgpack::unpacked ret;                                            \
-      msgpack::unpack(ret, sbuf.data(), sbuf.size());                   \
-      test_type val2 = ret.get().as<test_type>();                       \
-      EXPECT_EQ(val1, val2);                                            \
-    }                                                                   \
-  } while(0);
+    do {                                                                \
+        vector<test_type> v;                                            \
+        v.push_back(0);                                                 \
+        for (unsigned int i = 0; i < v.size(); i++) {                   \
+            test_type val1 = v[i];                                      \
+            msgpack::pack(vbuf, val1);                                  \
+            msgpack::sbuffer sbuf;                                      \
+            const struct iovec* cur = vbuf.vector();                    \
+            const struct iovec* end = cur + vbuf.vector_size();         \
+            for(; cur != end; ++cur)                                    \
+                sbuf.write((const char*)cur->iov_base, cur->iov_len);   \
+            msgpack::object_handle oh;                                  \
+            msgpack::unpack(oh, sbuf.data(), sbuf.size());              \
+            test_type val2 = oh.get().as<test_type>();                  \
+            EXPECT_EQ(val1, val2);                                      \
+        }                                                               \
+    } while(0);
 
 TEST(MSGPACK, vrefbuffer_char)
 {
-  msgpack::vrefbuffer vbuf;
-  GEN_TEST_VREF(char, vbuf);
+    msgpack::vrefbuffer vbuf;
+    GEN_TEST_VREF(char, vbuf);
 }
 
 TEST(MSGPACK, vrefbuffer_signed_char)
 {
-  msgpack::vrefbuffer vbuf;
-  GEN_TEST_VREF(signed char, vbuf);
+    msgpack::vrefbuffer vbuf;
+    GEN_TEST_VREF(signed char, vbuf);
 }
 
 TEST(MSGPACK, vrefbuffer_unsigned_char)
 {
-  msgpack::vrefbuffer vbuf;
-  GEN_TEST_VREF(unsigned char, vbuf);
+    msgpack::vrefbuffer vbuf;
+    GEN_TEST_VREF(unsigned char, vbuf);
 }
 
 TEST(MSGPACK, vrefbuffer_short)
 {
-  msgpack::vrefbuffer vbuf;
-  GEN_TEST_VREF(short, vbuf);
+    msgpack::vrefbuffer vbuf;
+    GEN_TEST_VREF(short, vbuf);
 }
 
 TEST(MSGPACK, vrefbuffer_int)
 {
-  msgpack::vrefbuffer vbuf;
-  GEN_TEST_VREF(int, vbuf);
+    msgpack::vrefbuffer vbuf;
+    GEN_TEST_VREF(int, vbuf);
 }
 
 TEST(MSGPACK, vrefbuffer_long)
 {
-  msgpack::vrefbuffer vbuf;
-  GEN_TEST_VREF(long, vbuf);
+    msgpack::vrefbuffer vbuf;
+    GEN_TEST_VREF(long, vbuf);
 }
 
 TEST(MSGPACK, vrefbuffer_long_long)
 {
-  msgpack::vrefbuffer vbuf;
-  GEN_TEST_VREF(long long, vbuf);
+    msgpack::vrefbuffer vbuf;
+    GEN_TEST_VREF(long long, vbuf);
 }
 
 TEST(MSGPACK, vrefbuffer_unsigned_short)
 {
-  msgpack::vrefbuffer vbuf;
-  GEN_TEST_VREF(unsigned short, vbuf);
+    msgpack::vrefbuffer vbuf;
+    GEN_TEST_VREF(unsigned short, vbuf);
 }
 
 TEST(MSGPACK, vrefbuffer_unsigned_int)
 {
-  msgpack::vrefbuffer vbuf;
-  GEN_TEST_VREF(unsigned int, vbuf);
+    msgpack::vrefbuffer vbuf;
+    GEN_TEST_VREF(unsigned int, vbuf);
 }
 
 TEST(MSGPACK, vrefbuffer_unsigned_long)
 {
-  msgpack::vrefbuffer vbuf;
-  GEN_TEST_VREF(unsigned long, vbuf);
+    msgpack::vrefbuffer vbuf;
+    GEN_TEST_VREF(unsigned long, vbuf);
 }
 
 TEST(MSGPACK, vrefbuffer_unsigned_long_long)
 {
-  msgpack::vrefbuffer vbuf;
-  GEN_TEST_VREF(unsigned long long, vbuf);
+    msgpack::vrefbuffer vbuf;
+    GEN_TEST_VREF(unsigned long long, vbuf);
 }
 
 TEST(MSGPACK, vrefbuffer_uint8)
 {
-  msgpack::vrefbuffer vbuf;
-  GEN_TEST_VREF(uint8_t, vbuf);
+    msgpack::vrefbuffer vbuf;
+    GEN_TEST_VREF(uint8_t, vbuf);
 }
 
 TEST(MSGPACK, vrefbuffer_uint16)
 {
-  msgpack::vrefbuffer vbuf;
-  GEN_TEST_VREF(uint16_t, vbuf);
+    msgpack::vrefbuffer vbuf;
+    GEN_TEST_VREF(uint16_t, vbuf);
 }
 
 TEST(MSGPACK, vrefbuffer_uint32)
 {
-  msgpack::vrefbuffer vbuf;
-  GEN_TEST_VREF(uint32_t, vbuf);
+    msgpack::vrefbuffer vbuf;
+    GEN_TEST_VREF(uint32_t, vbuf);
 }
 
 TEST(MSGPACK, vrefbuffer_uint64)
 {
-  msgpack::vrefbuffer vbuf;
-  GEN_TEST_VREF(uint64_t, vbuf);
+    msgpack::vrefbuffer vbuf;
+    GEN_TEST_VREF(uint64_t, vbuf);
 }
 
 TEST(MSGPACK, vrefbuffer_int8)
 {
-  msgpack::vrefbuffer vbuf;
-  GEN_TEST_VREF(int8_t, vbuf);
+    msgpack::vrefbuffer vbuf;
+    GEN_TEST_VREF(int8_t, vbuf);
 }
 
 TEST(MSGPACK, vrefbuffer_int16)
 {
-  msgpack::vrefbuffer vbuf;
-  GEN_TEST_VREF(int16_t, vbuf);
+    msgpack::vrefbuffer vbuf;
+    GEN_TEST_VREF(int16_t, vbuf);
 }
 
 TEST(MSGPACK, vrefbuffer_int32)
 {
-  msgpack::vrefbuffer vbuf;
-  GEN_TEST_VREF(int32_t, vbuf);
+    msgpack::vrefbuffer vbuf;
+    GEN_TEST_VREF(int32_t, vbuf);
 }
 
 TEST(MSGPACK, vrefbuffer_int64)
 {
-  msgpack::vrefbuffer vbuf;
-  GEN_TEST_VREF(int64_t, vbuf);
+    msgpack::vrefbuffer vbuf;
+    GEN_TEST_VREF(int64_t, vbuf);
 }
 
 // small ref_size and chunk_size
 TEST(MSGPACK, vrefbuffer_small_char)
 {
-  msgpack::vrefbuffer vbuf(0, 0);
-  GEN_TEST_VREF(char, vbuf);
+    msgpack::vrefbuffer vbuf(0, 0);
+    GEN_TEST_VREF(char, vbuf);
 }
 
 TEST(MSGPACK, vrefbuffer_small_signed_char)
 {
-  msgpack::vrefbuffer vbuf(0, 0);
-  GEN_TEST_VREF(signed char, vbuf);
+    msgpack::vrefbuffer vbuf(0, 0);
+    GEN_TEST_VREF(signed char, vbuf);
 }
 
 TEST(MSGPACK, vrefbuffer_small_unsigned_char)
 {
-  msgpack::vrefbuffer vbuf(0, 0);
-  GEN_TEST_VREF(unsigned char, vbuf);
+    msgpack::vrefbuffer vbuf(0, 0);
+    GEN_TEST_VREF(unsigned char, vbuf);
 }
 
 TEST(MSGPACK, vrefbuffer_small_short)
 {
-  msgpack::vrefbuffer vbuf(0, 0);
-  GEN_TEST_VREF(short, vbuf);
+    msgpack::vrefbuffer vbuf(0, 0);
+    GEN_TEST_VREF(short, vbuf);
 }
 
 TEST(MSGPACK, vrefbuffer_small_int)
 {
-  msgpack::vrefbuffer vbuf(0, 0);
-  GEN_TEST_VREF(int, vbuf);
+    msgpack::vrefbuffer vbuf(0, 0);
+    GEN_TEST_VREF(int, vbuf);
 }
 
 TEST(MSGPACK, vrefbuffer_small_long)
 {
-  msgpack::vrefbuffer vbuf(0, 0);
-  GEN_TEST_VREF(long, vbuf);
+    msgpack::vrefbuffer vbuf(0, 0);
+    GEN_TEST_VREF(long, vbuf);
 }
 
 TEST(MSGPACK, vrefbuffer_small_long_long)
 {
-  msgpack::vrefbuffer vbuf(0, 0);
-  GEN_TEST_VREF(long long, vbuf);
+    msgpack::vrefbuffer vbuf(0, 0);
+    GEN_TEST_VREF(long long, vbuf);
 }
 
 TEST(MSGPACK, vrefbuffer_small_unsigned_short)
 {
-  msgpack::vrefbuffer vbuf(0, 0);
-  GEN_TEST_VREF(unsigned short, vbuf);
+    msgpack::vrefbuffer vbuf(0, 0);
+    GEN_TEST_VREF(unsigned short, vbuf);
 }
 
 TEST(MSGPACK, vrefbuffer_small_unsigned_int)
 {
-  msgpack::vrefbuffer vbuf(0, 0);
-  GEN_TEST_VREF(unsigned int, vbuf);
+    msgpack::vrefbuffer vbuf(0, 0);
+    GEN_TEST_VREF(unsigned int, vbuf);
 }
 
 TEST(MSGPACK, vrefbuffer_small_unsigned_long)
 {
-  msgpack::vrefbuffer vbuf(0, 0);
-  GEN_TEST_VREF(unsigned long, vbuf);
+    msgpack::vrefbuffer vbuf(0, 0);
+    GEN_TEST_VREF(unsigned long, vbuf);
 }
 
 TEST(MSGPACK, vrefbuffer_small_unsigned_long_long)
 {
-  msgpack::vrefbuffer vbuf(0, 0);
-  GEN_TEST_VREF(unsigned long long, vbuf);
+    msgpack::vrefbuffer vbuf(0, 0);
+    GEN_TEST_VREF(unsigned long long, vbuf);
 }
 
 TEST(MSGPACK, vrefbuffer_small_uint8)
 {
-  msgpack::vrefbuffer vbuf(0, 0);
-  GEN_TEST_VREF(uint8_t, vbuf);
+    msgpack::vrefbuffer vbuf(0, 0);
+    GEN_TEST_VREF(uint8_t, vbuf);
 }
 
 TEST(MSGPACK, vrefbuffer_small_uint16)
 {
-  msgpack::vrefbuffer vbuf(0, 0);
-  GEN_TEST_VREF(uint16_t, vbuf);
+    msgpack::vrefbuffer vbuf(0, 0);
+    GEN_TEST_VREF(uint16_t, vbuf);
 }
 
 TEST(MSGPACK, vrefbuffer_small_uint32)
 {
-  msgpack::vrefbuffer vbuf(0, 0);
-  GEN_TEST_VREF(uint32_t, vbuf);
+    msgpack::vrefbuffer vbuf(0, 0);
+    GEN_TEST_VREF(uint32_t, vbuf);
 }
 
 TEST(MSGPACK, vrefbuffer_small_uint64)
 {
-  msgpack::vrefbuffer vbuf(0, 0);
-  GEN_TEST_VREF(uint64_t, vbuf);
+    msgpack::vrefbuffer vbuf(0, 0);
+    GEN_TEST_VREF(uint64_t, vbuf);
 }
 
 TEST(MSGPACK, vrefbuffer_small_int8)
 {
-  msgpack::vrefbuffer vbuf(0, 0);
-  GEN_TEST_VREF(int8_t, vbuf);
+    msgpack::vrefbuffer vbuf(0, 0);
+    GEN_TEST_VREF(int8_t, vbuf);
 }
 
 TEST(MSGPACK, vrefbuffer_small_int16)
 {
-  msgpack::vrefbuffer vbuf(0, 0);
-  GEN_TEST_VREF(int16_t, vbuf);
+    msgpack::vrefbuffer vbuf(0, 0);
+    GEN_TEST_VREF(int16_t, vbuf);
 }
 
 TEST(MSGPACK, vrefbuffer_small_int32)
 {
-  msgpack::vrefbuffer vbuf(0, 0);
-  GEN_TEST_VREF(int32_t, vbuf);
+    msgpack::vrefbuffer vbuf(0, 0);
+    GEN_TEST_VREF(int32_t, vbuf);
 }
 
 TEST(MSGPACK, vrefbuffer_small_int64)
 {
-  msgpack::vrefbuffer vbuf(0, 0);
-  GEN_TEST_VREF(int64_t, vbuf);
+    msgpack::vrefbuffer vbuf(0, 0);
+    GEN_TEST_VREF(int64_t, vbuf);
 }

--- a/test/object.cpp
+++ b/test/object.cpp
@@ -68,11 +68,11 @@ TEST(object, convert)
     msgpack::sbuffer sbuf;
     msgpack::pack(sbuf, m1);
 
-    msgpack::unpacked ret;
-    msgpack::unpack(ret, sbuf.data(), sbuf.size());
+    msgpack::object_handle oh =
+        msgpack::unpack(sbuf.data(), sbuf.size());
 
     myclass m2;
-    ret.get().convert(m2);
+    oh.get().convert(m2);
 
     EXPECT_EQ(m1, m2);
 }
@@ -85,10 +85,10 @@ TEST(object, as)
     msgpack::sbuffer sbuf;
     msgpack::pack(sbuf, m1);
 
-    msgpack::unpacked ret;
-    msgpack::unpack(ret, sbuf.data(), sbuf.size());
+    msgpack::object_handle oh =
+        msgpack::unpack(sbuf.data(), sbuf.size());
 
-    EXPECT_EQ(m1, ret.get().as<myclass>());
+    EXPECT_EQ(m1, oh.get().as<myclass>());
 }
 
 TEST(object, cross_zone_copy)

--- a/test/pack_unpack.cpp
+++ b/test/pack_unpack.cpp
@@ -55,8 +55,8 @@ TEST(unpack, int_ret_no_offset_no_ref)
     msgpack::sbuffer sbuf;
     msgpack::pack(sbuf, 1);
 
-    msgpack::unpacked msg = msgpack::unpack(sbuf.data(), sbuf.size());
-    EXPECT_EQ(1, msg.get().as<int>());
+    msgpack::object_handle oh = msgpack::unpack(sbuf.data(), sbuf.size());
+    EXPECT_EQ(1, oh.get().as<int>());
 }
 
 TEST(unpack, int_ret_offset_no_ref)
@@ -66,8 +66,8 @@ TEST(unpack, int_ret_offset_no_ref)
 
     std::size_t off = 0;
 
-    msgpack::unpacked msg = msgpack::unpack(sbuf.data(), sbuf.size(), off);
-    EXPECT_EQ(1, msg.get().as<int>());
+    msgpack::object_handle oh = msgpack::unpack(sbuf.data(), sbuf.size(), off);
+    EXPECT_EQ(1, oh.get().as<int>());
     EXPECT_EQ(off, sbuf.size());
 }
 
@@ -77,8 +77,8 @@ TEST(unpack, int_ret_no_offset_ref)
     msgpack::pack(sbuf, 1);
     bool referenced;
 
-    msgpack::unpacked msg = msgpack::unpack(sbuf.data(), sbuf.size(), referenced);
-    EXPECT_EQ(1, msg.get().as<int>());
+    msgpack::object_handle oh = msgpack::unpack(sbuf.data(), sbuf.size(), referenced);
+    EXPECT_EQ(1, oh.get().as<int>());
     EXPECT_EQ(false, referenced);
 }
 
@@ -89,8 +89,8 @@ TEST(unpack, int_ret_offset_ref)
     std::size_t off = 0;
     bool referenced;
 
-    msgpack::unpacked msg = msgpack::unpack(sbuf.data(), sbuf.size(), off, referenced);
-    EXPECT_EQ(1, msg.get().as<int>());
+    msgpack::object_handle oh = msgpack::unpack(sbuf.data(), sbuf.size(), off, referenced);
+    EXPECT_EQ(1, oh.get().as<int>());
     EXPECT_EQ(false, referenced);
     EXPECT_EQ(off, sbuf.size());
 }
@@ -100,22 +100,22 @@ TEST(unpack, int_no_offset_no_ref)
 {
     msgpack::sbuffer sbuf;
     msgpack::pack(sbuf, 1);
-    msgpack::unpacked msg;
+    msgpack::object_handle oh;
 
-    msgpack::unpack(msg, sbuf.data(), sbuf.size());
-    EXPECT_EQ(1, msg.get().as<int>());
+    msgpack::unpack(oh, sbuf.data(), sbuf.size());
+    EXPECT_EQ(1, oh.get().as<int>());
 }
 
 TEST(unpack, int_offset_no_ref)
 {
     msgpack::sbuffer sbuf;
     msgpack::pack(sbuf, 1);
-    msgpack::unpacked msg;
+    msgpack::object_handle oh;
 
     std::size_t off = 0;
 
-    msgpack::unpack(msg, sbuf.data(), sbuf.size(), off);
-    EXPECT_EQ(1, msg.get().as<int>());
+    msgpack::unpack(oh, sbuf.data(), sbuf.size(), off);
+    EXPECT_EQ(1, oh.get().as<int>());
     EXPECT_EQ(off, sbuf.size());
 }
 
@@ -123,11 +123,11 @@ TEST(unpack, int_no_offset_ref)
 {
     msgpack::sbuffer sbuf;
     msgpack::pack(sbuf, 1);
-    msgpack::unpacked msg;
+    msgpack::object_handle oh;
     bool referenced;
 
-    msgpack::unpack(msg, sbuf.data(), sbuf.size(), referenced);
-    EXPECT_EQ(1, msg.get().as<int>());
+    msgpack::unpack(oh, sbuf.data(), sbuf.size(), referenced);
+    EXPECT_EQ(1, oh.get().as<int>());
     EXPECT_EQ(false, referenced);
 }
 
@@ -135,12 +135,12 @@ TEST(unpack, int_offset_ref)
 {
     msgpack::sbuffer sbuf;
     msgpack::pack(sbuf, 1);
-    msgpack::unpacked msg;
+    msgpack::object_handle oh;
     std::size_t off = 0;
     bool referenced;
 
-    msgpack::unpack(msg, sbuf.data(), sbuf.size(), off, referenced);
-    EXPECT_EQ(1, msg.get().as<int>());
+    msgpack::unpack(oh, sbuf.data(), sbuf.size(), off, referenced);
+    EXPECT_EQ(1, oh.get().as<int>());
     EXPECT_EQ(false, referenced);
     EXPECT_EQ(off, sbuf.size());
 }
@@ -150,13 +150,13 @@ TEST(unpack, int_pointer_off_no_ref)
 {
     msgpack::sbuffer sbuf;
     msgpack::pack(sbuf, 1);
-    msgpack::unpacked msg;
+    msgpack::object_handle oh;
 
     std::size_t off = 0;
 
     // obsolete
-    msgpack::unpack(&msg, sbuf.data(), sbuf.size(), &off);
-    EXPECT_EQ(1, msg.get().as<int>());
+    msgpack::unpack(&oh, sbuf.data(), sbuf.size(), &off);
+    EXPECT_EQ(1, oh.get().as<int>());
     EXPECT_EQ(off, sbuf.size());
 }
 
@@ -164,13 +164,13 @@ TEST(unpack, int_pointer_off_no_ref_explicit)
 {
     msgpack::sbuffer sbuf;
     msgpack::pack(sbuf, 1);
-    msgpack::unpacked msg;
+    msgpack::object_handle oh;
 
     std::size_t off = 0;
 
     // obsolete
-    msgpack::unpack(&msg, sbuf.data(), sbuf.size(), &off, nullptr);
-    EXPECT_EQ(1, msg.get().as<int>());
+    msgpack::unpack(&oh, sbuf.data(), sbuf.size(), &off, nullptr);
+    EXPECT_EQ(1, oh.get().as<int>());
     EXPECT_EQ(off, sbuf.size());
 }
 
@@ -178,12 +178,12 @@ TEST(unpack, int_pointer_no_off_ref)
 {
     msgpack::sbuffer sbuf;
     msgpack::pack(sbuf, 1);
-    msgpack::unpacked msg;
+    msgpack::object_handle oh;
     bool referenced;
 
     // obsolete
-    msgpack::unpack(&msg, sbuf.data(), sbuf.size(), nullptr, &referenced);
-    EXPECT_EQ(1, msg.get().as<int>());
+    msgpack::unpack(&oh, sbuf.data(), sbuf.size(), nullptr, &referenced);
+    EXPECT_EQ(1, oh.get().as<int>());
     EXPECT_EQ(false, referenced);
 }
 
@@ -191,13 +191,13 @@ TEST(unpack, int_pointer_off_ref)
 {
     msgpack::sbuffer sbuf;
     msgpack::pack(sbuf, 1);
-    msgpack::unpacked msg;
+    msgpack::object_handle oh;
     bool referenced;
     std::size_t off = 0;
 
     // obsolete
-    msgpack::unpack(&msg, sbuf.data(), sbuf.size(), &off, &referenced);
-    EXPECT_EQ(1, msg.get().as<int>());
+    msgpack::unpack(&oh, sbuf.data(), sbuf.size(), &off, &referenced);
+    EXPECT_EQ(1, oh.get().as<int>());
     EXPECT_EQ(off, sbuf.size());
     EXPECT_EQ(false, referenced);
 }
@@ -207,11 +207,11 @@ TEST(unpack, int_default_null_pointer)
 {
     msgpack::sbuffer sbuf;
     msgpack::pack(sbuf, 1);
-    msgpack::unpacked msg;
+    msgpack::object_handle oh;
 
     // obsolete
-    msgpack::unpack(&msg, sbuf.data(), sbuf.size());
-    EXPECT_EQ(1, msg.get().as<int>());
+    msgpack::unpack(&oh, sbuf.data(), sbuf.size());
+    EXPECT_EQ(1, oh.get().as<int>());
 }
 
 TEST(unpack, int_zone_no_offset_no_ref)
@@ -273,16 +273,16 @@ TEST(unpack, sequence)
 
     std::size_t off = 0;
 
-    msgpack::unpacked msg;
+    msgpack::object_handle oh;
 
-    msgpack::unpack(msg, sbuf.data(), sbuf.size(), off);
-    EXPECT_EQ(1, msg.get().as<int>());
+    msgpack::unpack(oh, sbuf.data(), sbuf.size(), off);
+    EXPECT_EQ(1, oh.get().as<int>());
 
-    msgpack::unpack(msg, sbuf.data(), sbuf.size(), off);
-    EXPECT_EQ(2, msg.get().as<int>());
+    msgpack::unpack(oh, sbuf.data(), sbuf.size(), off);
+    EXPECT_EQ(2, oh.get().as<int>());
 
-    msgpack::unpack(msg, sbuf.data(), sbuf.size(), off);
-    EXPECT_EQ(3, msg.get().as<int>());
+    msgpack::unpack(oh, sbuf.data(), sbuf.size(), off);
+    EXPECT_EQ(3, oh.get().as<int>());
 
     EXPECT_EQ(off, sbuf.size());
 }
@@ -325,9 +325,9 @@ TEST(unpack, insufficient_bytes_ref)
 
     std::size_t off = 0;
 
-    msgpack::unpacked msg;
+    msgpack::object_handle oh;
     try {
-        msgpack::unpack(msg, sbuf.data(), 1, off);
+        msgpack::unpack(oh, sbuf.data(), 1, off);
         EXPECT_TRUE(false);
     }
     catch (msgpack::insufficient_bytes const&) {
@@ -343,7 +343,6 @@ TEST(unpack, insufficient_bytes_object_handle)
 
     std::size_t off = 0;
 
-    msgpack::unpacked msg;
     try {
         msgpack::object_handle oh(msgpack::unpack(sbuf.data(), 1, off));
         EXPECT_TRUE(false);
@@ -361,7 +360,6 @@ TEST(unpack, insufficient_bytes_zone)
 
     std::size_t off = 0;
 
-    msgpack::unpacked msg;
     try {
         msgpack::zone z;
         msgpack::unpack(z, sbuf.data(), 1, off);
@@ -381,9 +379,9 @@ TEST(unpack, parse_error)
     sbuf.write(&c, 1);
 
     bool thrown = false;
-    msgpack::unpacked msg;
+    msgpack::object_handle oh;
     try {
-        msgpack::unpack(msg, sbuf.data(), sbuf.size());
+        msgpack::unpack(oh, sbuf.data(), sbuf.size());
         EXPECT_TRUE(false);
     }
     catch (msgpack::parse_error const&) {
@@ -434,8 +432,8 @@ TEST(unpack, extra_bytes)
     msgpack::sbuffer sbuf;
     msgpack::pack(sbuf, 1);
 
-    msgpack::unpacked msg = msgpack::unpack(sbuf.data(), sbuf.size() + 1);
-    EXPECT_EQ(1, msg.get().as<int>());
+    msgpack::object_handle oh = msgpack::unpack(sbuf.data(), sbuf.size() + 1);
+    EXPECT_EQ(1, oh.get().as<int>());
 }
 
 TEST(unpack, zone_extra_bytes)
@@ -457,7 +455,7 @@ TEST(unpack, int_off_larger_than_length)
 
     bool thrown = false;
     try {
-        msgpack::unpacked msg = msgpack::unpack(sbuf.data(), sbuf.size(), off);
+        msgpack::object_handle oh = msgpack::unpack(sbuf.data(), sbuf.size(), off);
     }
     catch (msgpack::insufficient_bytes const&) {
         thrown = true;

--- a/test/raw.cpp
+++ b/test/raw.cpp
@@ -23,9 +23,9 @@ TEST(MSGPACK_RAW_REF, pack_unpack)
     EXPECT_EQ(packed_str[3], 'B');
     EXPECT_EQ(packed_str[4], 'C');
 
-    msgpack::unpacked upd;
-    msgpack::unpack(upd, ss.str().data(), ss.str().size());
-    msgpack::type::raw_ref rr2 = upd.get().as<msgpack::type::raw_ref>();
+    msgpack::object_handle oh =
+        msgpack::unpack(ss.str().data(), ss.str().size());
+    msgpack::type::raw_ref rr2 = oh.get().as<msgpack::type::raw_ref>();
     EXPECT_TRUE(rr1 == rr2);
 }
 
@@ -40,9 +40,9 @@ TEST(MSGPACK_RAW_REF, pack_unpack_8_l)
     EXPECT_EQ(packed_str[0], static_cast<char>(0xc4u));
     EXPECT_EQ(packed_str[1], static_cast<char>(0x00u));
 
-    msgpack::unpacked upd;
-    msgpack::unpack(upd, ss.str().data(), ss.str().size());
-    msgpack::type::raw_ref rr2 = upd.get().as<msgpack::type::raw_ref>();
+    msgpack::object_handle oh =
+        msgpack::unpack(ss.str().data(), ss.str().size());
+    msgpack::type::raw_ref rr2 = oh.get().as<msgpack::type::raw_ref>();
     EXPECT_TRUE(rr1 == rr2);
 }
 
@@ -58,9 +58,9 @@ TEST(MSGPACK_RAW_REF, pack_unpack_8_h)
     EXPECT_EQ(packed_str[1], static_cast<char>(0xffu));
     EXPECT_EQ(packed_str[2], 'A');
 
-    msgpack::unpacked upd;
-    msgpack::unpack(upd, ss.str().data(), ss.str().size());
-    msgpack::type::raw_ref rr2 = upd.get().as<msgpack::type::raw_ref>();
+    msgpack::object_handle oh =
+        msgpack::unpack(ss.str().data(), ss.str().size());
+    msgpack::type::raw_ref rr2 = oh.get().as<msgpack::type::raw_ref>();
     EXPECT_TRUE(rr1 == rr2);
 }
 
@@ -77,9 +77,9 @@ TEST(MSGPACK_RAW_REF, pack_unpack_16_l)
     EXPECT_EQ(packed_str[2], static_cast<char>(0x00));
     EXPECT_EQ(packed_str[3], 'A');
 
-    msgpack::unpacked upd;
-    msgpack::unpack(upd, ss.str().data(), ss.str().size());
-    msgpack::type::raw_ref rr2 = upd.get().as<msgpack::type::raw_ref>();
+    msgpack::object_handle oh =
+        msgpack::unpack(ss.str().data(), ss.str().size());
+    msgpack::type::raw_ref rr2 = oh.get().as<msgpack::type::raw_ref>();
     EXPECT_TRUE(rr1 == rr2);
 }
 
@@ -96,9 +96,9 @@ TEST(MSGPACK_RAW_REF, pack_unpack_16_h)
     EXPECT_EQ(packed_str[2], static_cast<char>(0xffu));
     EXPECT_EQ(packed_str[3], 'A');
 
-    msgpack::unpacked upd;
-    msgpack::unpack(upd, ss.str().data(), ss.str().size());
-    msgpack::type::raw_ref rr2 = upd.get().as<msgpack::type::raw_ref>();
+    msgpack::object_handle oh =
+        msgpack::unpack(ss.str().data(), ss.str().size());
+    msgpack::type::raw_ref rr2 = oh.get().as<msgpack::type::raw_ref>();
     EXPECT_TRUE(rr1 == rr2);
 }
 
@@ -117,9 +117,9 @@ TEST(MSGPACK_RAW_REF, pack_unpack_32_l)
     EXPECT_EQ(packed_str[4], static_cast<char>(0x00));
     EXPECT_EQ(packed_str[5], 'A');
 
-    msgpack::unpacked upd;
-    msgpack::unpack(upd, ss.str().data(), ss.str().size());
-    msgpack::type::raw_ref rr2 = upd.get().as<msgpack::type::raw_ref>();
+    msgpack::object_handle oh =
+        msgpack::unpack(ss.str().data(), ss.str().size());
+    msgpack::type::raw_ref rr2 = oh.get().as<msgpack::type::raw_ref>();
     EXPECT_TRUE(rr1 == rr2);
 }
 
@@ -136,9 +136,9 @@ TEST(MSGPACK_V4RAW_REF, pack_unpack)
     EXPECT_EQ(packed_str[2], 'B');
     EXPECT_EQ(packed_str[3], 'C');
 
-    msgpack::unpacked upd;
-    msgpack::unpack(upd, ss.str().data(), ss.str().size());
-    msgpack::type::v4raw_ref rr2 = upd.get().as<msgpack::type::v4raw_ref>();
+    msgpack::object_handle oh =
+        msgpack::unpack(ss.str().data(), ss.str().size());
+    msgpack::type::v4raw_ref rr2 = oh.get().as<msgpack::type::v4raw_ref>();
     EXPECT_TRUE(rr1 == rr2);
 }
 
@@ -152,9 +152,9 @@ TEST(MSGPACK_V4RAW_REF, pack_unpack_fix_l)
     std::string packed_str = ss.str();
     EXPECT_EQ(packed_str[0], static_cast<char>(0xa0u));
 
-    msgpack::unpacked upd;
-    msgpack::unpack(upd, ss.str().data(), ss.str().size());
-    msgpack::type::v4raw_ref rr2 = upd.get().as<msgpack::type::v4raw_ref>();
+    msgpack::object_handle oh =
+        msgpack::unpack(ss.str().data(), ss.str().size());
+    msgpack::type::v4raw_ref rr2 = oh.get().as<msgpack::type::v4raw_ref>();
     EXPECT_TRUE(rr1 == rr2);
 }
 
@@ -169,9 +169,9 @@ TEST(MSGPACK_V4RAW_REF, pack_unpack_fix_h)
     EXPECT_EQ(packed_str[0], static_cast<char>(0xbfu));
     EXPECT_EQ(packed_str[1], 'A');
 
-    msgpack::unpacked upd;
-    msgpack::unpack(upd, ss.str().data(), ss.str().size());
-    msgpack::type::v4raw_ref rr2 = upd.get().as<msgpack::type::v4raw_ref>();
+    msgpack::object_handle oh =
+        msgpack::unpack(ss.str().data(), ss.str().size());
+    msgpack::type::v4raw_ref rr2 = oh.get().as<msgpack::type::v4raw_ref>();
     EXPECT_TRUE(rr1 == rr2);
 }
 
@@ -188,9 +188,9 @@ TEST(MSGPACK_V4RAW_REF, pack_unpack_16_l)
     EXPECT_EQ(packed_str[2], static_cast<char>(0x20u));
     EXPECT_EQ(packed_str[3], 'A');
 
-    msgpack::unpacked upd;
-    msgpack::unpack(upd, ss.str().data(), ss.str().size());
-    msgpack::type::v4raw_ref rr2 = upd.get().as<msgpack::type::v4raw_ref>();
+    msgpack::object_handle oh =
+        msgpack::unpack(ss.str().data(), ss.str().size());
+    msgpack::type::v4raw_ref rr2 = oh.get().as<msgpack::type::v4raw_ref>();
     EXPECT_TRUE(rr1 == rr2);
 }
 
@@ -207,9 +207,9 @@ TEST(MSGPACK_V4RAW_REF, pack_unpack_16_h)
     EXPECT_EQ(packed_str[2], static_cast<char>(0xffu));
     EXPECT_EQ(packed_str[3], 'A');
 
-    msgpack::unpacked upd;
-    msgpack::unpack(upd, ss.str().data(), ss.str().size());
-    msgpack::type::v4raw_ref rr2 = upd.get().as<msgpack::type::v4raw_ref>();
+    msgpack::object_handle oh =
+        msgpack::unpack(ss.str().data(), ss.str().size());
+    msgpack::type::v4raw_ref rr2 = oh.get().as<msgpack::type::v4raw_ref>();
     EXPECT_TRUE(rr1 == rr2);
 }
 
@@ -228,8 +228,8 @@ TEST(MSGPACK_V4RAW_REF, pack_unpack_32_l)
     EXPECT_EQ(packed_str[4], static_cast<char>(0x00));
     EXPECT_EQ(packed_str[5], 'A');
 
-    msgpack::unpacked upd;
-    msgpack::unpack(upd, ss.str().data(), ss.str().size());
-    msgpack::type::v4raw_ref rr2 = upd.get().as<msgpack::type::v4raw_ref>();
+    msgpack::object_handle oh =
+        msgpack::unpack(ss.str().data(), ss.str().size());
+    msgpack::type::v4raw_ref rr2 = oh.get().as<msgpack::type::v4raw_ref>();
     EXPECT_TRUE(rr1 == rr2);
 }

--- a/test/reference.cpp
+++ b/test/reference.cpp
@@ -5,10 +5,10 @@ TEST(reference, unpack_int)
 {
     msgpack::sbuffer sbuf;
     msgpack::pack(sbuf, 1);
-    msgpack::unpacked ret;
     bool referenced;
 
-    msgpack::unpack(ret, sbuf.data(), sbuf.size(), referenced);
+    msgpack::object_handle oh =
+        msgpack::unpack(sbuf.data(), sbuf.size(), referenced);
     EXPECT_FALSE(referenced);
 }
 
@@ -16,10 +16,10 @@ TEST(reference, unpack_string)
 {
     msgpack::sbuffer sbuf;
     msgpack::pack(sbuf, std::string("abcdefg"));
-    msgpack::unpacked ret;
     bool referenced;
 
-    msgpack::unpack(ret, sbuf.data(), sbuf.size(), referenced);
+    msgpack::object_handle oh =
+        msgpack::unpack(sbuf.data(), sbuf.size(), referenced);
     EXPECT_FALSE(referenced);
 }
 
@@ -31,9 +31,9 @@ TEST(reference, unpack_bin)
     packer.pack_bin(sizeof(c));
     packer.pack_bin_body(c, sizeof(c));
 
-    msgpack::unpacked ret;
     bool referenced;
-    msgpack::unpack(ret, sbuf.data(), sbuf.size(), referenced);
+    msgpack::object_handle oh =
+        msgpack::unpack(sbuf.data(), sbuf.size(), referenced);
     EXPECT_FALSE(referenced);
 }
 
@@ -45,9 +45,9 @@ TEST(reference, unpack_ext)
 
     packer.pack_ext(sizeof(buf), 1);
     packer.pack_ext_body(buf, sizeof(buf));
-    msgpack::unpacked ret;
     bool referenced;
-    msgpack::unpack(ret, sbuf.data(), sbuf.size(), referenced);
+    msgpack::object_handle oh =
+        msgpack::unpack(sbuf.data(), sbuf.size(), referenced);
     EXPECT_FALSE(referenced);
 }
 
@@ -66,10 +66,10 @@ TEST(reference, unpack_int_ref)
 {
     msgpack::sbuffer sbuf;
     msgpack::pack(sbuf, 1);
-    msgpack::unpacked ret;
     bool referenced;
 
-    msgpack::unpack(ret, sbuf.data(), sbuf.size(), referenced, never_called);
+    msgpack::object_handle oh =
+        msgpack::unpack(sbuf.data(), sbuf.size(), referenced, never_called);
     EXPECT_FALSE(referenced);
 }
 
@@ -77,11 +77,10 @@ TEST(reference, unpack_string_ref)
 {
     msgpack::sbuffer sbuf;
     msgpack::pack(sbuf, std::string("abcdefg"));
-    msgpack::unpacked ret;
     bool referenced;
 
-
-    msgpack::unpack(ret, sbuf.data(), sbuf.size(), referenced, always_reference);
+    msgpack::object_handle oh =
+        msgpack::unpack(sbuf.data(), sbuf.size(), referenced, always_reference);
     EXPECT_TRUE(referenced);
 }
 
@@ -93,9 +92,9 @@ TEST(reference, unpack_bin_ref)
     packer.pack_bin(sizeof(c));
     packer.pack_bin_body(c, sizeof(c));
 
-    msgpack::unpacked ret;
     bool referenced;
-    msgpack::unpack(ret, sbuf.data(), sbuf.size(), referenced, always_reference);
+    msgpack::object_handle oh =
+        msgpack::unpack(sbuf.data(), sbuf.size(), referenced, always_reference);
     EXPECT_TRUE(referenced);
 }
 
@@ -107,9 +106,10 @@ TEST(reference, unpack_ext_ref)
 
     packer.pack_ext(sizeof(buf), 1);
     packer.pack_ext_body(buf, sizeof(buf));
-    msgpack::unpacked ret;
     bool referenced;
-    msgpack::unpack(ret, sbuf.data(), sbuf.size(), referenced, always_reference);
+
+    msgpack::object_handle oh =
+        msgpack::unpack(sbuf.data(), sbuf.size(), referenced, always_reference);
     EXPECT_TRUE(referenced);
 }
 
@@ -139,10 +139,11 @@ TEST(reference, unpack_int_sized_ref)
     msgpack::sbuffer sbuf;
     msgpack::pack(sbuf, 1);
 
-    msgpack::unpacked ret;
     bool referenced;
     s_p = nullptr;
-    msgpack::unpack(ret, sbuf.data(), sbuf.size(), referenced, never_called, &sbuf);
+
+    msgpack::object_handle oh =
+        msgpack::unpack(sbuf.data(), sbuf.size(), referenced, never_called, &sbuf);
     EXPECT_FALSE(referenced);
     EXPECT_EQ(nullptr, s_p);
 }
@@ -152,12 +153,12 @@ TEST(reference, unpack_string_sized_ref_4)
     msgpack::sbuffer sbuf;
     msgpack::pack(sbuf, std::string("1234"));
 
-    msgpack::unpacked ret;
     bool referenced;
     s_p = nullptr;
     // the last argument sbuf is any pointer as a user data.
     // That is stored to s_p in sized_reference
-    msgpack::unpack(ret, sbuf.data(), sbuf.size(), referenced, sized_reference, &sbuf);
+    msgpack::object_handle oh =
+        msgpack::unpack(sbuf.data(), sbuf.size(), referenced, sized_reference, &sbuf);
     EXPECT_FALSE(referenced);
     // compare the passed argument with stored s_p.
     EXPECT_EQ(&sbuf, s_p);
@@ -168,10 +169,11 @@ TEST(reference, unpack_string_sized_ref_5)
     msgpack::sbuffer sbuf;
     msgpack::pack(sbuf, std::string("12345"));
 
-    msgpack::unpacked ret;
     bool referenced;
     s_p = nullptr;
-    msgpack::unpack(ret, sbuf.data(), sbuf.size(), referenced, sized_reference, &sbuf);
+
+    msgpack::object_handle oh =
+        msgpack::unpack(sbuf.data(), sbuf.size(), referenced, sized_reference, &sbuf);
     EXPECT_TRUE(referenced);
     EXPECT_EQ(&sbuf, s_p);
 }
@@ -185,10 +187,11 @@ TEST(reference, unpack_bin_sized_ref_5)
     packer.pack_bin(sizeof(c));
     packer.pack_bin_body(c, sizeof(c));
 
-    msgpack::unpacked ret;
     bool referenced;
     s_p = nullptr;
-    msgpack::unpack(ret, sbuf.data(), sbuf.size(), referenced, sized_reference, &sbuf);
+
+    msgpack::object_handle oh =
+        msgpack::unpack(sbuf.data(), sbuf.size(), referenced, sized_reference, &sbuf);
     EXPECT_FALSE(referenced);
     EXPECT_EQ(&sbuf, s_p);
 }
@@ -201,10 +204,10 @@ TEST(reference, unpack_bin_sized_ref_6)
     packer.pack_bin(sizeof(c));
     packer.pack_bin_body(c, sizeof(c));
 
-    msgpack::unpacked ret;
     bool referenced;
     s_p = nullptr;
-    msgpack::unpack(ret, sbuf.data(), sbuf.size(), referenced, sized_reference, &sbuf);
+    msgpack::object_handle oh =
+        msgpack::unpack(sbuf.data(), sbuf.size(), referenced, sized_reference, &sbuf);
     EXPECT_TRUE(referenced);
     EXPECT_EQ(&sbuf, s_p);
 }
@@ -218,10 +221,10 @@ TEST(reference, unpack_ext_sized_ref_6)
     packer.pack_ext(sizeof(buf), 1); // 5 + 1(type) = 6
     packer.pack_ext_body(buf, sizeof(buf));
 
-    msgpack::unpacked ret;
     bool referenced;
     s_p = nullptr;
-    msgpack::unpack(ret, sbuf.data(), sbuf.size(), referenced, sized_reference, &sbuf);
+    msgpack::object_handle oh =
+        msgpack::unpack(sbuf.data(), sbuf.size(), referenced, sized_reference, &sbuf);
     EXPECT_FALSE(referenced);
     EXPECT_EQ(&sbuf, s_p);
 }
@@ -235,10 +238,10 @@ TEST(reference, unpack_ext_sized_ref_7)
     packer.pack_ext(sizeof(buf), 1); // 6 + 1(type) = 7
     packer.pack_ext_body(buf, sizeof(buf));
 
-    msgpack::unpacked ret;
     bool referenced;
     s_p = nullptr;
-    msgpack::unpack(ret, sbuf.data(), sbuf.size(), referenced, sized_reference, &sbuf);
+    msgpack::object_handle oh =
+        msgpack::unpack(sbuf.data(), sbuf.size(), referenced, sized_reference, &sbuf);
     EXPECT_TRUE(referenced);
     EXPECT_EQ(&sbuf, s_p);
 }
@@ -252,12 +255,12 @@ TEST(reference, unpacker_int)
     msgpack::pack(sbuf, 1);
 
     msgpack::unpacker unp;
-    msgpack::unpacked ret;
+    msgpack::object_handle oh;
     bool referenced;
     unp.reserve_buffer(sbuf.size());
     std::memcpy(unp.buffer(), sbuf.data(), sbuf.size());
     unp.buffer_consumed(sbuf.size());
-    bool b = unp.next(ret, referenced);
+    bool b = unp.next(oh, referenced);
     EXPECT_TRUE(b);
     EXPECT_FALSE(referenced);
 }
@@ -268,12 +271,12 @@ TEST(reference, unpacker_string)
     msgpack::pack(sbuf, std::string("a"));
 
     msgpack::unpacker unp;
-    msgpack::unpacked ret;
+    msgpack::object_handle oh;
     bool referenced;
     unp.reserve_buffer(sbuf.size());
     std::memcpy(unp.buffer(), sbuf.data(), sbuf.size());
     unp.buffer_consumed(sbuf.size());
-    bool b = unp.next(ret, referenced);
+    bool b = unp.next(oh, referenced);
     EXPECT_TRUE(b);
     EXPECT_TRUE(referenced);
 }
@@ -287,12 +290,12 @@ TEST(reference, unpacker_bin)
     packer.pack_bin_body(c, sizeof(c));
 
     msgpack::unpacker unp;
-    msgpack::unpacked ret;
+    msgpack::object_handle oh;
     bool referenced;
     unp.reserve_buffer(sbuf.size());
     std::memcpy(unp.buffer(), sbuf.data(), sbuf.size());
     unp.buffer_consumed(sbuf.size());
-    bool b = unp.next(ret, referenced);
+    bool b = unp.next(oh, referenced);
     EXPECT_TRUE(b);
     EXPECT_TRUE(referenced);
 }
@@ -307,12 +310,12 @@ TEST(reference, unpacker_ext)
     packer.pack_ext_body(buf, sizeof(buf));
 
     msgpack::unpacker unp;
-    msgpack::unpacked ret;
+    msgpack::object_handle oh;
     bool referenced;
     unp.reserve_buffer(sbuf.size());
     std::memcpy(unp.buffer(), sbuf.data(), sbuf.size());
     unp.buffer_consumed(sbuf.size());
-    bool b = unp.next(ret, referenced);
+    bool b = unp.next(oh, referenced);
     EXPECT_TRUE(b);
     EXPECT_TRUE(referenced);
 }
@@ -325,13 +328,13 @@ TEST(reference, unpacker_int_sized_ref)
     msgpack::pack(sbuf, 1);
 
     msgpack::unpacker unp(never_called, &sbuf);
-    msgpack::unpacked ret;
+    msgpack::object_handle oh;
     bool referenced;
     unp.reserve_buffer(sbuf.size());
     std::memcpy(unp.buffer(), sbuf.data(), sbuf.size());
     unp.buffer_consumed(sbuf.size());
     s_p = nullptr;
-    bool b = unp.next(ret, referenced);
+    bool b = unp.next(oh, referenced);
     EXPECT_TRUE(b);
     EXPECT_FALSE(referenced);
     EXPECT_EQ(nullptr, s_p);
@@ -343,13 +346,13 @@ TEST(reference, unpacker_string_sized_ref_4)
     msgpack::pack(sbuf, std::string("1234"));
 
     msgpack::unpacker unp(sized_reference, &sbuf);
-    msgpack::unpacked ret;
+    msgpack::object_handle oh;
     bool referenced;
     unp.reserve_buffer(sbuf.size());
     std::memcpy(unp.buffer(), sbuf.data(), sbuf.size());
     unp.buffer_consumed(sbuf.size());
     s_p = nullptr;
-    bool b = unp.next(ret, referenced);
+    bool b = unp.next(oh, referenced);
     EXPECT_TRUE(b);
     EXPECT_FALSE(referenced);
     EXPECT_EQ(&sbuf, s_p);
@@ -361,13 +364,13 @@ TEST(reference, unpacker_string_sized_ref_5)
     msgpack::pack(sbuf, std::string("12345"));
 
     msgpack::unpacker unp(sized_reference, &sbuf);
-    msgpack::unpacked ret;
+    msgpack::object_handle oh;
     bool referenced;
     unp.reserve_buffer(sbuf.size());
     std::memcpy(unp.buffer(), sbuf.data(), sbuf.size());
     unp.buffer_consumed(sbuf.size());
     s_p = nullptr;
-    bool b = unp.next(ret, referenced);
+    bool b = unp.next(oh, referenced);
     EXPECT_TRUE(b);
     EXPECT_TRUE(referenced);
     EXPECT_EQ(&sbuf, s_p);
@@ -383,13 +386,13 @@ TEST(reference, unpacker_bin_sized_ref_5)
     packer.pack_bin_body(c, sizeof(c));
 
     msgpack::unpacker unp(sized_reference, &sbuf);
-    msgpack::unpacked ret;
+    msgpack::object_handle oh;
     bool referenced;
     unp.reserve_buffer(sbuf.size());
     std::memcpy(unp.buffer(), sbuf.data(), sbuf.size());
     unp.buffer_consumed(sbuf.size());
     s_p = nullptr;
-    bool b = unp.next(ret, referenced);
+    bool b = unp.next(oh, referenced);
     EXPECT_TRUE(b);
     EXPECT_FALSE(referenced);
     EXPECT_EQ(&sbuf, s_p);
@@ -404,13 +407,13 @@ TEST(reference, unpacker_bin_sized_ref_6)
     packer.pack_bin_body(c, sizeof(c));
 
     msgpack::unpacker unp(sized_reference, &sbuf);
-    msgpack::unpacked ret;
+    msgpack::object_handle oh;
     bool referenced;
     unp.reserve_buffer(sbuf.size());
     std::memcpy(unp.buffer(), sbuf.data(), sbuf.size());
     unp.buffer_consumed(sbuf.size());
     s_p = nullptr;
-    bool b = unp.next(ret, referenced);
+    bool b = unp.next(oh, referenced);
     EXPECT_TRUE(b);
     EXPECT_TRUE(referenced);
     EXPECT_EQ(&sbuf, s_p);
@@ -426,13 +429,13 @@ TEST(reference, unpacker_ext_sized_ref_6)
     packer.pack_ext_body(buf, sizeof(buf));
 
     msgpack::unpacker unp(sized_reference, &sbuf);
-    msgpack::unpacked ret;
+    msgpack::object_handle oh;
     bool referenced;
     unp.reserve_buffer(sbuf.size());
     std::memcpy(unp.buffer(), sbuf.data(), sbuf.size());
     unp.buffer_consumed(sbuf.size());
     s_p = nullptr;
-    bool b = unp.next(ret, referenced);
+    bool b = unp.next(oh, referenced);
     EXPECT_TRUE(b);
     EXPECT_FALSE(referenced);
     EXPECT_EQ(&sbuf, s_p);
@@ -448,13 +451,13 @@ TEST(reference, unpacker_ext_sized_ref_7)
     packer.pack_ext_body(buf, sizeof(buf));
 
     msgpack::unpacker unp(sized_reference, &sbuf);
-    msgpack::unpacked ret;
+    msgpack::object_handle oh;
     bool referenced;
     unp.reserve_buffer(sbuf.size());
     std::memcpy(unp.buffer(), sbuf.data(), sbuf.size());
     unp.buffer_consumed(sbuf.size());
     s_p = nullptr;
-    bool b = unp.next(ret, referenced);
+    bool b = unp.next(oh, referenced);
     EXPECT_TRUE(b);
     EXPECT_TRUE(referenced);
     EXPECT_EQ(&sbuf, s_p);

--- a/test/reference_cpp11.cpp
+++ b/test/reference_cpp11.cpp
@@ -9,7 +9,7 @@ TEST(reference, unpack_int)
     msgpack::pack(sbuf, 1);
     bool referenced;
 
-    msgpack::unpacked ret = msgpack::unpack(sbuf.data(), sbuf.size(), referenced);
+    msgpack::object_handle oh = msgpack::unpack(sbuf.data(), sbuf.size(), referenced);
     EXPECT_FALSE(referenced);
 }
 
@@ -19,7 +19,7 @@ TEST(reference, unpack_string)
     msgpack::pack(sbuf, std::string("abcdefg"));
     bool referenced;
 
-    msgpack::unpacked ret = msgpack::unpack(sbuf.data(), sbuf.size(), referenced);
+    msgpack::object_handle oh = msgpack::unpack(sbuf.data(), sbuf.size(), referenced);
     EXPECT_FALSE(referenced);
 }
 
@@ -32,7 +32,7 @@ TEST(reference, unpack_bin)
     packer.pack_bin_body(c, sizeof(c));
 
     bool referenced;
-    msgpack::unpacked ret = msgpack::unpack(sbuf.data(), sbuf.size(), referenced);
+    msgpack::object_handle oh = msgpack::unpack(sbuf.data(), sbuf.size(), referenced);
     EXPECT_FALSE(referenced);
 }
 
@@ -45,7 +45,7 @@ TEST(reference, unpack_ext)
     packer.pack_ext(sizeof(buf), 1);
     packer.pack_ext_body(buf, sizeof(buf));
     bool referenced;
-    msgpack::unpacked ret = msgpack::unpack(sbuf.data(), sbuf.size(), referenced);
+    msgpack::object_handle oh = msgpack::unpack(sbuf.data(), sbuf.size(), referenced);
     EXPECT_FALSE(referenced);
 }
 
@@ -66,7 +66,7 @@ TEST(reference, unpack_int_ref)
     msgpack::pack(sbuf, 1);
     bool referenced;
 
-    msgpack::unpacked ret = msgpack::unpack(sbuf.data(), sbuf.size(), referenced, never_called);
+    msgpack::object_handle oh = msgpack::unpack(sbuf.data(), sbuf.size(), referenced, never_called);
     EXPECT_FALSE(referenced);
 }
 
@@ -76,7 +76,7 @@ TEST(reference, unpack_string_ref)
     msgpack::pack(sbuf, std::string("abcdefg"));
     bool referenced;
 
-    msgpack::unpacked ret = msgpack::unpack(sbuf.data(), sbuf.size(), referenced, always_reference);
+    msgpack::object_handle oh = msgpack::unpack(sbuf.data(), sbuf.size(), referenced, always_reference);
     EXPECT_TRUE(referenced);
 }
 
@@ -89,7 +89,7 @@ TEST(reference, unpack_bin_ref)
     packer.pack_bin_body(c, sizeof(c));
 
     bool referenced;
-    msgpack::unpacked ret = msgpack::unpack(sbuf.data(), sbuf.size(), referenced, always_reference);
+    msgpack::object_handle oh = msgpack::unpack(sbuf.data(), sbuf.size(), referenced, always_reference);
     EXPECT_TRUE(referenced);
 }
 
@@ -102,7 +102,7 @@ TEST(reference, unpack_ext_ref)
     packer.pack_ext(sizeof(buf), 1);
     packer.pack_ext_body(buf, sizeof(buf));
     bool referenced;
-    msgpack::unpacked ret = msgpack::unpack(sbuf.data(), sbuf.size(), referenced, always_reference);
+    msgpack::object_handle oh = msgpack::unpack(sbuf.data(), sbuf.size(), referenced, always_reference);
     EXPECT_TRUE(referenced);
 }
 
@@ -134,7 +134,7 @@ TEST(reference, unpack_int_sized_ref)
 
     bool referenced;
     s_p = nullptr;
-    msgpack::unpacked ret = msgpack::unpack(sbuf.data(), sbuf.size(), referenced, never_called, &sbuf);
+    msgpack::object_handle oh = msgpack::unpack(sbuf.data(), sbuf.size(), referenced, never_called, &sbuf);
     EXPECT_FALSE(referenced);
     EXPECT_EQ(nullptr, s_p);
 }
@@ -148,7 +148,7 @@ TEST(reference, unpack_string_sized_ref_4)
     s_p = nullptr;
     // the last argument sbuf is any pointer as a user data.
     // That is stored to s_p in sized_reference
-    msgpack::unpacked ret = msgpack::unpack(sbuf.data(), sbuf.size(), referenced, sized_reference, &sbuf);
+    msgpack::object_handle oh = msgpack::unpack(sbuf.data(), sbuf.size(), referenced, sized_reference, &sbuf);
     EXPECT_FALSE(referenced);
     // compare the passed argument with stored s_p.
     EXPECT_EQ(&sbuf, s_p);
@@ -161,7 +161,7 @@ TEST(reference, unpack_string_sized_ref_5)
 
     bool referenced;
     s_p = nullptr;
-    msgpack::unpacked ret = msgpack::unpack(sbuf.data(), sbuf.size(), referenced, sized_reference, &sbuf);
+    msgpack::object_handle oh = msgpack::unpack(sbuf.data(), sbuf.size(), referenced, sized_reference, &sbuf);
     EXPECT_TRUE(referenced);
     EXPECT_EQ(&sbuf, s_p);
 }
@@ -177,7 +177,7 @@ TEST(reference, unpack_bin_sized_ref_5)
 
     bool referenced;
     s_p = nullptr;
-    msgpack::unpacked ret = msgpack::unpack(sbuf.data(), sbuf.size(), referenced, sized_reference, &sbuf);
+    msgpack::object_handle oh = msgpack::unpack(sbuf.data(), sbuf.size(), referenced, sized_reference, &sbuf);
     EXPECT_FALSE(referenced);
     EXPECT_EQ(&sbuf, s_p);
 }
@@ -192,7 +192,7 @@ TEST(reference, unpack_bin_sized_ref_6)
 
     bool referenced;
     s_p = nullptr;
-    msgpack::unpacked ret = msgpack::unpack(sbuf.data(), sbuf.size(), referenced, sized_reference, &sbuf);
+    msgpack::object_handle oh = msgpack::unpack(sbuf.data(), sbuf.size(), referenced, sized_reference, &sbuf);
     EXPECT_TRUE(referenced);
     EXPECT_EQ(&sbuf, s_p);
 }
@@ -208,7 +208,7 @@ TEST(reference, unpack_ext_sized_ref_6)
 
     bool referenced;
     s_p = nullptr;
-    msgpack::unpacked ret = msgpack::unpack(sbuf.data(), sbuf.size(), referenced, sized_reference, &sbuf);
+    msgpack::object_handle oh = msgpack::unpack(sbuf.data(), sbuf.size(), referenced, sized_reference, &sbuf);
     EXPECT_FALSE(referenced);
     EXPECT_EQ(&sbuf, s_p);
 }
@@ -224,7 +224,7 @@ TEST(reference, unpack_ext_sized_ref_7)
 
     bool referenced;
     s_p = nullptr;
-    msgpack::unpacked ret = msgpack::unpack(sbuf.data(), sbuf.size(), referenced, sized_reference, &sbuf);
+    msgpack::object_handle oh = msgpack::unpack(sbuf.data(), sbuf.size(), referenced, sized_reference, &sbuf);
     EXPECT_TRUE(referenced);
     EXPECT_EQ(&sbuf, s_p);
 }

--- a/test/shared_ptr_cpp11.cpp
+++ b/test/shared_ptr_cpp11.cpp
@@ -14,9 +14,9 @@ TEST(SHARED_PTR, pack_convert_nil)
     std::stringstream ss;
     std::shared_ptr<int> val1;
     msgpack::pack(ss, val1);
-    msgpack::unpacked ret;
-    msgpack::unpack(ret, ss.str().data(), ss.str().size());
-    std::shared_ptr<int> val2 = ret.get().as<std::shared_ptr<int>>();
+    msgpack::object_handle oh =
+        msgpack::unpack(ss.str().data(), ss.str().size());
+    std::shared_ptr<int> val2 = oh.get().as<std::shared_ptr<int>>();
     EXPECT_TRUE(val1 == val2);
 }
 
@@ -25,9 +25,9 @@ TEST(SHARED_PTR, pack_convert_int)
     std::stringstream ss;
     std::shared_ptr<int> val1(new int(1));
     msgpack::pack(ss, val1);
-    msgpack::unpacked ret;
-    msgpack::unpack(ret, ss.str().data(), ss.str().size());
-    std::shared_ptr<int> val2 = ret.get().as<std::shared_ptr<int>>();
+    msgpack::object_handle oh =
+        msgpack::unpack(ss.str().data(), ss.str().size());
+    std::shared_ptr<int> val2 = oh.get().as<std::shared_ptr<int>>();
     EXPECT_TRUE(*val1 == *val2);
 }
 
@@ -113,9 +113,9 @@ TEST(SHARED_PTR, pack_convert_nil_no_def_con)
     std::stringstream ss;
     std::shared_ptr<no_def_con> val1(new no_def_con(1));
     msgpack::pack(ss, val1);
-    msgpack::unpacked ret;
-    msgpack::unpack(ret, ss.str().data(), ss.str().size());
-    std::shared_ptr<no_def_con> val2 = ret.get().as<std::shared_ptr<no_def_con>>();
+    msgpack::object_handle oh =
+        msgpack::unpack(ss.str().data(), ss.str().size());
+    std::shared_ptr<no_def_con> val2 = oh.get().as<std::shared_ptr<no_def_con>>();
     EXPECT_TRUE(*val1 == *val2);
 }
 

--- a/test/streaming.cpp
+++ b/test/streaming.cpp
@@ -15,7 +15,7 @@ TEST(streaming, basic)
     const char* const eof = input + buffer.size();
 
     msgpack::unpacker pac;
-    msgpack::unpacked result;
+    msgpack::object_handle oh;
 
     int count = 0;
     while(count < 3) {
@@ -29,8 +29,8 @@ TEST(streaming, basic)
 
         pac.buffer_consumed(len);
 
-        while(pac.next(result)) {
-            msgpack::object obj = result.get();
+        while(pac.next(oh)) {
+            msgpack::object obj = oh.get();
             switch(count++) {
             case 0:
                 EXPECT_EQ(1, obj.as<int>());
@@ -61,7 +61,7 @@ TEST(streaming, basic_pointer)
     const char* const eof = input + buffer.size();
 
     msgpack::unpacker pac;
-    msgpack::unpacked result;
+    msgpack::object_handle oh;
 
     int count = 0;
     while(count < 3) {
@@ -75,8 +75,8 @@ TEST(streaming, basic_pointer)
 
         pac.buffer_consumed(len);
 
-        while(pac.next(&result)) {
-            msgpack::object obj = result.get();
+        while(pac.next(&oh)) {
+            msgpack::object obj = oh.get();
             switch(count++) {
             case 0:
                 EXPECT_EQ(1, obj.as<int>());
@@ -109,7 +109,7 @@ TEST(streaming, move)
     const char* const eof = input + buffer.size();
 
     msgpack::unpacker pac;
-    msgpack::unpacked result;
+    msgpack::object_handle oh;
 
     int count = 0;
     while(count < 3) {
@@ -124,8 +124,8 @@ TEST(streaming, move)
 
         pac_in.buffer_consumed(len);
 
-        while(pac_in.next(result)) {
-            msgpack::object obj = result.get();
+        while(pac_in.next(oh)) {
+            msgpack::object obj = oh.get();
             switch(count++) {
             case 0:
                 EXPECT_EQ(1, obj.as<int>());
@@ -164,9 +164,9 @@ public:
 
             pac.buffer_consumed(len);
 
-            msgpack::unpacked result;
-            while(pac.next(result)) {
-                on_message(result.get(), msgpack::move(result.zone()));
+            msgpack::object_handle oh;
+            while(pac.next(oh)) {
+                on_message(oh.get(), msgpack::move(oh.zone()));
             }
 
             if(pac.message_size() > 10*1024*1024) {

--- a/test/unique_ptr_cpp11.cpp
+++ b/test/unique_ptr_cpp11.cpp
@@ -14,9 +14,9 @@ TEST(UNIQUE_PTR, pack_convert_nil)
     std::stringstream ss;
     std::unique_ptr<int> val1;
     msgpack::pack(ss, val1);
-    msgpack::unpacked ret;
-    msgpack::unpack(ret, ss.str().data(), ss.str().size());
-    std::unique_ptr<int> val2 = ret.get().as<std::unique_ptr<int>>();
+    msgpack::object_handle oh =
+        msgpack::unpack(ss.str().data(), ss.str().size());
+    std::unique_ptr<int> val2 = oh.get().as<std::unique_ptr<int>>();
     EXPECT_TRUE(val1 == val2);
 }
 
@@ -25,9 +25,9 @@ TEST(UNIQUE_PTR, pack_convert_int)
     std::stringstream ss;
     std::unique_ptr<int> val1(new int(1));
     msgpack::pack(ss, val1);
-    msgpack::unpacked ret;
-    msgpack::unpack(ret, ss.str().data(), ss.str().size());
-    std::unique_ptr<int> val2 = ret.get().as<std::unique_ptr<int>>();
+    msgpack::object_handle oh =
+        msgpack::unpack(ss.str().data(), ss.str().size());
+    std::unique_ptr<int> val2 = oh.get().as<std::unique_ptr<int>>();
     EXPECT_TRUE(*val1 == *val2);
 }
 
@@ -113,9 +113,9 @@ TEST(UNIQUE_PTR, pack_convert_nil_no_def_con)
     std::stringstream ss;
     std::unique_ptr<no_def_con> val1(new no_def_con(1));
     msgpack::pack(ss, val1);
-    msgpack::unpacked ret;
-    msgpack::unpack(ret, ss.str().data(), ss.str().size());
-    std::unique_ptr<no_def_con> val2 = ret.get().as<std::unique_ptr<no_def_con>>();
+    msgpack::object_handle oh =
+        msgpack::unpack(ss.str().data(), ss.str().size());
+    std::unique_ptr<no_def_con> val2 = oh.get().as<std::unique_ptr<no_def_con>>();
     EXPECT_TRUE(*val1 == *val2);
 }
 

--- a/test/user_class.cpp
+++ b/test/user_class.cpp
@@ -21,20 +21,20 @@ const double kEPS = 1e-10;
 class TestEnumMemberClass
 {
 public:
-  TestEnumMemberClass()
-    : t1(STATE_A), t2(STATE_B), t3(STATE_C) {}
+    TestEnumMemberClass()
+        : t1(STATE_A), t2(STATE_B), t3(STATE_C) {}
 
-  enum TestEnumType {
-    STATE_INVALID = 0,
-    STATE_A = 1,
-    STATE_B = 2,
-    STATE_C = 3
-  };
-  TestEnumType t1;
-  TestEnumType t2;
-  TestEnumType t3;
+    enum TestEnumType {
+        STATE_INVALID = 0,
+        STATE_A = 1,
+        STATE_B = 2,
+        STATE_C = 3
+    };
+    TestEnumType t1;
+    TestEnumType t2;
+    TestEnumType t3;
 
-  MSGPACK_DEFINE(t1, t2, t3);
+    MSGPACK_DEFINE(t1, t2, t3);
 };
 
 MSGPACK_ADD_ENUM(TestEnumMemberClass::TestEnumType);
@@ -42,148 +42,148 @@ MSGPACK_ADD_ENUM(TestEnumMemberClass::TestEnumType);
 class TestClass
 {
 public:
-  TestClass() : i(0), s("kzk") {}
-  int i;
-  string s;
-  MSGPACK_DEFINE(i, s);
+    TestClass() : i(0), s("kzk") {}
+    int i;
+    string s;
+    MSGPACK_DEFINE(i, s);
 };
 
 TEST(MSGPACK_USER_DEFINED, simple_buffer_class)
 {
-  for (unsigned int k = 0; k < kLoop; k++) {
-    TestClass val1;
-    msgpack::sbuffer sbuf;
-    msgpack::pack(sbuf, val1);
-    msgpack::unpacked ret;
-    msgpack::unpack(ret, sbuf.data(), sbuf.size());
-    TestClass val2 = ret.get().as<TestClass>();
-    EXPECT_EQ(val1.i, val2.i);
-    EXPECT_EQ(val1.s, val2.s);
-  }
+    for (unsigned int k = 0; k < kLoop; k++) {
+        TestClass val1;
+        msgpack::sbuffer sbuf;
+        msgpack::pack(sbuf, val1);
+        msgpack::object_handle oh =
+            msgpack::unpack(sbuf.data(), sbuf.size());
+        TestClass val2 = oh.get().as<TestClass>();
+        EXPECT_EQ(val1.i, val2.i);
+        EXPECT_EQ(val1.s, val2.s);
+    }
 }
 
 class TestClass2
 {
 public:
-  TestClass2() : i(0), s("kzk") {
-    for (unsigned int i = 0; i < kElements; i++)
-      v.push_back(rand());
-  }
-  int i;
-  string s;
-  vector<int> v;
-  MSGPACK_DEFINE(i, s, v);
+    TestClass2() : i(0), s("kzk") {
+        for (unsigned int i = 0; i < kElements; i++)
+            v.push_back(rand());
+    }
+    int i;
+    string s;
+    vector<int> v;
+    MSGPACK_DEFINE(i, s, v);
 };
 
 TEST(MSGPACK_USER_DEFINED, simple_buffer_class_old_to_new)
 {
-  for (unsigned int k = 0; k < kLoop; k++) {
-    TestClass val1;
-    msgpack::sbuffer sbuf;
-    msgpack::pack(sbuf, val1);
-    msgpack::unpacked ret;
-    msgpack::unpack(ret, sbuf.data(), sbuf.size());
-    TestClass2 val2 = ret.get().as<TestClass2>();
-    EXPECT_EQ(val1.i, val2.i);
-    EXPECT_EQ(val1.s, val2.s);
-    EXPECT_FALSE(val2.s.empty());
-  }
+    for (unsigned int k = 0; k < kLoop; k++) {
+        TestClass val1;
+        msgpack::sbuffer sbuf;
+        msgpack::pack(sbuf, val1);
+        msgpack::object_handle oh =
+            msgpack::unpack(sbuf.data(), sbuf.size());
+        TestClass2 val2 = oh.get().as<TestClass2>();
+        EXPECT_EQ(val1.i, val2.i);
+        EXPECT_EQ(val1.s, val2.s);
+        EXPECT_FALSE(val2.s.empty());
+    }
 }
 
 TEST(MSGPACK_USER_DEFINED, simple_buffer_class_new_to_old)
 {
-  for (unsigned int k = 0; k < kLoop; k++) {
-    TestClass2 val1;
-    msgpack::sbuffer sbuf;
-    msgpack::pack(sbuf, val1);
-    msgpack::unpacked ret;
-    msgpack::unpack(ret, sbuf.data(), sbuf.size());
-    TestClass val2 = ret.get().as<TestClass>();
-    EXPECT_EQ(val1.i, val2.i);
-    EXPECT_EQ(val1.s, val2.s);
-    EXPECT_FALSE(val2.s.empty());
-  }
+    for (unsigned int k = 0; k < kLoop; k++) {
+        TestClass2 val1;
+        msgpack::sbuffer sbuf;
+        msgpack::pack(sbuf, val1);
+        msgpack::object_handle oh =
+            msgpack::unpack(sbuf.data(), sbuf.size());
+        TestClass val2 = oh.get().as<TestClass>();
+        EXPECT_EQ(val1.i, val2.i);
+        EXPECT_EQ(val1.s, val2.s);
+        EXPECT_FALSE(val2.s.empty());
+    }
 }
 
 TEST(MSGPACK_USER_DEFINED, simple_buffer_enum_member)
 {
-  TestEnumMemberClass val1;
-  msgpack::sbuffer sbuf;
-  msgpack::pack(sbuf, val1);
-  msgpack::unpacked ret;
-  msgpack::unpack(ret, sbuf.data(), sbuf.size());
-  TestEnumMemberClass val2 = ret.get().as<TestEnumMemberClass>();
-  EXPECT_EQ(val1.t1, val2.t1);
-  EXPECT_EQ(val1.t2, val2.t2);
-  EXPECT_EQ(val1.t3, val2.t3);
+    TestEnumMemberClass val1;
+    msgpack::sbuffer sbuf;
+    msgpack::pack(sbuf, val1);
+    msgpack::object_handle oh =
+        msgpack::unpack(sbuf.data(), sbuf.size());
+    TestEnumMemberClass val2 = oh.get().as<TestEnumMemberClass>();
+    EXPECT_EQ(val1.t1, val2.t1);
+    EXPECT_EQ(val1.t2, val2.t2);
+    EXPECT_EQ(val1.t3, val2.t3);
 }
 
 class TestUnionMemberClass
 {
 public:
-  TestUnionMemberClass() {}
-  TestUnionMemberClass(double f) {
-    is_double = true;
-    value.f = f;
-  }
-  TestUnionMemberClass(int i) {
-    is_double = false;
-    value.i = i;
-  }
+    TestUnionMemberClass() {}
+    TestUnionMemberClass(double f) {
+        is_double = true;
+        value.f = f;
+    }
+    TestUnionMemberClass(int i) {
+        is_double = false;
+        value.i = i;
+    }
 
-  union {
-    double f;
-    int i;
-  } value;
-  bool is_double;
+    union {
+        double f;
+        int i;
+    } value;
+    bool is_double;
 
-  template <typename Packer>
-  void msgpack_pack(Packer& pk) const
-  {
-    if (is_double)
-      pk.pack(msgpack::type::tuple<bool, double>(true, value.f));
-    else
-      pk.pack(msgpack::type::tuple<bool, int>(false, value.i));
-  }
+    template <typename Packer>
+    void msgpack_pack(Packer& pk) const
+    {
+        if (is_double)
+            pk.pack(msgpack::type::tuple<bool, double>(true, value.f));
+        else
+            pk.pack(msgpack::type::tuple<bool, int>(false, value.i));
+    }
 
-  void msgpack_unpack(msgpack::object o)
-  {
-    msgpack::type::tuple<bool, msgpack::object> tuple;
-    o.convert(tuple);
+    void msgpack_unpack(msgpack::object o)
+    {
+        msgpack::type::tuple<bool, msgpack::object> tuple;
+        o.convert(tuple);
 
-    is_double = tuple.get<0>();
-    if (is_double)
-      tuple.get<1>().convert(value.f);
-    else
-      tuple.get<1>().convert(value.i);
-  }
+        is_double = tuple.get<0>();
+        if (is_double)
+            tuple.get<1>().convert(value.f);
+        else
+            tuple.get<1>().convert(value.i);
+    }
 };
 
 TEST(MSGPACK_USER_DEFINED, simple_buffer_union_member)
 {
-  {
-    // double
-    TestUnionMemberClass val1(1.0);
-    msgpack::sbuffer sbuf;
-    msgpack::pack(sbuf, val1);
-    msgpack::unpacked ret;
-    msgpack::unpack(ret, sbuf.data(), sbuf.size());
-    TestUnionMemberClass val2 = ret.get().as<TestUnionMemberClass>();
-    EXPECT_EQ(val1.is_double, val2.is_double);
-    EXPECT_TRUE(fabs(val1.value.f - val2.value.f) < kEPS);
-  }
-  {
-    // int
-    TestUnionMemberClass val1(1);
-    msgpack::sbuffer sbuf;
-    msgpack::pack(sbuf, val1);
-    msgpack::unpacked ret;
-    msgpack::unpack(ret, sbuf.data(), sbuf.size());
-    TestUnionMemberClass val2 = ret.get().as<TestUnionMemberClass>();
-    EXPECT_EQ(val1.is_double, val2.is_double);
-    EXPECT_EQ(val1.value.i, 1);
-    EXPECT_EQ(val1.value.i, val2.value.i);
-  }
+    {
+        // double
+        TestUnionMemberClass val1(1.0);
+        msgpack::sbuffer sbuf;
+        msgpack::pack(sbuf, val1);
+        msgpack::object_handle oh =
+            msgpack::unpack(sbuf.data(), sbuf.size());
+        TestUnionMemberClass val2 = oh.get().as<TestUnionMemberClass>();
+        EXPECT_EQ(val1.is_double, val2.is_double);
+        EXPECT_TRUE(fabs(val1.value.f - val2.value.f) < kEPS);
+    }
+    {
+        // int
+        TestUnionMemberClass val1(1);
+        msgpack::sbuffer sbuf;
+        msgpack::pack(sbuf, val1);
+        msgpack::object_handle oh =
+            msgpack::unpack(sbuf.data(), sbuf.size());
+        TestUnionMemberClass val2 = oh.get().as<TestUnionMemberClass>();
+        EXPECT_EQ(val1.is_double, val2.is_double);
+        EXPECT_EQ(val1.value.i, 1);
+        EXPECT_EQ(val1.value.i, val2.value.i);
+    }
 }
 
 // inheritance
@@ -220,9 +220,9 @@ TEST(MSGPACK_INHERIT, define_non_virtual)
     b.d_mid2::t = 5;
     msgpack::sbuffer sbuf;
     msgpack::pack(sbuf, b);
-    msgpack::unpacked ret;
-    msgpack::unpack(ret, sbuf.data(), sbuf.size());
-    d_bottom br = ret.get().as<d_bottom>();
+    msgpack::object_handle oh =
+        msgpack::unpack(sbuf.data(), sbuf.size());
+    d_bottom br = oh.get().as<d_bottom>();
     EXPECT_EQ(b.b, br.b);
     EXPECT_EQ(b.m1, br.m1);
     EXPECT_EQ(b.m2, br.m2);
@@ -259,9 +259,9 @@ TEST(MSGPACK_INHERIT, define_virtual)
     b.t = 4;
     msgpack::sbuffer sbuf;
     msgpack::pack(sbuf, b);
-    msgpack::unpacked ret;
-    msgpack::unpack(ret, sbuf.data(), sbuf.size());
-    v_d_bottom br = ret.get().as<v_d_bottom>();
+    msgpack::object_handle oh =
+        msgpack::unpack(sbuf.data(), sbuf.size());
+    v_d_bottom br = oh.get().as<v_d_bottom>();
     EXPECT_EQ(b.b, br.b);
     EXPECT_EQ(b.m1, br.m1);
     EXPECT_EQ(b.m2, br.m2);
@@ -300,9 +300,9 @@ TEST(MSGPACK_INHERIT, define_array_non_virtual)
     b.da_mid2::t = 5;
     msgpack::sbuffer sbuf;
     msgpack::pack(sbuf, b);
-    msgpack::unpacked ret;
-    msgpack::unpack(ret, sbuf.data(), sbuf.size());
-    da_bottom br = ret.get().as<da_bottom>();
+    msgpack::object_handle oh =
+        msgpack::unpack(sbuf.data(), sbuf.size());
+    da_bottom br = oh.get().as<da_bottom>();
     EXPECT_EQ(b.b, br.b);
     EXPECT_EQ(b.m1, br.m1);
     EXPECT_EQ(b.m2, br.m2);
@@ -339,9 +339,9 @@ TEST(MSGPACK_INHERIT, define_array_virtual)
     b.t = 4;
     msgpack::sbuffer sbuf;
     msgpack::pack(sbuf, b);
-    msgpack::unpacked ret;
-    msgpack::unpack(ret, sbuf.data(), sbuf.size());
-    v_da_bottom br = ret.get().as<v_da_bottom>();
+    msgpack::object_handle oh =
+        msgpack::unpack(sbuf.data(), sbuf.size());
+    v_da_bottom br = oh.get().as<v_da_bottom>();
     EXPECT_EQ(b.b, br.b);
     EXPECT_EQ(b.m1, br.m1);
     EXPECT_EQ(b.m2, br.m2);
@@ -380,9 +380,9 @@ TEST(MSGPACK_INHERIT, define_map_non_virtual)
     b.dm_mid2::t = 5;
     msgpack::sbuffer sbuf;
     msgpack::pack(sbuf, b);
-    msgpack::unpacked ret;
-    msgpack::unpack(ret, sbuf.data(), sbuf.size());
-    dm_bottom br = ret.get().as<dm_bottom>();
+    msgpack::object_handle oh =
+        msgpack::unpack(sbuf.data(), sbuf.size());
+    dm_bottom br = oh.get().as<dm_bottom>();
     EXPECT_EQ(b.b, br.b);
     EXPECT_EQ(b.m1, br.m1);
     EXPECT_EQ(b.m2, br.m2);
@@ -419,9 +419,9 @@ TEST(MSGPACK_INHERIT, define_map_virtual)
     b.t = 4;
     msgpack::sbuffer sbuf;
     msgpack::pack(sbuf, b);
-    msgpack::unpacked ret;
-    msgpack::unpack(ret, sbuf.data(), sbuf.size());
-    v_dm_bottom br = ret.get().as<v_dm_bottom>();
+    msgpack::object_handle oh =
+        msgpack::unpack(sbuf.data(), sbuf.size());
+    v_dm_bottom br = oh.get().as<v_dm_bottom>();
     EXPECT_EQ(b.b, br.b);
     EXPECT_EQ(b.m1, br.m1);
     EXPECT_EQ(b.m2, br.m2);
@@ -451,9 +451,9 @@ TEST(MSGPACK_MIGRATION, order_number_changed)
     msgpack::sbuffer sbuf;
     msgpack::pack(sbuf, v1);
 
-    msgpack::unpacked ret;
-    msgpack::unpack(ret, sbuf.data(), sbuf.size());
-    s_v2 v2 = ret.get().as<s_v2>();
+    msgpack::object_handle oh =
+        msgpack::unpack(sbuf.data(), sbuf.size());
+    s_v2 v2 = oh.get().as<s_v2>();
 
     EXPECT_EQ(v2.c, 'A');
     EXPECT_EQ(v2.s, "foo"); // from v1


### PR DESCRIPTION
msgpack::unpacked is a typedef of the msgpack::object_handle.
I recommend using msgpack::object_handle. It can be used not only
holding unpacked msgpack objects but also msgpack::objects that are
created by any types.

Replaced unpack() APIs in test codes and examples. They used to use old
APIs.