### PR TITLE
Fixed #457.

### DIFF
--- a/include/msgpack/v1/object.hpp
+++ b/include/msgpack/v1/object.hpp
@@ -734,7 +734,7 @@ inline std::ostream& operator<< (std::ostream& s, const msgpack::object& o)
 {
     switch(o.type) {
     case msgpack::type::NIL:
-        s << "nil";
+        s << "null";
         break;
 
     case msgpack::type::BOOLEAN:


### PR DESCRIPTION
JSON doesn't have `nil` but has `null`.
msgpack::object JSON output uses `null` when the object is nil_t.