### PR TITLE
Support MSVC cli.

### DIFF
--- a/erb/v1/cpp03_define_array.hpp.erb
+++ b/erb/v1/cpp03_define_array.hpp.erb
@@ -38,7 +38,7 @@ struct define_array<> {
     void msgpack_object(msgpack::object* o, msgpack::zone&) const
     {
         o->type = msgpack::type::ARRAY;
-        o->via.array.ptr = nullptr;
+        o->via.array.ptr = MSGPACK_NULLPTR;
         o->via.array.size = 0;
     }
 };

--- a/erb/v1/cpp03_define_map.hpp.erb
+++ b/erb/v1/cpp03_define_map.hpp.erb
@@ -38,7 +38,7 @@ struct define_map<> {
     void msgpack_object(msgpack::object* o, msgpack::zone&) const
     {
         o->type = msgpack::type::MAP;
-        o->via.map.ptr = nullptr;
+        o->via.map.ptr = MSGPACK_NULLPTR;
         o->via.map.size = 0;
     }
 };

--- a/erb/v1/cpp03_msgpack_tuple.hpp.erb
+++ b/erb/v1/cpp03_msgpack_tuple.hpp.erb
@@ -192,7 +192,7 @@ struct object_with_zone<type::tuple<> > {
         msgpack::object::with_zone& o,
         const type::tuple<>&) const {
         o.type = msgpack::type::ARRAY;
-        o.via.array.ptr = nullptr;
+        o.via.array.ptr = MSGPACK_NULLPTR;
         o.via.array.size = 0;
     }
 };

