### PR TITLE
Add msgpack_object_print_buffer() function

### DIFF
--- a/example/c/user_buffer_unpack.c
+++ b/example/c/user_buffer_unpack.c
@@ -2,6 +2,8 @@
 #include <stdio.h>
 #include <assert.h>
 
+#define UNPACKED_BUFFER_SIZE 2048
+
 void prepare(msgpack_sbuffer* sbuf) {
     msgpack_packer pk;
 
@@ -27,6 +29,7 @@ void unpack(char const* buf, size_t len) {
     size_t off = 0;
     msgpack_unpack_return ret;
     int i = 0;
+    char unpacked_buffer[UNPACKED_BUFFER_SIZE];
     msgpack_unpacked_init(&result);
     ret = msgpack_unpack_next(&result, buf, len, &off);
     while (ret == MSGPACK_UNPACK_SUCCESS) {
@@ -36,6 +39,8 @@ void unpack(char const* buf, size_t len) {
         printf("Object no %d:\n", ++i);
         msgpack_object_print(stdout, obj);
         printf("\n");
+        msgpack_object_print_buffer(unpacked_buffer, UNPACKED_BUFFER_SIZE, obj);
+        printf("%s\n", unpacked_buffer);
         /* If you want to allocate something on the zone, you can use zone. */
         /* msgpack_zone* zone = result.zone; */
         /* The lifetime of the obj and the zone,  */

--- a/include/msgpack/object.h
+++ b/include/msgpack/object.h
@@ -99,6 +99,9 @@ MSGPACK_DLLEXPORT
 void msgpack_object_print(FILE* out, msgpack_object o);
 
 MSGPACK_DLLEXPORT
+int msgpack_object_print_buffer(char *buffer, uint32_t buffer_size, msgpack_object o);
+
+MSGPACK_DLLEXPORT
 bool msgpack_object_equal(const msgpack_object x, const msgpack_object y);
 
 /** @} */

--- a/include/msgpack/sysdep.h
+++ b/include/msgpack/sysdep.h
@@ -14,6 +14,11 @@
 
 #include <stdlib.h>
 #include <stddef.h>
+
+#if defined(_MSC_VER) && _MSC_VER <= 1800
+#   define snprintf(buf, len, format,...) _snprintf_s(buf, len, len, format, __VA_ARGS__)
+#endif
+
 #if defined(_MSC_VER) && _MSC_VER < 1600
     typedef signed __int8 int8_t;
     typedef unsigned __int8 uint8_t;


### PR DESCRIPTION
In order to print the msgpack object in a memory buffer.
Similar to msgpack_object_print(), but prints in a given, allocated buffer.

Basically tested it with ./user_buffer_unpack.