### PR TITLE
Backported #441 to cpp-1.4.

### DIFF
--- a/erb/cpp03_zone.hpp.erb
+++ b/erb/cpp03_zone.hpp.erb
@@ -125,6 +125,7 @@ class zone {
                     ::free(c);
                     c = n;
                 } else {
+                    m_head = c;
                     break;
                 }
             }

--- a/include/msgpack/detail/cpp03_zone.hpp
+++ b/include/msgpack/detail/cpp03_zone.hpp
@@ -125,6 +125,7 @@ class zone {
                     ::free(c);
                     c = n;
                 } else {
+                    m_head = c;
                     break;
                 }
             }


### PR DESCRIPTION
Fixed a pointer operation problem at msgpack::zone::chunk_list::clear().
It was only happened on C++03.