--- a/erb/v1/cpp03_zone.hpp.erb
+++ b/erb/v1/cpp03_zone.hpp.erb
@@ -27,7 +27,7 @@ class zone {
         void* m_data;
     };
     struct finalizer_array {
-        finalizer_array():m_tail(nullptr), m_end(nullptr), m_array(nullptr) {}
+        finalizer_array():m_tail(MSGPACK_NULLPTR), m_end(MSGPACK_NULLPTR), m_array(MSGPACK_NULLPTR) {}
         void call() {
             finalizer* fin = m_tail;
             for(; fin != m_array; --fin) (*(fin-1))();
@@ -93,7 +93,7 @@ class zone {
             m_head = c;
             m_free = chunk_size;
             m_ptr  = reinterpret_cast<char*>(c) + sizeof(chunk);
-            c->m_next = nullptr;
+            c->m_next = MSGPACK_NULLPTR;
         }
         ~chunk_list()
         {
@@ -117,7 +117,7 @@ class zone {
                     break;
                 }
             }
-            m_head->m_next = nullptr;
+            m_head->m_next = MSGPACK_NULLPTR;
             m_free = chunk_size;
             m_ptr  = reinterpret_cast<char*>(m_head) + sizeof(chunk);
         }

--- a/include/msgpack/adaptor/tr1/unordered_map.hpp
+++ b/include/msgpack/adaptor/tr1/unordered_map.hpp
@@ -80,7 +80,7 @@ struct object_with_zone<MSGPACK_STD_TR1::unordered_map<K, V, Hash, Pred, Alloc> 
     void operator()(msgpack::object::with_zone& o, const MSGPACK_STD_TR1::unordered_map<K, V, Hash, Pred, Alloc>& v) const {
         o.type = msgpack::type::MAP;
         if(v.empty()) {
-            o.via.map.ptr  = nullptr;
+            o.via.map.ptr  = MSGPACK_NULLPTR;
             o.via.map.size = 0;
         } else {
             uint32_t size = checked_get_container_size(v.size());
@@ -137,7 +137,7 @@ struct object_with_zone<MSGPACK_STD_TR1::unordered_multimap<K, V, Hash, Pred, Al
     void operator()(msgpack::object::with_zone& o, const MSGPACK_STD_TR1::unordered_multimap<K, V, Hash, Pred, Alloc>& v) const {
         o.type = msgpack::type::MAP;
         if(v.empty()) {
-            o.via.map.ptr  = nullptr;
+            o.via.map.ptr  = MSGPACK_NULLPTR;
             o.via.map.size = 0;
         } else {
             uint32_t size = checked_get_container_size(v.size());

--- a/include/msgpack/adaptor/tr1/unordered_set.hpp
+++ b/include/msgpack/adaptor/tr1/unordered_set.hpp
@@ -78,7 +78,7 @@ struct object_with_zone<MSGPACK_STD_TR1::unordered_set<T, Hash, Compare, Alloc> 
     void operator()(msgpack::object::with_zone& o, const MSGPACK_STD_TR1::unordered_set<T, Hash, Compare, Alloc>& v) const {
         o.type = msgpack::type::ARRAY;
         if(v.empty()) {
-            o.via.array.ptr = nullptr;
+            o.via.array.ptr = MSGPACK_NULLPTR;
             o.via.array.size = 0;
         } else {
             uint32_t size = checked_get_container_size(v.size());
@@ -132,7 +132,7 @@ struct object_with_zone<MSGPACK_STD_TR1::unordered_multiset<T, Hash, Compare, Al
     void operator()(msgpack::object::with_zone& o, const MSGPACK_STD_TR1::unordered_multiset<T, Hash, Compare, Alloc>& v) const {
         o.type = msgpack::type::ARRAY;
         if(v.empty()) {
-            o.via.array.ptr = nullptr;
+            o.via.array.ptr = MSGPACK_NULLPTR;
             o.via.array.size = 0;
         } else {
             uint32_t size = checked_get_container_size(v.size());

--- a/include/msgpack/v1/adaptor/array_ref.hpp
+++ b/include/msgpack/v1/adaptor/array_ref.hpp
@@ -26,7 +26,7 @@ namespace type {
 
 template <typename T>
 struct array_ref {
-    array_ref() : data(nullptr) {}
+    array_ref() : data(MSGPACK_NULLPTR) {}
     array_ref(T& t) : data(&t) {}
 
     T* data;
@@ -67,7 +67,7 @@ struct array_ref {
 
 template <typename T, std::size_t N>
 struct array_ref<T[N]> {
-    array_ref() : data(nullptr) {}
+    array_ref() : data(MSGPACK_NULLPTR) {}
     array_ref(T(&t)[N]) : data(t) {}
 
     T* data;
@@ -248,7 +248,7 @@ struct object_with_zone<msgpack::type::array_ref<T> > {
         if (!v.data) { throw msgpack::type_error(); }
         o.type = msgpack::type::ARRAY;
         if (v.data->empty()) {
-            o.via.array.ptr = nullptr;
+            o.via.array.ptr = MSGPACK_NULLPTR;
             o.via.array.size = 0;
         }
         else {

--- a/include/msgpack/v1/adaptor/boost/msgpack_variant.hpp
+++ b/include/msgpack/v1/adaptor/boost/msgpack_variant.hpp
@@ -115,51 +115,51 @@ struct basic_variant :
     basic_variant(unsigned long long v):base(uint64_t(v)) {}
 
     bool is_nil() const {
-        return boost::get<msgpack::type::nil_t>(this) != nullptr;
+        return boost::get<msgpack::type::nil_t>(this) != MSGPACK_NULLPTR;
     }
     bool is_bool() const {
-        return boost::get<bool>(this) != nullptr;
+        return boost::get<bool>(this) != MSGPACK_NULLPTR;
     }
     bool is_int64_t() const {
-        return boost::get<int64_t>(this) != nullptr;
+        return boost::get<int64_t>(this) != MSGPACK_NULLPTR;
     }
     bool is_uint64_t() const {
-        return boost::get<uint64_t>(this) != nullptr;
+        return boost::get<uint64_t>(this) != MSGPACK_NULLPTR;
     }
     bool is_double() const {
-        return boost::get<double>(this) != nullptr;
+        return boost::get<double>(this) != MSGPACK_NULLPTR;
     }
     bool is_string() const {
-        return boost::get<std::string>(this) != nullptr;
+        return boost::get<std::string>(this) != MSGPACK_NULLPTR;
     }
 #if (BOOST_VERSION / 100000) >= 1 && ((BOOST_VERSION / 100) % 1000) >= 53
     bool is_boost_string_ref() const {
-        return boost::get<boost::string_ref>(this) != nullptr;
+        return boost::get<boost::string_ref>(this) != MSGPACK_NULLPTR;
     }
 #endif // (BOOST_VERSION / 100000) >= 1 && ((BOOST_VERSION / 100) % 1000) >= 53
     bool is_vector_char() const {
-        return boost::get<std::vector<char> >(this) != nullptr;
+        return boost::get<std::vector<char> >(this) != MSGPACK_NULLPTR;
     }
     bool is_vector_char() {
-        return boost::get<std::vector<char> >(this) != nullptr;
+        return boost::get<std::vector<char> >(this) != MSGPACK_NULLPTR;
     }
     bool is_raw_ref() const {
-        return boost::get<raw_ref>(this) != nullptr;
+        return boost::get<raw_ref>(this) != MSGPACK_NULLPTR;
     }
     bool is_ext() const {
-        return boost::get<ext>(this) != nullptr;
+        return boost::get<ext>(this) != MSGPACK_NULLPTR;
     }
     bool is_ext_ref() const {
-        return boost::get<ext_ref>(this) != nullptr;
+        return boost::get<ext_ref>(this) != MSGPACK_NULLPTR;
     }
     bool is_vector() const {
-        return boost::get<std::vector<basic_variant<STR, BIN, EXT> > >(this) != nullptr;
+        return boost::get<std::vector<basic_variant<STR, BIN, EXT> > >(this) != MSGPACK_NULLPTR;
     }
     bool is_map() const {
-        return boost::get<std::map<basic_variant<STR, BIN, EXT>, basic_variant<STR, BIN, EXT> > >(this) != nullptr;
+        return boost::get<std::map<basic_variant<STR, BIN, EXT>, basic_variant<STR, BIN, EXT> > >(this) != MSGPACK_NULLPTR;
     }
     bool is_multimap() const {
-        return boost::get<std::multimap<basic_variant<STR, BIN, EXT>, basic_variant<STR, BIN, EXT> > >(this) != nullptr;
+        return boost::get<std::multimap<basic_variant<STR, BIN, EXT>, basic_variant<STR, BIN, EXT> > >(this) != MSGPACK_NULLPTR;
     }
 
     bool as_bool() const {

--- a/include/msgpack/v1/adaptor/cpp11/array.hpp
+++ b/include/msgpack/v1/adaptor/cpp11/array.hpp
@@ -115,7 +115,7 @@ struct object_with_zone<std::array<T, N>> {
     void operator()(msgpack::object::with_zone& o, const std::array<T, N>& v) const {
         o.type = msgpack::type::ARRAY;
         if(v.empty()) {
-            o.via.array.ptr = nullptr;
+            o.via.array.ptr = MSGPACK_NULLPTR;
             o.via.array.size = 0;
         } else {
             uint32_t size = checked_get_container_size(v.size());

--- a/include/msgpack/v1/adaptor/cpp11/forward_list.hpp
+++ b/include/msgpack/v1/adaptor/cpp11/forward_list.hpp
@@ -70,7 +70,7 @@ struct object_with_zone<std::forward_list<T, Alloc>> {
     void operator()(msgpack::object::with_zone& o, const std::forward_list<T, Alloc>& v) const {
         o.type = msgpack::type::ARRAY;
         if(v.empty()) {
-            o.via.array.ptr = nullptr;
+            o.via.array.ptr = MSGPACK_NULLPTR;
             o.via.array.size = 0;
         } else {
             uint32_t size = checked_get_container_size(std::distance(v.begin(), v.end()));

--- a/include/msgpack/v1/adaptor/cpp11/shared_ptr.hpp
+++ b/include/msgpack/v1/adaptor/cpp11/shared_ptr.hpp
@@ -28,7 +28,7 @@ namespace adaptor {
 template <typename T>
 struct as<std::shared_ptr<T>, typename std::enable_if<msgpack::has_as<T>::value>::type> {
     std::shared_ptr<T> operator()(msgpack::object const& o) const {
-        if(o.is_nil()) return nullptr;
+        if(o.is_nil()) return MSGPACK_NULLPTR;
         return std::make_shared<T>(o.as<T>());
     }
 };

--- a/include/msgpack/v1/adaptor/cpp11/unique_ptr.hpp
+++ b/include/msgpack/v1/adaptor/cpp11/unique_ptr.hpp
@@ -28,7 +28,7 @@ namespace adaptor {
 template <typename T>
 struct as<std::unique_ptr<T>, typename std::enable_if<msgpack::has_as<T>::value>::type> {
     std::unique_ptr<T> operator()(msgpack::object const& o) const {
-        if(o.is_nil()) return nullptr;
+        if(o.is_nil()) return MSGPACK_NULLPTR;
         return std::unique_ptr<T>(new T(o.as<T>()));
     }
 };

--- a/include/msgpack/v1/adaptor/cpp11/unordered_map.hpp
+++ b/include/msgpack/v1/adaptor/cpp11/unordered_map.hpp
@@ -77,7 +77,7 @@ struct object_with_zone<std::unordered_map<K, V, Hash, Compare, Alloc>> {
     void operator()(msgpack::object::with_zone& o, const std::unordered_map<K, V, Hash, Compare, Alloc>& v) const {
         o.type = msgpack::type::MAP;
         if(v.empty()) {
-            o.via.map.ptr  = nullptr;
+            o.via.map.ptr  = MSGPACK_NULLPTR;
             o.via.map.size = 0;
         } else {
             uint32_t size = checked_get_container_size(v.size());
@@ -151,7 +151,7 @@ struct object_with_zone<std::unordered_multimap<K, V, Hash, Compare, Alloc>> {
     void operator()(msgpack::object::with_zone& o, const std::unordered_multimap<K, V, Hash, Compare, Alloc>& v) const {
         o.type = msgpack::type::MAP;
         if(v.empty()) {
-            o.via.map.ptr  = nullptr;
+            o.via.map.ptr  = MSGPACK_NULLPTR;
             o.via.map.size = 0;
         } else {
             uint32_t size = checked_get_container_size(v.size());

--- a/include/msgpack/v1/adaptor/cpp11/unordered_set.hpp
+++ b/include/msgpack/v1/adaptor/cpp11/unordered_set.hpp
@@ -74,7 +74,7 @@ struct object_with_zone<std::unordered_set<Key, Hash, Compare, Alloc>> {
     void operator()(msgpack::object::with_zone& o, const std::unordered_set<Key, Hash, Compare, Alloc>& v) const {
         o.type = msgpack::type::ARRAY;
         if(v.empty()) {
-            o.via.array.ptr = nullptr;
+            o.via.array.ptr = MSGPACK_NULLPTR;
             o.via.array.size = 0;
         } else {
             uint32_t size = checked_get_container_size(v.size());
@@ -143,7 +143,7 @@ struct object_with_zone<std::unordered_multiset<Key, Hash, Compare, Alloc>> {
     void operator()(msgpack::object::with_zone& o, const std::unordered_multiset<Key, Hash, Compare, Alloc>& v) const {
         o.type = msgpack::type::ARRAY;
         if(v.empty()) {
-            o.via.array.ptr = nullptr;
+            o.via.array.ptr = MSGPACK_NULLPTR;
             o.via.array.size = 0;
         } else {
             uint32_t size = checked_get_container_size(v.size());

--- a/include/msgpack/v1/adaptor/deque.hpp
+++ b/include/msgpack/v1/adaptor/deque.hpp
@@ -79,7 +79,7 @@ struct object_with_zone<std::deque<T, Alloc> > {
     void operator()(msgpack::object::with_zone& o, const std::deque<T, Alloc>& v) const {
         o.type = msgpack::type::ARRAY;
         if(v.empty()) {
-            o.via.array.ptr = nullptr;
+            o.via.array.ptr = MSGPACK_NULLPTR;
             o.via.array.size = 0;
         } else {
             uint32_t size = checked_get_container_size(v.size());

--- a/include/msgpack/v1/adaptor/detail/cpp03_define_array.hpp
+++ b/include/msgpack/v1/adaptor/detail/cpp03_define_array.hpp
@@ -38,7 +38,7 @@ struct define_array<> {
     void msgpack_object(msgpack::object* o, msgpack::zone&) const
     {
         o->type = msgpack::type::ARRAY;
-        o->via.array.ptr = nullptr;
+        o->via.array.ptr = MSGPACK_NULLPTR;
         o->via.array.size = 0;
     }
 };

--- a/include/msgpack/v1/adaptor/detail/cpp03_define_map.hpp
+++ b/include/msgpack/v1/adaptor/detail/cpp03_define_map.hpp
@@ -38,7 +38,7 @@ struct define_map<> {
     void msgpack_object(msgpack::object* o, msgpack::zone&) const
     {
         o->type = msgpack::type::MAP;
-        o->via.map.ptr = nullptr;
+        o->via.map.ptr = MSGPACK_NULLPTR;
         o->via.map.size = 0;
     }
 };

--- a/include/msgpack/v1/adaptor/detail/cpp03_msgpack_tuple.hpp
+++ b/include/msgpack/v1/adaptor/detail/cpp03_msgpack_tuple.hpp
@@ -12964,7 +12964,7 @@ struct object_with_zone<type::tuple<> > {
         msgpack::object::with_zone& o,
         const type::tuple<>&) const {
         o.type = msgpack::type::ARRAY;
-        o.via.array.ptr = nullptr;
+        o.via.array.ptr = MSGPACK_NULLPTR;
         o.via.array.size = 0;
     }
 };

--- a/include/msgpack/v1/adaptor/list.hpp
+++ b/include/msgpack/v1/adaptor/list.hpp
@@ -76,7 +76,7 @@ struct object_with_zone<std::list<T, Alloc> > {
     void operator()(msgpack::object::with_zone& o, const std::list<T, Alloc>& v) const {
         o.type = msgpack::type::ARRAY;
         if (v.empty()) {
-            o.via.array.ptr = nullptr;
+            o.via.array.ptr = MSGPACK_NULLPTR;
             o.via.array.size = 0;
         }
         else {

--- a/include/msgpack/v1/adaptor/map.hpp
+++ b/include/msgpack/v1/adaptor/map.hpp
@@ -104,7 +104,7 @@ struct object_with_zone<type::assoc_vector<K, V, Compare, Alloc> > {
     void operator()(msgpack::object::with_zone& o, const type::assoc_vector<K, V, Compare, Alloc>& v) const {
         o.type = msgpack::type::MAP;
         if (v.empty()) {
-            o.via.map.ptr  = nullptr;
+            o.via.map.ptr  = MSGPACK_NULLPTR;
             o.via.map.size = 0;
         }
         else {
@@ -189,7 +189,7 @@ struct object_with_zone<std::map<K, V, Compare, Alloc> > {
     void operator()(msgpack::object::with_zone& o, const std::map<K, V, Compare, Alloc>& v) const {
         o.type = msgpack::type::MAP;
         if (v.empty()) {
-            o.via.map.ptr  = nullptr;
+            o.via.map.ptr  = MSGPACK_NULLPTR;
             o.via.map.size = 0;
         }
         else {
@@ -283,7 +283,7 @@ struct object_with_zone<std::multimap<K, V, Compare, Alloc> > {
     void operator()(msgpack::object::with_zone& o, const std::multimap<K, V, Compare, Alloc>& v) const {
         o.type = msgpack::type::MAP;
         if (v.empty()) {
-            o.via.map.ptr  = nullptr;
+            o.via.map.ptr  = MSGPACK_NULLPTR;
             o.via.map.size = 0;
         }
         else {

--- a/include/msgpack/v1/adaptor/raw.hpp
+++ b/include/msgpack/v1/adaptor/raw.hpp
@@ -24,7 +24,7 @@ MSGPACK_API_VERSION_NAMESPACE(v1) {
 namespace type {
 
 struct raw_ref {
-    raw_ref() : size(0), ptr(nullptr) {}
+    raw_ref() : size(0), ptr(MSGPACK_NULLPTR) {}
     raw_ref(const char* p, uint32_t s) : size(s), ptr(p) {}
 
     uint32_t size;

--- a/include/msgpack/v1/adaptor/set.hpp
+++ b/include/msgpack/v1/adaptor/set.hpp
@@ -82,7 +82,7 @@ struct object_with_zone<std::set<T, Compare, Alloc> > {
     void operator()(msgpack::object::with_zone& o, const std::set<T, Compare, Alloc>& v) const {
         o.type = msgpack::type::ARRAY;
         if (v.empty()) {
-            o.via.array.ptr = nullptr;
+            o.via.array.ptr = MSGPACK_NULLPTR;
             o.via.array.size = 0;
         }
         else {
@@ -159,7 +159,7 @@ struct object_with_zone<std::multiset<T, Compare, Alloc> > {
     void operator()(msgpack::object::with_zone& o, const std::multiset<T, Compare, Alloc>& v) const {
         o.type = msgpack::type::ARRAY;
         if (v.empty()) {
-            o.via.array.ptr = nullptr;
+            o.via.array.ptr = MSGPACK_NULLPTR;
             o.via.array.size = 0;
         } else {
             uint32_t size = checked_get_container_size(v.size());

--- a/include/msgpack/v1/adaptor/tr1/unordered_map.hpp
+++ b/include/msgpack/v1/adaptor/tr1/unordered_map.hpp
@@ -80,7 +80,7 @@ struct object_with_zone<MSGPACK_STD_TR1::unordered_map<K, V, Hash, Pred, Alloc> 
     void operator()(msgpack::object::with_zone& o, const MSGPACK_STD_TR1::unordered_map<K, V, Hash, Pred, Alloc>& v) const {
         o.type = msgpack::type::MAP;
         if(v.empty()) {
-            o.via.map.ptr  = nullptr;
+            o.via.map.ptr  = MSGPACK_NULLPTR;
             o.via.map.size = 0;
         } else {
             uint32_t size = checked_get_container_size(v.size());
@@ -137,7 +137,7 @@ struct object_with_zone<MSGPACK_STD_TR1::unordered_multimap<K, V, Hash, Pred, Al
     void operator()(msgpack::object::with_zone& o, const MSGPACK_STD_TR1::unordered_multimap<K, V, Hash, Pred, Alloc>& v) const {
         o.type = msgpack::type::MAP;
         if(v.empty()) {
-            o.via.map.ptr  = nullptr;
+            o.via.map.ptr  = MSGPACK_NULLPTR;
             o.via.map.size = 0;
         } else {
             uint32_t size = checked_get_container_size(v.size());

--- a/include/msgpack/v1/adaptor/tr1/unordered_set.hpp
+++ b/include/msgpack/v1/adaptor/tr1/unordered_set.hpp
@@ -78,7 +78,7 @@ struct object_with_zone<MSGPACK_STD_TR1::unordered_set<T, Hash, Compare, Alloc> 
     void operator()(msgpack::object::with_zone& o, const MSGPACK_STD_TR1::unordered_set<T, Hash, Compare, Alloc>& v) const {
         o.type = msgpack::type::ARRAY;
         if(v.empty()) {
-            o.via.array.ptr = nullptr;
+            o.via.array.ptr = MSGPACK_NULLPTR;
             o.via.array.size = 0;
         } else {
             uint32_t size = checked_get_container_size(v.size());
@@ -132,7 +132,7 @@ struct object_with_zone<MSGPACK_STD_TR1::unordered_multiset<T, Hash, Compare, Al
     void operator()(msgpack::object::with_zone& o, const MSGPACK_STD_TR1::unordered_multiset<T, Hash, Compare, Alloc>& v) const {
         o.type = msgpack::type::ARRAY;
         if(v.empty()) {
-            o.via.array.ptr = nullptr;
+            o.via.array.ptr = MSGPACK_NULLPTR;
             o.via.array.size = 0;
         } else {
             uint32_t size = checked_get_container_size(v.size());

--- a/include/msgpack/v1/adaptor/v4raw.hpp
+++ b/include/msgpack/v1/adaptor/v4raw.hpp
@@ -23,7 +23,7 @@ MSGPACK_API_VERSION_NAMESPACE(v1) {
 namespace type {
 
 struct v4raw_ref {
-    v4raw_ref() : size(0), ptr(nullptr) {}
+    v4raw_ref() : size(0), ptr(MSGPACK_NULLPTR) {}
     v4raw_ref(const char* p, uint32_t s) : size(s), ptr(p) {}
 
     uint32_t size;

--- a/include/msgpack/v1/adaptor/vector.hpp
+++ b/include/msgpack/v1/adaptor/vector.hpp
@@ -84,7 +84,7 @@ struct object_with_zone<std::vector<T, Alloc> > {
     void operator()(msgpack::object::with_zone& o, const std::vector<T, Alloc>& v) const {
         o.type = msgpack::type::ARRAY;
         if (v.empty()) {
-            o.via.array.ptr = nullptr;
+            o.via.array.ptr = MSGPACK_NULLPTR;
             o.via.array.size = 0;
         }
         else {

--- a/include/msgpack/v1/adaptor/vector_bool.hpp
+++ b/include/msgpack/v1/adaptor/vector_bool.hpp
@@ -61,7 +61,7 @@ struct object_with_zone<std::vector<bool, Alloc> > {
     void operator()(msgpack::object::with_zone& o, const std::vector<bool, Alloc>& v) const {
         o.type = msgpack::type::ARRAY;
         if(v.empty()) {
-            o.via.array.ptr = nullptr;
+            o.via.array.ptr = MSGPACK_NULLPTR;
             o.via.array.size = 0;
         } else {
             uint32_t size = checked_get_container_size(v.size());

--- a/include/msgpack/v1/cpp_config_decl.hpp
+++ b/include/msgpack/v1/cpp_config_decl.hpp
@@ -25,11 +25,15 @@
 
 #if defined(MSGPACK_USE_CPP03)
 
-#if !defined(nullptr)
-#  if _MSC_VER < 1600
-#    define nullptr (0)
-#  endif
-#endif
+#if defined(nullptr)
+#  if defined (__cplusplus_cli)
+#    define MSGPACK_NULLPTR __nullptr
+#  else  // defined (__cplusplus_cli)
+#    define MSGPACK_NULLPTR nullptr
+#  endif // defined (__cplusplus_cli)
+#else  // defined(nullptr)
+#  define MSGPACK_NULLPTR (0)
+#endif // defined(nullptr)
 
 #include <memory>
 
@@ -84,6 +88,12 @@ struct is_pointer;
 
 
 #else  // MSGPACK_USE_CPP03
+
+#if defined (__cplusplus_cli)
+#  define MSGPACK_NULLPTR __nullptr
+#else  // defined (__cplusplus_cli)
+#  define MSGPACK_NULLPTR nullptr
+#endif // defined (__cplusplus_cli)
 
 #include <memory>
 #include <tuple>

--- a/include/msgpack/v1/detail/cpp03_zone.hpp
+++ b/include/msgpack/v1/detail/cpp03_zone.hpp
@@ -27,7 +27,7 @@ class zone {
         void* m_data;
     };
     struct finalizer_array {
-        finalizer_array():m_tail(nullptr), m_end(nullptr), m_array(nullptr) {}
+        finalizer_array():m_tail(MSGPACK_NULLPTR), m_end(MSGPACK_NULLPTR), m_array(MSGPACK_NULLPTR) {}
         void call() {
             finalizer* fin = m_tail;
             for(; fin != m_array; --fin) (*(fin-1))();
@@ -93,7 +93,7 @@ class zone {
             m_head = c;
             m_free = chunk_size;
             m_ptr  = reinterpret_cast<char*>(c) + sizeof(chunk);
-            c->m_next = nullptr;
+            c->m_next = MSGPACK_NULLPTR;
         }
         ~chunk_list()
         {
@@ -117,7 +117,7 @@ class zone {
                     break;
                 }
             }
-            m_head->m_next = nullptr;
+            m_head->m_next = MSGPACK_NULLPTR;
             m_free = chunk_size;
             m_ptr  = reinterpret_cast<char*>(m_head) + sizeof(chunk);
         }

--- a/include/msgpack/v1/detail/cpp11_zone.hpp
+++ b/include/msgpack/v1/detail/cpp11_zone.hpp
@@ -33,7 +33,7 @@ private:
         void* m_data;
     };
     struct finalizer_array {
-        finalizer_array():m_tail(nullptr), m_end(nullptr), m_array(nullptr) {}
+        finalizer_array():m_tail(MSGPACK_NULLPTR), m_end(MSGPACK_NULLPTR), m_array(MSGPACK_NULLPTR) {}
         void call() {
             finalizer* fin = m_tail;
             for(; fin != m_array; --fin) (*(fin-1))();
@@ -84,9 +84,9 @@ private:
         finalizer_array(finalizer_array&& other) noexcept
             :m_tail(other.m_tail), m_end(other.m_end), m_array(other.m_array)
         {
-            other.m_tail = nullptr;
-            other.m_end = nullptr;
-            other.m_array = nullptr;
+            other.m_tail = MSGPACK_NULLPTR;
+            other.m_end = MSGPACK_NULLPTR;
+            other.m_array = MSGPACK_NULLPTR;
         }
         finalizer_array& operator=(finalizer_array&& other) noexcept
         {
@@ -117,7 +117,7 @@ private:
             m_head = c;
             m_free = chunk_size;
             m_ptr  = reinterpret_cast<char*>(c) + sizeof(chunk);
-            c->m_next = nullptr;
+            c->m_next = MSGPACK_NULLPTR;
         }
         ~chunk_list()
         {
@@ -141,14 +141,14 @@ private:
                     break;
                 }
             }
-            m_head->m_next = nullptr;
+            m_head->m_next = MSGPACK_NULLPTR;
             m_free = chunk_size;
             m_ptr  = reinterpret_cast<char*>(m_head) + sizeof(chunk);
         }
         chunk_list(chunk_list&& other) noexcept
             :m_free(other.m_free), m_ptr(other.m_ptr), m_head(other.m_head)
         {
-            other.m_head = nullptr;
+            other.m_head = MSGPACK_NULLPTR;
         }
         chunk_list& operator=(chunk_list&& other) noexcept
         {

--- a/include/msgpack/v1/object.hpp
+++ b/include/msgpack/v1/object.hpp
@@ -179,7 +179,7 @@ inline std::size_t aligned_zone_size(msgpack::object const& obj) {
  */
 inline object_handle clone(msgpack::object const& obj) {
     std::size_t size = msgpack::aligned_zone_size(obj);
-    msgpack::unique_ptr<msgpack::zone> z(size == 0 ? nullptr : new msgpack::zone(size));
+    msgpack::unique_ptr<msgpack::zone> z(size == 0 ? MSGPACK_NULLPTR : new msgpack::zone(size));
     msgpack::object newobj = z.get() ? msgpack::object(obj, *z) : obj;
     return object_handle(newobj, msgpack::move(z));
 }

--- a/include/msgpack/v1/object_fwd.hpp
+++ b/include/msgpack/v1/object_fwd.hpp
@@ -62,7 +62,7 @@ private:
     template <typename>
     static std::false_type check(...);
 public:
-    using type = decltype(check<T>(nullptr));
+    using type = decltype(check<T>(MSGPACK_NULLPTR));
     static constexpr bool value = type::value;
 };
 

--- a/include/msgpack/v1/sbuffer.hpp
+++ b/include/msgpack/v1/sbuffer.hpp
@@ -26,7 +26,7 @@ public:
     sbuffer(size_t initsz = MSGPACK_SBUFFER_INIT_SIZE):m_size(0), m_alloc(initsz)
     {
         if(initsz == 0) {
-            m_data = nullptr;
+            m_data = MSGPACK_NULLPTR;
         } else {
             m_data = (char*)::malloc(initsz);
             if(!m_data) {
@@ -48,7 +48,7 @@ public:
         m_size(other.m_size), m_data(other.m_data), m_alloc(other.m_alloc)
     {
         other.m_size = other.m_alloc = 0;
-        other.m_data = nullptr;
+        other.m_data = MSGPACK_NULLPTR;
     }
 
     sbuffer& operator=(sbuffer&& other)
@@ -60,7 +60,7 @@ public:
         m_data = other.m_data;
 
         other.m_size = other.m_alloc = 0;
-        other.m_data = nullptr;
+        other.m_data = MSGPACK_NULLPTR;
 
         return *this;
     }
@@ -94,7 +94,7 @@ public:
     {
         char* tmp = m_data;
         m_size = 0;
-        m_data = nullptr;
+        m_data = MSGPACK_NULLPTR;
         m_alloc = 0;
         return tmp;
     }

--- a/include/msgpack/v1/unpack.hpp
+++ b/include/msgpack/v1/unpack.hpp
@@ -133,8 +133,8 @@ namespace detail {
 
 class unpack_user {
 public:
-    unpack_user(unpack_reference_func f = nullptr,
-                void* user_data = nullptr,
+    unpack_user(unpack_reference_func f = MSGPACK_NULLPTR,
+                void* user_data = MSGPACK_NULLPTR,
                 unpack_limit const& limit = unpack_limit())
         :m_func(f), m_user_data(user_data), m_limit(limit) {}
     msgpack::zone const& zone() const { return *m_zone; }
@@ -538,7 +538,7 @@ inline int context::execute(const char* data, std::size_t len, std::size_t& off)
     m_start = data;
     m_current = data + off;
     const char* const pe = data + len;
-    const char* n = nullptr;
+    const char* n = MSGPACK_NULLPTR;
 
     msgpack::object obj;
 
@@ -938,7 +938,7 @@ public:
      *
      */
     unpacker(unpack_reference_func f = &unpacker::default_reference_func,
-             void* user_data = nullptr,
+             void* user_data = MSGPACK_NULLPTR,
              std::size_t initial_buffer_size = MSGPACK_UNPACKER_INIT_BUFFER_SIZE,
              unpack_limit const& limit = unpack_limit());
 
@@ -1168,7 +1168,7 @@ inline unpacker::unpacker(unpacker&& other)
      m_z(std::move(other.m_z)),
      m_initial_buffer_size(other.m_initial_buffer_size),
      m_ctx(other.m_ctx) {
-    other.m_buffer = nullptr;
+    other.m_buffer = MSGPACK_NULLPTR;
 }
 
 inline unpacker& unpacker::operator=(unpacker&& other) {
@@ -1345,7 +1345,7 @@ inline msgpack::object const& unpacker::data()
 inline msgpack::zone* unpacker::release_zone()
 {
     if(!flush_zone()) {
-        return nullptr;
+        return MSGPACK_NULLPTR;
     }
 
     msgpack::zone* r =  new msgpack::zone;
@@ -1419,7 +1419,7 @@ namespace detail {
 inline unpack_return
 unpack_imp(const char* data, std::size_t len, std::size_t& off,
            msgpack::zone& result_zone, msgpack::object& result, bool& referenced,
-           unpack_reference_func f = nullptr, void* user_data = nullptr,
+           unpack_reference_func f = MSGPACK_NULLPTR, void* user_data = MSGPACK_NULLPTR,
            unpack_limit const& limit = unpack_limit())
 {
     std::size_t noff = off;

--- a/include/msgpack/v1/unpack_decl.hpp
+++ b/include/msgpack/v1/unpack_decl.hpp
@@ -223,7 +223,7 @@ class unpacker;
  */
 object_handle unpack(
     const char* data, std::size_t len, std::size_t& off, bool& referenced,
-    unpack_reference_func f = nullptr, void* user_data = nullptr, unpack_limit const& limit = unpack_limit());
+    unpack_reference_func f = MSGPACK_NULLPTR, void* user_data = MSGPACK_NULLPTR, unpack_limit const& limit = unpack_limit());
 
 /// Unpack msgpack::object from a buffer.
 /**
@@ -239,7 +239,7 @@ object_handle unpack(
  */
 object_handle unpack(
     const char* data, std::size_t len, std::size_t& off,
-    unpack_reference_func f = nullptr, void* user_data = nullptr, unpack_limit const& limit = unpack_limit());
+    unpack_reference_func f = MSGPACK_NULLPTR, void* user_data = MSGPACK_NULLPTR, unpack_limit const& limit = unpack_limit());
 
 /// Unpack msgpack::object from a buffer.
 /**
@@ -255,7 +255,7 @@ object_handle unpack(
  */
 object_handle unpack(
     const char* data, std::size_t len, bool& referenced,
-    unpack_reference_func f = nullptr, void* user_data = nullptr, unpack_limit const& limit = unpack_limit());
+    unpack_reference_func f = MSGPACK_NULLPTR, void* user_data = MSGPACK_NULLPTR, unpack_limit const& limit = unpack_limit());
 
 /// Unpack msgpack::object from a buffer.
 /**
@@ -270,7 +270,7 @@ object_handle unpack(
  */
 object_handle unpack(
     const char* data, std::size_t len,
-    unpack_reference_func f = nullptr, void* user_data = nullptr, unpack_limit const& limit = unpack_limit());
+    unpack_reference_func f = MSGPACK_NULLPTR, void* user_data = MSGPACK_NULLPTR, unpack_limit const& limit = unpack_limit());
 
 
 /// Unpack msgpack::object from a buffer.
@@ -289,7 +289,7 @@ object_handle unpack(
 void unpack(
     object_handle& result,
     const char* data, std::size_t len, std::size_t& off, bool& referenced,
-    unpack_reference_func f = nullptr, void* user_data = nullptr, unpack_limit const& limit = unpack_limit());
+    unpack_reference_func f = MSGPACK_NULLPTR, void* user_data = MSGPACK_NULLPTR, unpack_limit const& limit = unpack_limit());
 
 /// Unpack msgpack::object from a buffer.
 /**
@@ -306,7 +306,7 @@ void unpack(
 void unpack(
     object_handle& result,
     const char* data, std::size_t len, std::size_t& off,
-    unpack_reference_func f = nullptr, void* user_data = nullptr, unpack_limit const& limit = unpack_limit());
+    unpack_reference_func f = MSGPACK_NULLPTR, void* user_data = MSGPACK_NULLPTR, unpack_limit const& limit = unpack_limit());
 
 /// Unpack msgpack::object from a buffer.
 /**
@@ -323,7 +323,7 @@ void unpack(
 void unpack(
     object_handle& result,
     const char* data, std::size_t len, bool& referenced,
-    unpack_reference_func f = nullptr, void* user_data = nullptr, unpack_limit const& limit = unpack_limit());
+    unpack_reference_func f = MSGPACK_NULLPTR, void* user_data = MSGPACK_NULLPTR, unpack_limit const& limit = unpack_limit());
 
 /// Unpack msgpack::object from a buffer.
 /**
@@ -339,7 +339,7 @@ void unpack(
 void unpack(
     object_handle& result,
     const char* data, std::size_t len,
-    unpack_reference_func f = nullptr, void* user_data = nullptr, unpack_limit const& limit = unpack_limit());
+    unpack_reference_func f = MSGPACK_NULLPTR, void* user_data = MSGPACK_NULLPTR, unpack_limit const& limit = unpack_limit());
 
 /// Unpack msgpack::object from a buffer.
 /**
@@ -358,7 +358,7 @@ void unpack(
 msgpack::object unpack(
     msgpack::zone& z,
     const char* data, std::size_t len, std::size_t& off, bool& referenced,
-    unpack_reference_func f = nullptr, void* user_data = nullptr, unpack_limit const& limit = unpack_limit());
+    unpack_reference_func f = MSGPACK_NULLPTR, void* user_data = MSGPACK_NULLPTR, unpack_limit const& limit = unpack_limit());
 
 /// Unpack msgpack::object from a buffer.
 /**
@@ -376,7 +376,7 @@ msgpack::object unpack(
 msgpack::object unpack(
     msgpack::zone& z,
     const char* data, std::size_t len, std::size_t& off,
-    unpack_reference_func f = nullptr, void* user_data = nullptr, unpack_limit const& limit = unpack_limit());
+    unpack_reference_func f = MSGPACK_NULLPTR, void* user_data = MSGPACK_NULLPTR, unpack_limit const& limit = unpack_limit());
 
 /// Unpack msgpack::object from a buffer.
 /**
@@ -394,7 +394,7 @@ msgpack::object unpack(
 msgpack::object unpack(
     msgpack::zone& z,
     const char* data, std::size_t len, bool& referenced,
-    unpack_reference_func f = nullptr, void* user_data = nullptr, unpack_limit const& limit = unpack_limit());
+    unpack_reference_func f = MSGPACK_NULLPTR, void* user_data = MSGPACK_NULLPTR, unpack_limit const& limit = unpack_limit());
 
 /// Unpack msgpack::object from a buffer.
 /**
@@ -411,7 +411,7 @@ msgpack::object unpack(
 msgpack::object unpack(
     msgpack::zone& z,
     const char* data, std::size_t len,
-    unpack_reference_func f = nullptr, void* user_data = nullptr, unpack_limit const& limit = unpack_limit());
+    unpack_reference_func f = MSGPACK_NULLPTR, void* user_data = MSGPACK_NULLPTR, unpack_limit const& limit = unpack_limit());
 
 
 /// Unpack msgpack::object from a buffer. [obsolete]
@@ -429,8 +429,8 @@ msgpack::object unpack(
  */
 void unpack(
     object_handle* result,
-    const char* data, std::size_t len, std::size_t* off = nullptr, bool* referenced = nullptr,
-    unpack_reference_func f = nullptr, void* user_data = nullptr, unpack_limit const& limit = unpack_limit());
+    const char* data, std::size_t len, std::size_t* off = MSGPACK_NULLPTR, bool* referenced = MSGPACK_NULLPTR,
+    unpack_reference_func f = MSGPACK_NULLPTR, void* user_data = MSGPACK_NULLPTR, unpack_limit const& limit = unpack_limit());
 
 
 // for internal use

--- a/include/msgpack/v1/vrefbuffer.hpp
+++ b/include/msgpack/v1/vrefbuffer.hpp
@@ -81,7 +81,7 @@ public:
         ib->free = chunk_size;
         ib->ptr      = reinterpret_cast<char*>(c) + sizeof(chunk);
         ib->head = c;
-        c->next = nullptr;
+        c->next = MSGPACK_NULLPTR;
 
     }
 
@@ -188,7 +188,7 @@ public:
             throw std::bad_alloc();
         }
 
-        empty->next = nullptr;
+        empty->next = MSGPACK_NULLPTR;
 
         const size_t nused = m_tail - m_array;
         if(to->m_tail + nused < m_end) {
@@ -255,7 +255,7 @@ public:
 
         inner_buffer* const ib = &m_inner_buffer;
         c = ib->head;
-        c->next = nullptr;
+        c->next = MSGPACK_NULLPTR;
         ib->free = m_chunk_size;
         ib->ptr      = reinterpret_cast<char*>(c) + sizeof(chunk);
 

--- a/include/msgpack/v1/zbuffer.hpp
+++ b/include/msgpack/v1/zbuffer.hpp
@@ -25,7 +25,7 @@ class zbuffer {
 public:
     zbuffer(int level = Z_DEFAULT_COMPRESSION,
             size_t init_size = MSGPACK_ZBUFFER_INIT_SIZE)
-        : m_data(nullptr), m_init_size(init_size)
+        : m_data(MSGPACK_NULLPTR), m_init_size(init_size)
     {
         m_stream.zalloc = Z_NULL;
         m_stream.zfree = Z_NULL;
@@ -111,8 +111,8 @@ public:
     char* release_buffer()
     {
         char* tmp = m_data;
-        m_data = nullptr;
-        m_stream.next_out = nullptr;
+        m_data = MSGPACK_NULLPTR;
+        m_stream.next_out = MSGPACK_NULLPTR;
         m_stream.avail_out = 0;
         return tmp;
     }
@@ -125,7 +125,7 @@ private:
         size_t nsize = (csize == 0) ? m_init_size : csize * 2;
 
         char* tmp = static_cast<char*>(::realloc(m_data, nsize));
-        if(tmp == nullptr) {
+        if(tmp == MSGPACK_NULLPTR) {
             return false;
         }
 

--- a/include/msgpack/v2/object_fwd.hpp
+++ b/include/msgpack/v2/object_fwd.hpp
@@ -94,7 +94,7 @@ private:
     template <typename>
     static std::false_type check(...);
 public:
-    using type = decltype(check<T>(nullptr));
+    using type = decltype(check<T>(MSGPACK_NULLPTR));
     static constexpr bool value = type::value;
 };
 

--- a/include/msgpack/v2/unpack.hpp
+++ b/include/msgpack/v2/unpack.hpp
@@ -97,7 +97,7 @@ public:
          m_stack(std::move(other.m_stack)),
          m_zone(other.m_zone),
          m_referenced(other.m_referenced) {
-        other.m_zone = nullptr;
+        other.m_zone = MSGPACK_NULLPTR;
         m_stack[0] = &m_obj;
     }
     create_object_visitor& operator=(create_object_visitor&& other) {
@@ -212,7 +212,7 @@ public:
         obj->type = msgpack::type::ARRAY;
         obj->via.array.size = num_elements;
         if (num_elements == 0) {
-            obj->via.array.ptr = nullptr;
+            obj->via.array.ptr = MSGPACK_NULLPTR;
         }
         else {
             obj->via.array.ptr =
@@ -239,7 +239,7 @@ public:
         obj->type = msgpack::type::MAP;
         obj->via.map.size = num_kv_pairs;
         if (num_kv_pairs == 0) {
-            obj->via.map.ptr = nullptr;
+            obj->via.map.ptr = MSGPACK_NULLPTR;
         }
         else {
             obj->via.map.ptr =
@@ -478,7 +478,7 @@ inline unpack_return context<VisitorHolder>::execute(const char* data, std::size
     m_start = data;
     m_current = data + off;
     const char* const pe = data + len;
-    const char* n = nullptr;
+    const char* n = MSGPACK_NULLPTR;
 
     msgpack::object obj;
 
@@ -1065,7 +1065,7 @@ inline parser<VisitorHolder, ReferencedBufferHook>::parser(this_type&& other)
      m_parsed(other.m_parsed),
      m_initial_buffer_size(other.m_initial_buffer_size),
      m_referenced_buffer_hook(other.m_referenced_buffer_hook) {
-    other.m_buffer = nullptr;
+    other.m_buffer = MSGPACK_NULLPTR;
     other.m_used = 0;
     other.m_free = 0;
     other.m_off = 0;
@@ -1265,7 +1265,7 @@ class unpacker : public parser<unpacker, zone_push_finalizer>,
     typedef parser<unpacker, zone_push_finalizer> parser;
 public:
     unpacker(unpack_reference_func f = &unpacker::default_reference_func,
-             void* user_data = nullptr,
+             void* user_data = MSGPACK_NULLPTR,
              std::size_t initial_buffer_size = MSGPACK_UNPACKER_INIT_BUFFER_SIZE,
              unpack_limit const& limit = unpack_limit())
         :parser(m_finalizer, initial_buffer_size),
@@ -1340,7 +1340,7 @@ inline bool unpacker::next(msgpack::object_handle& result) {
 inline msgpack::zone* unpacker::release_zone()
 {
     if(!flush_zone()) {
-        return nullptr;
+        return MSGPACK_NULLPTR;
     }
 
     msgpack::zone* r =  new msgpack::zone;
@@ -1599,7 +1599,7 @@ parse_imp(const char* data, size_t len, size_t& off, Visitor& v) {
 inline unpack_return
 unpack_imp(const char* data, std::size_t len, std::size_t& off,
            msgpack::zone& result_zone, msgpack::object& result, bool& referenced,
-           unpack_reference_func f = nullptr, void* user_data = nullptr,
+           unpack_reference_func f = MSGPACK_NULLPTR, void* user_data = MSGPACK_NULLPTR,
            unpack_limit const& limit = unpack_limit())
 {
     create_object_visitor v(f, user_data, limit);

--- a/include/msgpack/v2/unpack_decl.hpp
+++ b/include/msgpack/v2/unpack_decl.hpp
@@ -110,7 +110,7 @@ typedef enum unpack_return {
  */
 object_handle unpack(
     const char* data, std::size_t len, std::size_t& off, bool& referenced,
-    unpack_reference_func f = nullptr, void* user_data = nullptr, unpack_limit const& limit = unpack_limit());
+    unpack_reference_func f = MSGPACK_NULLPTR, void* user_data = MSGPACK_NULLPTR, unpack_limit const& limit = unpack_limit());
 
 /// Unpack msgpack::object from a buffer.
 /**
@@ -126,7 +126,7 @@ object_handle unpack(
  */
 object_handle unpack(
     const char* data, std::size_t len, std::size_t& off,
-    unpack_reference_func f = nullptr, void* user_data = nullptr, unpack_limit const& limit = unpack_limit());
+    unpack_reference_func f = MSGPACK_NULLPTR, void* user_data = MSGPACK_NULLPTR, unpack_limit const& limit = unpack_limit());
 
 /// Unpack msgpack::object from a buffer.
 /**
@@ -142,7 +142,7 @@ object_handle unpack(
  */
 object_handle unpack(
     const char* data, std::size_t len, bool& referenced,
-    unpack_reference_func f = nullptr, void* user_data = nullptr, unpack_limit const& limit = unpack_limit());
+    unpack_reference_func f = MSGPACK_NULLPTR, void* user_data = MSGPACK_NULLPTR, unpack_limit const& limit = unpack_limit());
 
 /// Unpack msgpack::object from a buffer.
 /**
@@ -157,7 +157,7 @@ object_handle unpack(
  */
 object_handle unpack(
     const char* data, std::size_t len,
-    unpack_reference_func f = nullptr, void* user_data = nullptr, unpack_limit const& limit = unpack_limit());
+    unpack_reference_func f = MSGPACK_NULLPTR, void* user_data = MSGPACK_NULLPTR, unpack_limit const& limit = unpack_limit());
 
 
 /// Unpack msgpack::object from a buffer.
@@ -176,7 +176,7 @@ object_handle unpack(
 void unpack(
     object_handle& result,
     const char* data, std::size_t len, std::size_t& off, bool& referenced,
-    unpack_reference_func f = nullptr, void* user_data = nullptr, unpack_limit const& limit = unpack_limit());
+    unpack_reference_func f = MSGPACK_NULLPTR, void* user_data = MSGPACK_NULLPTR, unpack_limit const& limit = unpack_limit());
 
 /// Unpack msgpack::object from a buffer.
 /**
@@ -193,7 +193,7 @@ void unpack(
 void unpack(
     object_handle& result,
     const char* data, std::size_t len, std::size_t& off,
-    unpack_reference_func f = nullptr, void* user_data = nullptr, unpack_limit const& limit = unpack_limit());
+    unpack_reference_func f = MSGPACK_NULLPTR, void* user_data = MSGPACK_NULLPTR, unpack_limit const& limit = unpack_limit());
 
 /// Unpack msgpack::object from a buffer.
 /**
@@ -210,7 +210,7 @@ void unpack(
 void unpack(
     object_handle& result,
     const char* data, std::size_t len, bool& referenced,
-    unpack_reference_func f = nullptr, void* user_data = nullptr, unpack_limit const& limit = unpack_limit());
+    unpack_reference_func f = MSGPACK_NULLPTR, void* user_data = MSGPACK_NULLPTR, unpack_limit const& limit = unpack_limit());
 
 /// Unpack msgpack::object from a buffer.
 /**
@@ -226,7 +226,7 @@ void unpack(
 void unpack(
     object_handle& result,
     const char* data, std::size_t len,
-    unpack_reference_func f = nullptr, void* user_data = nullptr, unpack_limit const& limit = unpack_limit());
+    unpack_reference_func f = MSGPACK_NULLPTR, void* user_data = MSGPACK_NULLPTR, unpack_limit const& limit = unpack_limit());
 
 /// Unpack msgpack::object from a buffer.
 /**
@@ -245,7 +245,7 @@ void unpack(
 msgpack::object unpack(
     msgpack::zone& z,
     const char* data, std::size_t len, std::size_t& off, bool& referenced,
-    unpack_reference_func f = nullptr, void* user_data = nullptr, unpack_limit const& limit = unpack_limit());
+    unpack_reference_func f = MSGPACK_NULLPTR, void* user_data = MSGPACK_NULLPTR, unpack_limit const& limit = unpack_limit());
 
 /// Unpack msgpack::object from a buffer.
 /**
@@ -263,7 +263,7 @@ msgpack::object unpack(
 msgpack::object unpack(
     msgpack::zone& z,
     const char* data, std::size_t len, std::size_t& off,
-    unpack_reference_func f = nullptr, void* user_data = nullptr, unpack_limit const& limit = unpack_limit());
+    unpack_reference_func f = MSGPACK_NULLPTR, void* user_data = MSGPACK_NULLPTR, unpack_limit const& limit = unpack_limit());
 
 /// Unpack msgpack::object from a buffer.
 /**
@@ -281,7 +281,7 @@ msgpack::object unpack(
 msgpack::object unpack(
     msgpack::zone& z,
     const char* data, std::size_t len, bool& referenced,
-    unpack_reference_func f = nullptr, void* user_data = nullptr, unpack_limit const& limit = unpack_limit());
+    unpack_reference_func f = MSGPACK_NULLPTR, void* user_data = MSGPACK_NULLPTR, unpack_limit const& limit = unpack_limit());
 
 /// Unpack msgpack::object from a buffer.
 /**
@@ -298,7 +298,7 @@ msgpack::object unpack(
 msgpack::object unpack(
     msgpack::zone& z,
     const char* data, std::size_t len,
-    unpack_reference_func f = nullptr, void* user_data = nullptr, unpack_limit const& limit = unpack_limit());
+    unpack_reference_func f = MSGPACK_NULLPTR, void* user_data = MSGPACK_NULLPTR, unpack_limit const& limit = unpack_limit());
 
 /// Unpack msgpack formatted data via a visitor
 /**

--- a/test/limit.cpp
+++ b/test/limit.cpp
@@ -12,7 +12,7 @@ TEST(limit, unpack_array_no_over)
     msgpack::pack(ss, v);
     try {
         msgpack::object_handle oh =
-            msgpack::unpack(ss.str().c_str(), ss.str().size(), nullptr, nullptr,
+            msgpack::unpack(ss.str().c_str(), ss.str().size(), MSGPACK_NULLPTR, MSGPACK_NULLPTR,
                         msgpack::unpack_limit(3, 0, 0, 0, 0));
         EXPECT_TRUE(true);
     }
@@ -34,7 +34,7 @@ TEST(limit, unpack_array_over)
     msgpack::pack(ss, v);
     try {
         msgpack::object_handle oh =
-            msgpack::unpack(ss.str().c_str(), ss.str().size(), nullptr, nullptr,
+            msgpack::unpack(ss.str().c_str(), ss.str().size(), MSGPACK_NULLPTR, MSGPACK_NULLPTR,
                         msgpack::unpack_limit(2, 0, 0, 0, 0));
         EXPECT_TRUE(false);
     }
@@ -56,7 +56,7 @@ TEST(limit, unpack_map_no_over)
     msgpack::pack(ss, m);
     try {
         msgpack::object_handle oh =
-            msgpack::unpack(ss.str().c_str(), ss.str().size(), nullptr, nullptr,
+            msgpack::unpack(ss.str().c_str(), ss.str().size(), MSGPACK_NULLPTR, MSGPACK_NULLPTR,
                         msgpack::unpack_limit(0, 3, 0, 0, 0));
         EXPECT_TRUE(true);
     }
@@ -78,7 +78,7 @@ TEST(limit, unpack_map_over)
     msgpack::pack(ss, m);
     try {
         msgpack::object_handle oh =
-            msgpack::unpack(ss.str().c_str(), ss.str().size(), nullptr, nullptr,
+            msgpack::unpack(ss.str().c_str(), ss.str().size(), MSGPACK_NULLPTR, MSGPACK_NULLPTR,
                         msgpack::unpack_limit(0, 2, 0, 0, 0));
         EXPECT_TRUE(false);
     }
@@ -97,7 +97,7 @@ TEST(limit, unpack_str_no_over)
     msgpack::pack(ss, s);
     try {
         msgpack::object_handle oh =
-            msgpack::unpack(ss.str().c_str(), ss.str().size(), nullptr, nullptr,
+            msgpack::unpack(ss.str().c_str(), ss.str().size(), MSGPACK_NULLPTR, MSGPACK_NULLPTR,
                         msgpack::unpack_limit(0, 0, 3, 0, 0));
         EXPECT_TRUE(true);
     }
@@ -116,7 +116,7 @@ TEST(limit, unpack_str_over)
     msgpack::pack(ss, s);
     try {
         msgpack::object_handle oh =
-            msgpack::unpack(ss.str().c_str(), ss.str().size(), nullptr, nullptr,
+            msgpack::unpack(ss.str().c_str(), ss.str().size(), MSGPACK_NULLPTR, MSGPACK_NULLPTR,
                         msgpack::unpack_limit(0, 0, 2, 0, 0));
         EXPECT_TRUE(false);
     }
@@ -138,7 +138,7 @@ TEST(limit, unpack_bin_no_over)
     msgpack::pack(ss, v);
     try {
         msgpack::object_handle oh =
-            msgpack::unpack(ss.str().c_str(), ss.str().size(), nullptr, nullptr,
+            msgpack::unpack(ss.str().c_str(), ss.str().size(), MSGPACK_NULLPTR, MSGPACK_NULLPTR,
                         msgpack::unpack_limit(0, 0, 0, 3, 0));
         EXPECT_TRUE(true);
     }
@@ -160,7 +160,7 @@ TEST(limit, unpack_bin_over)
     msgpack::pack(ss, v);
     try {
         msgpack::object_handle oh =
-            msgpack::unpack(ss.str().c_str(), ss.str().size(), nullptr, nullptr,
+            msgpack::unpack(ss.str().c_str(), ss.str().size(), MSGPACK_NULLPTR, MSGPACK_NULLPTR,
                         msgpack::unpack_limit(0, 0, 0, 2, 0));
         EXPECT_TRUE(false);
     }
@@ -181,7 +181,7 @@ TEST(limit, unpack_ext_no_over)
     packer.pack_ext_body(buf, sizeof(buf));
     try {
         msgpack::object_handle oh =
-            msgpack::unpack(ss.str().c_str(), ss.str().size(), nullptr, nullptr,
+            msgpack::unpack(ss.str().c_str(), ss.str().size(), MSGPACK_NULLPTR, MSGPACK_NULLPTR,
                         msgpack::unpack_limit(0, 0, 0, 0, 3+1));
         EXPECT_TRUE(true);
     }
@@ -202,7 +202,7 @@ TEST(limit, unpack_ext_over)
     packer.pack_ext_body(buf, sizeof(buf));
     try {
         msgpack::object_handle oh =
-            msgpack::unpack(ss.str().c_str(), ss.str().size(), nullptr, nullptr,
+            msgpack::unpack(ss.str().c_str(), ss.str().size(), MSGPACK_NULLPTR, MSGPACK_NULLPTR,
                         msgpack::unpack_limit(0, 0, 0, 0, 2+1));
         EXPECT_TRUE(false);
     }
@@ -227,7 +227,7 @@ TEST(limit, unpack_ext_over_32_bit)
         };
         try {
             msgpack::object_handle unp;
-            msgpack::unpack(unp, buf, sizeof(buf), nullptr, nullptr,
+            msgpack::unpack(unp, buf, sizeof(buf), MSGPACK_NULLPTR, MSGPACK_NULLPTR,
                             msgpack::unpack_limit(0, 0, 0, 0, 0xffffffff));
             EXPECT_TRUE(false);
         }
@@ -253,7 +253,7 @@ TEST(limit, unpack_ext_no_over_64_bit)
         };
         try {
             msgpack::object_handle unp;
-            msgpack::unpack(unp, buf, sizeof(buf), nullptr, nullptr,
+            msgpack::unpack(unp, buf, sizeof(buf), MSGPACK_NULLPTR, MSGPACK_NULLPTR,
                             msgpack::unpack_limit(0, 0, 0, 0, 0xffffffff));
             EXPECT_TRUE(false);
         }
@@ -279,7 +279,7 @@ TEST(limit, unpack_depth_no_over)
     msgpack::pack(ss, outer);
     try {
         msgpack::object_handle unp;
-        msgpack::unpack(unp, ss.str().c_str(), ss.str().size(), nullptr, nullptr,
+        msgpack::unpack(unp, ss.str().c_str(), ss.str().size(), MSGPACK_NULLPTR, MSGPACK_NULLPTR,
                         msgpack::unpack_limit(1, 0, 0, 0, 0, 2));
         EXPECT_TRUE(true);
     }
@@ -301,7 +301,7 @@ TEST(limit, unpack_depth_over)
     msgpack::pack(ss, outer);
     try {
         msgpack::object_handle unp;
-        msgpack::unpack(unp, ss.str().c_str(), ss.str().size(), nullptr, nullptr,
+        msgpack::unpack(unp, ss.str().c_str(), ss.str().size(), MSGPACK_NULLPTR, MSGPACK_NULLPTR,
                         msgpack::unpack_limit(1, 0, 0, 0, 0, 1));
         EXPECT_TRUE(false);
     }
@@ -327,7 +327,7 @@ TEST(limit, unpack_array_over_cpp11_no_off_no_ref)
     msgpack::pack(ss, v);
     try {
         msgpack::object_handle unp =
-            msgpack::unpack(ss.str().c_str(), ss.str().size(), nullptr, nullptr,
+            msgpack::unpack(ss.str().c_str(), ss.str().size(), MSGPACK_NULLPTR, MSGPACK_NULLPTR,
                             msgpack::unpack_limit(2, 0, 0, 0, 0));
         EXPECT_TRUE(false);
     }
@@ -350,7 +350,7 @@ TEST(limit, unpack_array_over_cpp11_no_off_ref)
     try {
         bool ref;
         msgpack::object_handle unp =
-            msgpack::unpack(ss.str().c_str(), ss.str().size(), ref, nullptr, nullptr,
+            msgpack::unpack(ss.str().c_str(), ss.str().size(), ref, MSGPACK_NULLPTR, MSGPACK_NULLPTR,
                             msgpack::unpack_limit(2, 0, 0, 0, 0));
         EXPECT_TRUE(false);
     }
@@ -373,7 +373,7 @@ TEST(limit, unpack_array_over_cpp11_off_no_ref)
     try {
         std::size_t off = 0;
         msgpack::object_handle unp =
-            msgpack::unpack(ss.str().c_str(), ss.str().size(), off, nullptr, nullptr,
+            msgpack::unpack(ss.str().c_str(), ss.str().size(), off, MSGPACK_NULLPTR, MSGPACK_NULLPTR,
                             msgpack::unpack_limit(2, 0, 0, 0, 0));
         EXPECT_TRUE(false);
     }
@@ -397,7 +397,7 @@ TEST(limit, unpack_array_over_cpp11_off_ref)
         bool ref;
         std::size_t off = 0;
         msgpack::object_handle unp =
-            msgpack::unpack(ss.str().c_str(), ss.str().size(), off, ref, nullptr, nullptr,
+            msgpack::unpack(ss.str().c_str(), ss.str().size(), off, ref, MSGPACK_NULLPTR, MSGPACK_NULLPTR,
                             msgpack::unpack_limit(2, 0, 0, 0, 0));
         EXPECT_TRUE(false);
     }
@@ -421,7 +421,7 @@ TEST(limit, unpack_array_over_no_off_no_ref)
     msgpack::pack(ss, v);
     try {
         msgpack::object_handle unp;
-        msgpack::unpack(unp, ss.str().c_str(), ss.str().size(), nullptr, nullptr,
+        msgpack::unpack(unp, ss.str().c_str(), ss.str().size(), MSGPACK_NULLPTR, MSGPACK_NULLPTR,
                         msgpack::unpack_limit(2, 0, 0, 0, 0));
         EXPECT_TRUE(false);
     }
@@ -444,7 +444,7 @@ TEST(limit, unpack_array_over_no_off_ref)
     try {
         bool ref;
         msgpack::object_handle unp;
-        msgpack::unpack(unp, ss.str().c_str(), ss.str().size(), ref, nullptr, nullptr,
+        msgpack::unpack(unp, ss.str().c_str(), ss.str().size(), ref, MSGPACK_NULLPTR, MSGPACK_NULLPTR,
                         msgpack::unpack_limit(2, 0, 0, 0, 0));
         EXPECT_TRUE(false);
     }
@@ -467,7 +467,7 @@ TEST(limit, unpack_array_over_off_no_ref)
     try {
         std::size_t off = 0;
         msgpack::object_handle unp;
-        msgpack::unpack(unp, ss.str().c_str(), ss.str().size(), off, nullptr, nullptr,
+        msgpack::unpack(unp, ss.str().c_str(), ss.str().size(), off, MSGPACK_NULLPTR, MSGPACK_NULLPTR,
                         msgpack::unpack_limit(2, 0, 0, 0, 0));
         EXPECT_TRUE(false);
     }
@@ -491,7 +491,7 @@ TEST(limit, unpack_array_over_off_ref)
         bool ref;
         std::size_t off = 0;
         msgpack::object_handle unp;
-        msgpack::unpack(unp, ss.str().c_str(), ss.str().size(), off, ref, nullptr, nullptr,
+        msgpack::unpack(unp, ss.str().c_str(), ss.str().size(), off, ref, MSGPACK_NULLPTR, MSGPACK_NULLPTR,
                         msgpack::unpack_limit(2, 0, 0, 0, 0));
         EXPECT_TRUE(false);
     }
@@ -518,7 +518,7 @@ TEST(limit, unpack_array_over_off_ref_pointer)
         bool ref;
         std::size_t off = 0;
         msgpack::object_handle unp;
-        msgpack::unpack(&unp, ss.str().c_str(), ss.str().size(), &off, &ref, nullptr, nullptr,
+        msgpack::unpack(&unp, ss.str().c_str(), ss.str().size(), &off, &ref, MSGPACK_NULLPTR, MSGPACK_NULLPTR,
                         msgpack::unpack_limit(2, 0, 0, 0, 0));
         EXPECT_TRUE(false);
     }
@@ -541,7 +541,7 @@ TEST(limit, unpacker_array_over)
     v.push_back(3);
     msgpack::pack(ss, v);
     try {
-        msgpack::unpacker u(nullptr, nullptr, MSGPACK_UNPACKER_INIT_BUFFER_SIZE,
+        msgpack::unpacker u(MSGPACK_NULLPTR, MSGPACK_NULLPTR, MSGPACK_UNPACKER_INIT_BUFFER_SIZE,
                             msgpack::unpack_limit(2, 0, 0, 0, 0));
         u.reserve_buffer(ss.str().size());
         memcpy(u.buffer(), ss.str().c_str(), ss.str().size());
@@ -560,7 +560,7 @@ TEST(limit, unpacker_array_over)
 
 TEST(limit, unpacker_reserve)
 {
-    msgpack::unpacker u(nullptr, nullptr, MSGPACK_UNPACKER_INIT_BUFFER_SIZE,
+    msgpack::unpacker u(MSGPACK_NULLPTR, MSGPACK_NULLPTR, MSGPACK_UNPACKER_INIT_BUFFER_SIZE,
                         msgpack::unpack_limit());
     std::size_t original_capacity = u.buffer_capacity();
     u.reserve_buffer(original_capacity + 1u);
@@ -569,7 +569,7 @@ TEST(limit, unpacker_reserve)
 
 TEST(limit, unpacker_reserve_more_than_twice)
 {
-    msgpack::unpacker u(nullptr, nullptr, MSGPACK_UNPACKER_INIT_BUFFER_SIZE,
+    msgpack::unpacker u(MSGPACK_NULLPTR, MSGPACK_NULLPTR, MSGPACK_UNPACKER_INIT_BUFFER_SIZE,
                         msgpack::unpack_limit());
     std::size_t original_capacity = u.buffer_capacity();
     u.reserve_buffer(original_capacity * 3);

--- a/test/pack_unpack.cpp
+++ b/test/pack_unpack.cpp
@@ -170,7 +170,7 @@ TEST(unpack, int_pointer_off_no_ref_explicit)
     std::size_t off = 0;
 
     // obsolete
-    msgpack::unpack(&oh, sbuf.data(), sbuf.size(), &off, nullptr);
+    msgpack::unpack(&oh, sbuf.data(), sbuf.size(), &off, MSGPACK_NULLPTR);
     EXPECT_EQ(1, oh.get().as<int>());
     EXPECT_EQ(off, sbuf.size());
 }
@@ -183,7 +183,7 @@ TEST(unpack, int_pointer_no_off_ref)
     bool referenced;
 
     // obsolete
-    msgpack::unpack(&oh, sbuf.data(), sbuf.size(), nullptr, &referenced);
+    msgpack::unpack(&oh, sbuf.data(), sbuf.size(), MSGPACK_NULLPTR, &referenced);
     EXPECT_EQ(1, oh.get().as<int>());
     EXPECT_EQ(false, referenced);
 }

--- a/test/reference.cpp
+++ b/test/reference.cpp
@@ -140,12 +140,12 @@ TEST(reference, unpack_int_sized_ref)
     msgpack::pack(sbuf, 1);
 
     bool referenced;
-    s_p = nullptr;
+    s_p = MSGPACK_NULLPTR;
 
     msgpack::object_handle oh =
         msgpack::unpack(sbuf.data(), sbuf.size(), referenced, never_called, &sbuf);
     EXPECT_FALSE(referenced);
-    EXPECT_EQ(nullptr, s_p);
+    EXPECT_EQ(MSGPACK_NULLPTR, s_p);
 }
 
 TEST(reference, unpack_string_sized_ref_4)
@@ -154,7 +154,7 @@ TEST(reference, unpack_string_sized_ref_4)
     msgpack::pack(sbuf, std::string("1234"));
 
     bool referenced;
-    s_p = nullptr;
+    s_p = MSGPACK_NULLPTR;
     // the last argument sbuf is any pointer as a user data.
     // That is stored to s_p in sized_reference
     msgpack::object_handle oh =
@@ -170,7 +170,7 @@ TEST(reference, unpack_string_sized_ref_5)
     msgpack::pack(sbuf, std::string("12345"));
 
     bool referenced;
-    s_p = nullptr;
+    s_p = MSGPACK_NULLPTR;
 
     msgpack::object_handle oh =
         msgpack::unpack(sbuf.data(), sbuf.size(), referenced, sized_reference, &sbuf);
@@ -188,7 +188,7 @@ TEST(reference, unpack_bin_sized_ref_5)
     packer.pack_bin_body(c, sizeof(c));
 
     bool referenced;
-    s_p = nullptr;
+    s_p = MSGPACK_NULLPTR;
 
     msgpack::object_handle oh =
         msgpack::unpack(sbuf.data(), sbuf.size(), referenced, sized_reference, &sbuf);
@@ -205,7 +205,7 @@ TEST(reference, unpack_bin_sized_ref_6)
     packer.pack_bin_body(c, sizeof(c));
 
     bool referenced;
-    s_p = nullptr;
+    s_p = MSGPACK_NULLPTR;
     msgpack::object_handle oh =
         msgpack::unpack(sbuf.data(), sbuf.size(), referenced, sized_reference, &sbuf);
     EXPECT_TRUE(referenced);
@@ -222,7 +222,7 @@ TEST(reference, unpack_ext_sized_ref_6)
     packer.pack_ext_body(buf, sizeof(buf));
 
     bool referenced;
-    s_p = nullptr;
+    s_p = MSGPACK_NULLPTR;
     msgpack::object_handle oh =
         msgpack::unpack(sbuf.data(), sbuf.size(), referenced, sized_reference, &sbuf);
     EXPECT_FALSE(referenced);
@@ -239,7 +239,7 @@ TEST(reference, unpack_ext_sized_ref_7)
     packer.pack_ext_body(buf, sizeof(buf));
 
     bool referenced;
-    s_p = nullptr;
+    s_p = MSGPACK_NULLPTR;
     msgpack::object_handle oh =
         msgpack::unpack(sbuf.data(), sbuf.size(), referenced, sized_reference, &sbuf);
     EXPECT_TRUE(referenced);
@@ -333,11 +333,11 @@ TEST(reference, unpacker_int_sized_ref)
     unp.reserve_buffer(sbuf.size());
     std::memcpy(unp.buffer(), sbuf.data(), sbuf.size());
     unp.buffer_consumed(sbuf.size());
-    s_p = nullptr;
+    s_p = MSGPACK_NULLPTR;
     bool b = unp.next(oh, referenced);
     EXPECT_TRUE(b);
     EXPECT_FALSE(referenced);
-    EXPECT_EQ(nullptr, s_p);
+    EXPECT_EQ(MSGPACK_NULLPTR, s_p);
 }
 
 TEST(reference, unpacker_string_sized_ref_4)
@@ -351,7 +351,7 @@ TEST(reference, unpacker_string_sized_ref_4)
     unp.reserve_buffer(sbuf.size());
     std::memcpy(unp.buffer(), sbuf.data(), sbuf.size());
     unp.buffer_consumed(sbuf.size());
-    s_p = nullptr;
+    s_p = MSGPACK_NULLPTR;
     bool b = unp.next(oh, referenced);
     EXPECT_TRUE(b);
     EXPECT_FALSE(referenced);
@@ -369,7 +369,7 @@ TEST(reference, unpacker_string_sized_ref_5)
     unp.reserve_buffer(sbuf.size());
     std::memcpy(unp.buffer(), sbuf.data(), sbuf.size());
     unp.buffer_consumed(sbuf.size());
-    s_p = nullptr;
+    s_p = MSGPACK_NULLPTR;
     bool b = unp.next(oh, referenced);
     EXPECT_TRUE(b);
     EXPECT_TRUE(referenced);
@@ -391,7 +391,7 @@ TEST(reference, unpacker_bin_sized_ref_5)
     unp.reserve_buffer(sbuf.size());
     std::memcpy(unp.buffer(), sbuf.data(), sbuf.size());
     unp.buffer_consumed(sbuf.size());
-    s_p = nullptr;
+    s_p = MSGPACK_NULLPTR;
     bool b = unp.next(oh, referenced);
     EXPECT_TRUE(b);
     EXPECT_FALSE(referenced);
@@ -412,7 +412,7 @@ TEST(reference, unpacker_bin_sized_ref_6)
     unp.reserve_buffer(sbuf.size());
     std::memcpy(unp.buffer(), sbuf.data(), sbuf.size());
     unp.buffer_consumed(sbuf.size());
-    s_p = nullptr;
+    s_p = MSGPACK_NULLPTR;
     bool b = unp.next(oh, referenced);
     EXPECT_TRUE(b);
     EXPECT_TRUE(referenced);
@@ -434,7 +434,7 @@ TEST(reference, unpacker_ext_sized_ref_6)
     unp.reserve_buffer(sbuf.size());
     std::memcpy(unp.buffer(), sbuf.data(), sbuf.size());
     unp.buffer_consumed(sbuf.size());
-    s_p = nullptr;
+    s_p = MSGPACK_NULLPTR;
     bool b = unp.next(oh, referenced);
     EXPECT_TRUE(b);
     EXPECT_FALSE(referenced);
@@ -456,7 +456,7 @@ TEST(reference, unpacker_ext_sized_ref_7)
     unp.reserve_buffer(sbuf.size());
     std::memcpy(unp.buffer(), sbuf.data(), sbuf.size());
     unp.buffer_consumed(sbuf.size());
-    s_p = nullptr;
+    s_p = MSGPACK_NULLPTR;
     bool b = unp.next(oh, referenced);
     EXPECT_TRUE(b);
     EXPECT_TRUE(referenced);

--- a/test/reference_cpp11.cpp
+++ b/test/reference_cpp11.cpp
@@ -133,10 +133,10 @@ TEST(reference, unpack_int_sized_ref)
     msgpack::pack(sbuf, 1);
 
     bool referenced;
-    s_p = nullptr;
+    s_p = MSGPACK_NULLPTR;
     msgpack::object_handle oh = msgpack::unpack(sbuf.data(), sbuf.size(), referenced, never_called, &sbuf);
     EXPECT_FALSE(referenced);
-    EXPECT_EQ(nullptr, s_p);
+    EXPECT_EQ(MSGPACK_NULLPTR, s_p);
 }
 
 TEST(reference, unpack_string_sized_ref_4)
@@ -145,7 +145,7 @@ TEST(reference, unpack_string_sized_ref_4)
     msgpack::pack(sbuf, std::string("1234"));
 
     bool referenced;
-    s_p = nullptr;
+    s_p = MSGPACK_NULLPTR;
     // the last argument sbuf is any pointer as a user data.
     // That is stored to s_p in sized_reference
     msgpack::object_handle oh = msgpack::unpack(sbuf.data(), sbuf.size(), referenced, sized_reference, &sbuf);
@@ -160,7 +160,7 @@ TEST(reference, unpack_string_sized_ref_5)
     msgpack::pack(sbuf, std::string("12345"));
 
     bool referenced;
-    s_p = nullptr;
+    s_p = MSGPACK_NULLPTR;
     msgpack::object_handle oh = msgpack::unpack(sbuf.data(), sbuf.size(), referenced, sized_reference, &sbuf);
     EXPECT_TRUE(referenced);
     EXPECT_EQ(&sbuf, s_p);
@@ -176,7 +176,7 @@ TEST(reference, unpack_bin_sized_ref_5)
     packer.pack_bin_body(c, sizeof(c));
 
     bool referenced;
-    s_p = nullptr;
+    s_p = MSGPACK_NULLPTR;
     msgpack::object_handle oh = msgpack::unpack(sbuf.data(), sbuf.size(), referenced, sized_reference, &sbuf);
     EXPECT_FALSE(referenced);
     EXPECT_EQ(&sbuf, s_p);
@@ -191,7 +191,7 @@ TEST(reference, unpack_bin_sized_ref_6)
     packer.pack_bin_body(c, sizeof(c));
 
     bool referenced;
-    s_p = nullptr;
+    s_p = MSGPACK_NULLPTR;
     msgpack::object_handle oh = msgpack::unpack(sbuf.data(), sbuf.size(), referenced, sized_reference, &sbuf);
     EXPECT_TRUE(referenced);
     EXPECT_EQ(&sbuf, s_p);
@@ -207,7 +207,7 @@ TEST(reference, unpack_ext_sized_ref_6)
     packer.pack_ext_body(buf, sizeof(buf));
 
     bool referenced;
-    s_p = nullptr;
+    s_p = MSGPACK_NULLPTR;
     msgpack::object_handle oh = msgpack::unpack(sbuf.data(), sbuf.size(), referenced, sized_reference, &sbuf);
     EXPECT_FALSE(referenced);
     EXPECT_EQ(&sbuf, s_p);
@@ -223,7 +223,7 @@ TEST(reference, unpack_ext_sized_ref_7)
     packer.pack_ext_body(buf, sizeof(buf));
 
     bool referenced;
-    s_p = nullptr;
+    s_p = MSGPACK_NULLPTR;
     msgpack::object_handle oh = msgpack::unpack(sbuf.data(), sbuf.size(), referenced, sized_reference, &sbuf);
     EXPECT_TRUE(referenced);
     EXPECT_EQ(&sbuf, s_p);


### PR DESCRIPTION
MSVC CLI defined their own nullptr and provides for __nullptr for standard C++11.
https://msdn.microsoft.com/en-us/library/4ex65770.aspx
msgpack-c introduce MSGPACK_NULLPTR for internal use, it is defined as __nullptr only if compiled on C++ CLI otherwise defined as nullptr.

A client doesn't need to use MSGPACK_NULLPTR, simply use nullptr on C++11 or later.