### PR TITLE
enable as<std::map>() use if key OR value has as() implementation

### DIFF
--- a/example/cpp11/non_def_con_class.cpp
+++ b/example/cpp11/non_def_con_class.cpp
@@ -23,6 +23,16 @@ struct my {
     my(int a):a(a) {}
     int a;
     MSGPACK_DEFINE(a);
+
+    bool operator==(const my & other) const
+    {
+       return other.a == a;
+    }
+
+    bool operator<(const my & other) const
+    {
+       return other.a > a;
+    }
 };
 
 namespace msgpack {
@@ -48,4 +58,34 @@ int main() {
     msgpack::object obj(m1, z);
     std::cout << obj << std::endl;
     assert(m1.a == obj.as<my>().a);
+
+    // useful keys for maps do not have as<>() method implemented:
+    std::cout << "has_as<int>    " << msgpack::has_as<int>::value << std::endl;
+    std::cout << "has_as<string> " << msgpack::has_as<std::string>::value << std::endl;
+
+    // BEFORE PATCH: as a result as<map<K, V> >() is not available either.
+    // AFTER PATCH:  as<map<K, V> >() is available if key OR value have an as<>() implementation
+    std::cout << "has_as<std::map<int, my> > " << msgpack::has_as<std::map<int, my> >::value << std::endl;
+
+    std::map<int, my> m;
+    m.emplace(1, my(17));
+    msgpack::object obj2(m, z);
+    std::cout << obj2 << std::endl;
+
+    // BEFORE PATCH: this makes the following break with a compiler error,
+    // beacuse it uses the deleted my:my() constructor, as it falls back to the
+    // convert() method.
+    // AFTER PATCH: the following works and uses the customary as() implementation
+    assert(m == obj2.as<decltype(m)>());
+
+    std::map<my, int> m2;
+    m2.emplace(17, 42);
+    msgpack::object obj3(m2, z);
+    std::cout << obj3 << std::endl;
+
+    // BEFORE PATCH: this makes the following break with a compiler error:
+    // beacuse it uses the deleted my:my() constructor, as it falls back to the
+    // convert() method.
+    // AFTER PATCH: the following works and uses the customary as() implementation
+    assert(m2 == obj3.as<decltype(m2)>());
 }

--- a/include/msgpack/v1/adaptor/map.hpp
+++ b/include/msgpack/v1/adaptor/map.hpp
@@ -48,7 +48,7 @@ namespace adaptor {
 template <typename K, typename V, typename Compare, typename Alloc>
 struct as<
     type::assoc_vector<K, V, Compare, Alloc>,
-    typename std::enable_if<msgpack::has_as<K>::value && msgpack::has_as<V>::value>::type> {
+    typename std::enable_if<msgpack::has_as<K>::value || msgpack::has_as<V>::value>::type> {
     type::assoc_vector<K, V, Compare, Alloc> operator()(msgpack::object const& o) const {
         if (o.type != msgpack::type::MAP) { throw msgpack::type_error(); }
         type::assoc_vector<K, V, Compare, Alloc> v;
@@ -129,7 +129,7 @@ struct object_with_zone<type::assoc_vector<K, V, Compare, Alloc> > {
 template <typename K, typename V, typename Compare, typename Alloc>
 struct as<
     std::map<K, V, Compare, Alloc>,
-    typename std::enable_if<msgpack::has_as<K>::value && msgpack::has_as<V>::value>::type> {
+    typename std::enable_if<msgpack::has_as<K>::value || msgpack::has_as<V>::value>::type> {
     std::map<K, V, Compare, Alloc> operator()(msgpack::object const& o) const {
         if (o.type != msgpack::type::MAP) { throw msgpack::type_error(); }
         msgpack::object_kv* p(o.via.map.ptr);
@@ -222,7 +222,7 @@ struct object_with_zone<std::map<K, V, Compare, Alloc> > {
 template <typename K, typename V, typename Compare, typename Alloc>
 struct as<
     std::multimap<K, V, Compare, Alloc>,
-    typename std::enable_if<msgpack::has_as<K>::value && msgpack::has_as<V>::value>::type> {
+    typename std::enable_if<msgpack::has_as<K>::value || msgpack::has_as<V>::value>::type> {
     std::multimap<K, V, Compare, Alloc> operator()(msgpack::object const& o) const {
         if (o.type != msgpack::type::MAP) { throw msgpack::type_error(); }
         msgpack::object_kv* p(o.via.map.ptr);


### PR DESCRIPTION
In a C++11 project, I based my msgpack code on the example from `cpp11/non_def_non_class`.  I believe it is very elegant, as the only thing I have to do to adapt custom classes is implementing an as<>() method. That is really lovely!

Unfortunately, my code broke (tries to use the deleted default constructor) when I tried do the following

     obj.as<std::map<int, my> >()

The reason is that msgpack-C++ is not using the `as<std::map>()` implementation, but falls back to the `convert<std::map>()` implementation, because `has_as<int>` is `false`.  The proposed pull request fixes the problem, and adapts the `non_def_non_class` example to demonstrate the problem and its fix.