### PR TITLE
unpack: new msgpack_unpacker_next_with_size() function

### DIFF
--- a/include/msgpack/unpack.h
+++ b/include/msgpack/unpack.h
@@ -147,6 +147,18 @@ MSGPACK_DLLEXPORT
 msgpack_unpack_return msgpack_unpacker_next(msgpack_unpacker* mpac, msgpack_unpacked* pac);
 
 /**
+ * Deserializes one object and set the number of parsed bytes involved.
+ * Returns true if it successes. Otherwise false is returned.
+ * @param mpac    pointer to an initialized msgpack_unpacker object.
+ * @param result  pointer to an initialized msgpack_unpacked object.
+ * @param p_bytes pointer to variable that will be set with the number of parsed bytes.
+ */
+MSGPACK_DLLEXPORT
+msgpack_unpack_return msgpack_unpacker_next_with_size(msgpack_unpacker* mpac,
+                                                      msgpack_unpacked* result,
+                                                      size_t *p_bytes);
+
+/**
  * Initializes a msgpack_unpacked object.
  * The initialized object must be destroyed by msgpack_unpacked_destroy(msgpack_unpacker*).
  * Use the object with msgpack_unpacker_next(msgpack_unpacker*, msgpack_unpacked*) or
@@ -267,4 +279,3 @@ static inline msgpack_zone* msgpack_unpacked_release_zone(msgpack_unpacked* resu
 #endif
 
 #endif /* msgpack/unpack.h */
-

--- a/src/unpack.c
+++ b/src/unpack.c
@@ -510,7 +510,8 @@ void msgpack_unpacker_reset(msgpack_unpacker* mpac)
     mpac->parsed = 0;
 }
 
-msgpack_unpack_return msgpack_unpacker_next(msgpack_unpacker* mpac, msgpack_unpacked* result)
+static inline msgpack_unpack_return unpacker_next(msgpack_unpacker* mpac,
+                                                  msgpack_unpacked* result)
 {
     int ret;
 
@@ -529,11 +530,37 @@ msgpack_unpack_return msgpack_unpacker_next(msgpack_unpacker* mpac, msgpack_unpa
     }
     result->zone = msgpack_unpacker_release_zone(mpac);
     result->data = msgpack_unpacker_data(mpac);
-    msgpack_unpacker_reset(mpac);
 
     return MSGPACK_UNPACK_SUCCESS;
 }
 
+msgpack_unpack_return msgpack_unpacker_next(msgpack_unpacker* mpac,
+                                            msgpack_unpacked* result)
+{
+    int ret;
+
+    ret = unpacker_next(mpac, result);
+    if (ret == MSGPACK_UNPACK_SUCCESS) {
+        msgpack_unpacker_reset(mpac);
+    }
+
+    return ret;
+}
+
+msgpack_unpack_return
+msgpack_unpacker_next_with_size(msgpack_unpacker* mpac,
+                                msgpack_unpacked* result, size_t *p_bytes)
+{
+    int ret;
+
+    ret = unpacker_next(mpac, result);
+    if (ret == MSGPACK_UNPACK_SUCCESS) {
+        *p_bytes = mpac->parsed;
+        msgpack_unpacker_reset(mpac);
+    }
+
+    return ret;
+}
 
 msgpack_unpack_return
 msgpack_unpack(const char* data, size_t len, size_t* off,

--- a/src/unpack.c
+++ b/src/unpack.c
@@ -554,8 +554,11 @@ msgpack_unpacker_next_with_size(msgpack_unpacker* mpac,
     int ret;
 
     ret = unpacker_next(mpac, result);
-    if (ret == MSGPACK_UNPACK_SUCCESS) {
+    if (ret == MSGPACK_UNPACK_SUCCESS || ret == MSGPACK_UNPACK_CONTINUE) {
         *p_bytes = mpac->parsed;
+    }
+
+    if (ret == MSGPACK_UNPACK_SUCCESS) {
         msgpack_unpacker_reset(mpac);
     }
 


### PR DESCRIPTION
This new function is an extension of the original msgpack_unpacker_next()
where it now adds third argument to store the number of parsed bytes for
the returned buffer upon a MSGPACK_UNPACK_SUCCESS case.

This is useful for cases where the caller needs to optimize memory usage
in the original buffer,s so upon success retrieval of the object, it can
later deprecate the already 'parsed' bytes.

For more details about the origins of this function please refer to the
following issue on github:

  https://github.com/msgpack/msgpack-c/issues/514

Signed-off-by: Eduardo Silva <eduardo@treasure-data.com>