### PR TITLE
alignment: use proper alignment size

### DIFF
--- a/erb/v1/cpp03_define_array.hpp.erb
+++ b/erb/v1/cpp03_define_array.hpp.erb
@@ -73,7 +73,7 @@ struct define_array<A0<%1.upto(i) {|j|%>, A<%=j%><%}%>> {
     void msgpack_object(msgpack::object* o, msgpack::zone& z) const
     {
         o->type = msgpack::type::ARRAY;
-        o->via.array.ptr = static_cast<msgpack::object*>(z.allocate_align(sizeof(msgpack::object)*<%=i+1%>));
+        o->via.array.ptr = static_cast<msgpack::object*>(z.allocate_align(sizeof(msgpack::object)*<%=i+1%>, MSGPACK_ZONE_ALIGNOF(msgpack::object)));
         o->via.array.size = <%=i+1%>;
         <%0.upto(i) {|j|%>
         o->via.array.ptr[<%=j%>] = msgpack::object(a<%=j%>, z);<%}%>

--- a/erb/v1/cpp03_define_map.hpp.erb
+++ b/erb/v1/cpp03_define_map.hpp.erb
@@ -82,7 +82,7 @@ struct define_map<A0<%1.upto(i) {|j|%>, A<%=j%><%}%>> {
     void msgpack_object(msgpack::object* o, msgpack::zone& z) const
     {
         o->type = msgpack::type::MAP;
-        o->via.map.ptr = static_cast<msgpack::object_kv*>(z.allocate_align(sizeof(msgpack::object_kv)*<%=(i+1)/2%>));
+        o->via.map.ptr = static_cast<msgpack::object_kv*>(z.allocate_align(sizeof(msgpack::object_kv)*<%=(i+1)/2%>, MSGPACK_ZONE_ALIGNOF(msgpack::object_kv)));
         o->via.map.size = <%=(i+1)/2%>;
         <%0.step(i,2) {|j|%>
         o->via.map.ptr[<%=j/2%>].key = msgpack::object(a<%=j%>, z);

--- a/erb/v1/cpp03_msgpack_tuple.hpp.erb
+++ b/erb/v1/cpp03_msgpack_tuple.hpp.erb
@@ -207,7 +207,7 @@ struct object_with_zone<type::tuple<A0<%1.upto(i) {|j|%>, A<%=j%><%}%>> > {
         msgpack::object::with_zone& o,
         const type::tuple<A0<%1.upto(i) {|j|%>, A<%=j%><%}%>>& v) const {
         o.type = msgpack::type::ARRAY;
-        o.via.array.ptr = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object)*<%=i+1%>));
+        o.via.array.ptr = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object)*<%=i+1%>, MSGPACK_ZONE_ALIGNOF(msgpack::object)));
         o.via.array.size = <%=i+1%>;
         <%0.upto(i) {|j|%>
         o.via.array.ptr[<%=j%>] = msgpack::object(v.template get<<%=j%>>(), o.zone);<%}%>

--- a/erb/v1/cpp03_zone.hpp.erb
+++ b/erb/v1/cpp03_zone.hpp.erb
@@ -300,7 +300,7 @@ inline std::size_t aligned_size(
 template <typename T<%1.upto(i) {|j|%>, typename A<%=j%><%}%>>
 T* zone::allocate(<%=(1..i).map{|j|"A#{j} a#{j}"}.join(', ')%>)
 {
-    void* x = allocate_align(sizeof(T));
+    void* x = allocate_align(sizeof(T), MSGPACK_ZONE_ALIGNOF(T));
     try {
         m_finalizer_array.push(&zone::object_destruct<T>, x);
     } catch (...) {

--- a/example/cpp03/class_non_intrusive.cpp
+++ b/example/cpp03/class_non_intrusive.cpp
@@ -69,7 +69,7 @@ struct object_with_zone<my_class> {
         o.type = type::ARRAY;
         o.via.array.size = 2;
         o.via.array.ptr = static_cast<msgpack::object*>(
-            o.zone.allocate_align(sizeof(msgpack::object) * o.via.array.size));
+            o.zone.allocate_align(sizeof(msgpack::object) * o.via.array.size, MSGPACK_ZONE_ALIGNOF(msgpack::object)));
         o.via.array.ptr[0] = msgpack::object(v.get_name(), o.zone);
         o.via.array.ptr[1] = msgpack::object(v.get_age(), o.zone);
     }

--- a/include/msgpack/adaptor/tr1/unordered_map.hpp
+++ b/include/msgpack/adaptor/tr1/unordered_map.hpp
@@ -84,7 +84,7 @@ struct object_with_zone<MSGPACK_STD_TR1::unordered_map<K, V, Hash, Pred, Alloc> 
             o.via.map.size = 0;
         } else {
             uint32_t size = checked_get_container_size(v.size());
-            msgpack::object_kv* p = static_cast<msgpack::object_kv*>(o.zone.allocate_align(sizeof(msgpack::object_kv)*size));
+            msgpack::object_kv* p = static_cast<msgpack::object_kv*>(o.zone.allocate_align(sizeof(msgpack::object_kv)*size, MSGPACK_ZONE_ALIGNOF(msgpack::object_kv)));
             msgpack::object_kv* const pend = p + size;
             o.via.map.ptr  = p;
             o.via.map.size = size;
@@ -141,7 +141,7 @@ struct object_with_zone<MSGPACK_STD_TR1::unordered_multimap<K, V, Hash, Pred, Al
             o.via.map.size = 0;
         } else {
             uint32_t size = checked_get_container_size(v.size());
-            msgpack::object_kv* p = static_cast<msgpack::object_kv*>(o.zone.allocate_align(sizeof(msgpack::object_kv)*size));
+            msgpack::object_kv* p = static_cast<msgpack::object_kv*>(o.zone.allocate_align(sizeof(msgpack::object_kv)*size, MSGPACK_ZONE_ALIGNOF(msgpack::object_kv)));
             msgpack::object_kv* const pend = p + size;
             o.via.map.ptr  = p;
             o.via.map.size = size;

--- a/include/msgpack/adaptor/tr1/unordered_set.hpp
+++ b/include/msgpack/adaptor/tr1/unordered_set.hpp
@@ -82,7 +82,7 @@ struct object_with_zone<MSGPACK_STD_TR1::unordered_set<T, Hash, Compare, Alloc> 
             o.via.array.size = 0;
         } else {
             uint32_t size = checked_get_container_size(v.size());
-            msgpack::object* p = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object)*size));
+            msgpack::object* p = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object)*size, MSGPACK_ZONE_ALIGNOF(msgpack::object)));
             msgpack::object* const pend = p + size;
             o.via.array.ptr = p;
             o.via.array.size = size;
@@ -136,7 +136,7 @@ struct object_with_zone<MSGPACK_STD_TR1::unordered_multiset<T, Hash, Compare, Al
             o.via.array.size = 0;
         } else {
             uint32_t size = checked_get_container_size(v.size());
-            msgpack::object* p = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object)*size));
+            msgpack::object* p = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object)*size, MSGPACK_ZONE_ALIGNOF(msgpack::object)));
             msgpack::object* const pend = p + size;
             o.via.array.ptr = p;
             o.via.array.size = size;

--- a/include/msgpack/v1/adaptor/array_ref.hpp
+++ b/include/msgpack/v1/adaptor/array_ref.hpp
@@ -253,7 +253,7 @@ struct object_with_zone<msgpack::type::array_ref<T> > {
         }
         else {
             uint32_t size = checked_get_container_size(v.size());
-            msgpack::object* p = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object)*size));
+            msgpack::object* p = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object)*size, MSGPACK_ZONE_ALIGNOF(msgpack::object)));
             msgpack::object* const pend = p + size;
             o.via.array.ptr = p;
             o.via.array.size = size;
@@ -280,7 +280,7 @@ struct object_with_zone<msgpack::type::array_ref<T[N]> > {
         if (!v.data) { throw msgpack::type_error(); }
         o.type = msgpack::type::ARRAY;
         uint32_t size = checked_get_container_size(v.size());
-        msgpack::object* p = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object)*size));
+        msgpack::object* p = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object)*size, MSGPACK_ZONE_ALIGNOF(msgpack::object)));
         msgpack::object* const pend = p + size;
         o.via.array.ptr = p;
         o.via.array.size = size;

--- a/include/msgpack/v1/adaptor/boost/fusion.hpp
+++ b/include/msgpack/v1/adaptor/boost/fusion.hpp
@@ -132,7 +132,7 @@ struct object_with_zone<T, typename msgpack::enable_if<boost::fusion::traits::is
     void operator()(msgpack::object::with_zone& o, const T& v) const {
         uint32_t size = checked_get_container_size(boost::fusion::size(v));
         o.type = msgpack::type::ARRAY;
-        o.via.array.ptr = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object)*size));
+        o.via.array.ptr = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object)*size, MSGPACK_ZONE_ALIGNOF(msgpack::object)));
         o.via.array.size = size;
         uint32_t count = 0;
         boost::fusion::for_each(v, with_zone_imp(o, count));

--- a/include/msgpack/v1/adaptor/carray.hpp
+++ b/include/msgpack/v1/adaptor/carray.hpp
@@ -151,7 +151,7 @@ struct object_with_zone<T[N]> {
     void operator()(msgpack::object::with_zone& o, const T(&v)[N]) const {
         uint32_t size = checked_get_container_size(N);
         o.type = msgpack::type::ARRAY;
-        msgpack::object* ptr = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object) * size));
+        msgpack::object* ptr = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object) * size, MSGPACK_ZONE_ALIGNOF(msgpack::object)));
         o.via.array.ptr = ptr;
         o.via.array.size = size;
         const T* pv = v;

--- a/include/msgpack/v1/adaptor/cpp11/array.hpp
+++ b/include/msgpack/v1/adaptor/cpp11/array.hpp
@@ -119,7 +119,7 @@ struct object_with_zone<std::array<T, N>> {
             o.via.array.size = 0;
         } else {
             uint32_t size = checked_get_container_size(v.size());
-            msgpack::object* p = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object)*size));
+            msgpack::object* p = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object)*size, MSGPACK_ZONE_ALIGNOF(msgpack::object)));
             o.via.array.size = size;
             o.via.array.ptr = p;
             for (auto const& e : v) *p++ = msgpack::object(e, o.zone);

--- a/include/msgpack/v1/adaptor/cpp11/forward_list.hpp
+++ b/include/msgpack/v1/adaptor/cpp11/forward_list.hpp
@@ -76,7 +76,7 @@ struct object_with_zone<std::forward_list<T, Alloc>> {
             uint32_t size = checked_get_container_size(std::distance(v.begin(), v.end()));
             o.via.array.size = size;
             msgpack::object* p = static_cast<msgpack::object*>(
-                o.zone.allocate_align(sizeof(msgpack::object)*size));
+                o.zone.allocate_align(sizeof(msgpack::object)*size, MSGPACK_ZONE_ALIGNOF(msgpack::object)));
             o.via.array.ptr = p;
             for(auto const& e : v) *p++ = msgpack::object(e, o.zone);
         }

--- a/include/msgpack/v1/adaptor/cpp11/tuple.hpp
+++ b/include/msgpack/v1/adaptor/cpp11/tuple.hpp
@@ -158,7 +158,7 @@ struct object_with_zone<std::tuple<Args...>> {
         std::tuple<Args...> const& v) const {
         uint32_t size = checked_get_container_size(sizeof...(Args));
         o.type = msgpack::type::ARRAY;
-        o.via.array.ptr = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object)*size));
+        o.via.array.ptr = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object)*size, MSGPACK_ZONE_ALIGNOF(msgpack::object)));
         o.via.array.size = size;
         StdTupleToObjectWithZone<decltype(v), sizeof...(Args)>::convert(o, v);
     }

--- a/include/msgpack/v1/adaptor/cpp11/unordered_map.hpp
+++ b/include/msgpack/v1/adaptor/cpp11/unordered_map.hpp
@@ -81,7 +81,7 @@ struct object_with_zone<std::unordered_map<K, V, Hash, Compare, Alloc>> {
             o.via.map.size = 0;
         } else {
             uint32_t size = checked_get_container_size(v.size());
-            msgpack::object_kv* p = static_cast<msgpack::object_kv*>(o.zone.allocate_align(sizeof(msgpack::object_kv)*size));
+            msgpack::object_kv* p = static_cast<msgpack::object_kv*>(o.zone.allocate_align(sizeof(msgpack::object_kv)*size, MSGPACK_ZONE_ALIGNOF(msgpack::object_kv)));
             msgpack::object_kv* const pend = p + size;
             o.via.map.ptr  = p;
             o.via.map.size = size;
@@ -155,7 +155,7 @@ struct object_with_zone<std::unordered_multimap<K, V, Hash, Compare, Alloc>> {
             o.via.map.size = 0;
         } else {
             uint32_t size = checked_get_container_size(v.size());
-            msgpack::object_kv* p = static_cast<msgpack::object_kv*>(o.zone.allocate_align(sizeof(msgpack::object_kv)*size));
+            msgpack::object_kv* p = static_cast<msgpack::object_kv*>(o.zone.allocate_align(sizeof(msgpack::object_kv)*size, MSGPACK_ZONE_ALIGNOF(msgpack::object_kv)));
             msgpack::object_kv* const pend = p + size;
             o.via.map.ptr  = p;
             o.via.map.size = size;

--- a/include/msgpack/v1/adaptor/cpp11/unordered_set.hpp
+++ b/include/msgpack/v1/adaptor/cpp11/unordered_set.hpp
@@ -78,7 +78,7 @@ struct object_with_zone<std::unordered_set<Key, Hash, Compare, Alloc>> {
             o.via.array.size = 0;
         } else {
             uint32_t size = checked_get_container_size(v.size());
-            msgpack::object* p = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object)*size));
+            msgpack::object* p = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object)*size, MSGPACK_ZONE_ALIGNOF(msgpack::object)));
             msgpack::object* const pend = p + size;
             o.via.array.ptr = p;
             o.via.array.size = size;
@@ -147,7 +147,7 @@ struct object_with_zone<std::unordered_multiset<Key, Hash, Compare, Alloc>> {
             o.via.array.size = 0;
         } else {
             uint32_t size = checked_get_container_size(v.size());
-            msgpack::object* p = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object)*size));
+            msgpack::object* p = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object)*size, MSGPACK_ZONE_ALIGNOF(msgpack::object)));
             msgpack::object* const pend = p + size;
             o.via.array.ptr = p;
             o.via.array.size = size;

--- a/include/msgpack/v1/adaptor/deque.hpp
+++ b/include/msgpack/v1/adaptor/deque.hpp
@@ -83,7 +83,7 @@ struct object_with_zone<std::deque<T, Alloc> > {
             o.via.array.size = 0;
         } else {
             uint32_t size = checked_get_container_size(v.size());
-            msgpack::object* p = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object)*size));
+            msgpack::object* p = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object)*size, MSGPACK_ZONE_ALIGNOF(msgpack::object)));
             msgpack::object* const pend = p + size;
             o.via.array.ptr = p;
             o.via.array.size = size;

--- a/include/msgpack/v1/adaptor/detail/cpp03_define_array.hpp
+++ b/include/msgpack/v1/adaptor/detail/cpp03_define_array.hpp
@@ -73,7 +73,7 @@ struct define_array<A0> {
     void msgpack_object(msgpack::object* o, msgpack::zone& z) const
     {
         o->type = msgpack::type::ARRAY;
-        o->via.array.ptr = static_cast<msgpack::object*>(z.allocate_align(sizeof(msgpack::object)*1));
+        o->via.array.ptr = static_cast<msgpack::object*>(z.allocate_align(sizeof(msgpack::object)*1, MSGPACK_ZONE_ALIGNOF(msgpack::object)));
         o->via.array.size = 1;
         
         o->via.array.ptr[0] = msgpack::object(a0, z);
@@ -112,7 +112,7 @@ struct define_array<A0, A1> {
     void msgpack_object(msgpack::object* o, msgpack::zone& z) const
     {
         o->type = msgpack::type::ARRAY;
-        o->via.array.ptr = static_cast<msgpack::object*>(z.allocate_align(sizeof(msgpack::object)*2));
+        o->via.array.ptr = static_cast<msgpack::object*>(z.allocate_align(sizeof(msgpack::object)*2, MSGPACK_ZONE_ALIGNOF(msgpack::object)));
         o->via.array.size = 2;
         
         o->via.array.ptr[0] = msgpack::object(a0, z);
@@ -155,7 +155,7 @@ struct define_array<A0, A1, A2> {
     void msgpack_object(msgpack::object* o, msgpack::zone& z) const
     {
         o->type = msgpack::type::ARRAY;
-        o->via.array.ptr = static_cast<msgpack::object*>(z.allocate_align(sizeof(msgpack::object)*3));
+        o->via.array.ptr = static_cast<msgpack::object*>(z.allocate_align(sizeof(msgpack::object)*3, MSGPACK_ZONE_ALIGNOF(msgpack::object)));
         o->via.array.size = 3;
         
         o->via.array.ptr[0] = msgpack::object(a0, z);
@@ -202,7 +202,7 @@ struct define_array<A0, A1, A2, A3> {
     void msgpack_object(msgpack::object* o, msgpack::zone& z) const
     {
         o->type = msgpack::type::ARRAY;
-        o->via.array.ptr = static_cast<msgpack::object*>(z.allocate_align(sizeof(msgpack::object)*4));
+        o->via.array.ptr = static_cast<msgpack::object*>(z.allocate_align(sizeof(msgpack::object)*4, MSGPACK_ZONE_ALIGNOF(msgpack::object)));
         o->via.array.size = 4;
         
         o->via.array.ptr[0] = msgpack::object(a0, z);
@@ -253,7 +253,7 @@ struct define_array<A0, A1, A2, A3, A4> {
     void msgpack_object(msgpack::object* o, msgpack::zone& z) const
     {
         o->type = msgpack::type::ARRAY;
-        o->via.array.ptr = static_cast<msgpack::object*>(z.allocate_align(sizeof(msgpack::object)*5));
+        o->via.array.ptr = static_cast<msgpack::object*>(z.allocate_align(sizeof(msgpack::object)*5, MSGPACK_ZONE_ALIGNOF(msgpack::object)));
         o->via.array.size = 5;
         
         o->via.array.ptr[0] = msgpack::object(a0, z);
@@ -308,7 +308,7 @@ struct define_array<A0, A1, A2, A3, A4, A5> {
     void msgpack_object(msgpack::object* o, msgpack::zone& z) const
     {
         o->type = msgpack::type::ARRAY;
-        o->via.array.ptr = static_cast<msgpack::object*>(z.allocate_align(sizeof(msgpack::object)*6));
+        o->via.array.ptr = static_cast<msgpack::object*>(z.allocate_align(sizeof(msgpack::object)*6, MSGPACK_ZONE_ALIGNOF(msgpack::object)));
         o->via.array.size = 6;
         
         o->via.array.ptr[0] = msgpack::object(a0, z);
@@ -367,7 +367,7 @@ struct define_array<A0, A1, A2, A3, A4, A5, A6> {
     void msgpack_object(msgpack::object* o, msgpack::zone& z) const
     {
         o->type = msgpack::type::ARRAY;
-        o->via.array.ptr = static_cast<msgpack::object*>(z.allocate_align(sizeof(msgpack::object)*7));
+        o->via.array.ptr = static_cast<msgpack::object*>(z.allocate_align(sizeof(msgpack::object)*7, MSGPACK_ZONE_ALIGNOF(msgpack::object)));
         o->via.array.size = 7;
         
         o->via.array.ptr[0] = msgpack::object(a0, z);
@@ -430,7 +430,7 @@ struct define_array<A0, A1, A2, A3, A4, A5, A6, A7> {
     void msgpack_object(msgpack::object* o, msgpack::zone& z) const
     {
         o->type = msgpack::type::ARRAY;
-        o->via.array.ptr = static_cast<msgpack::object*>(z.allocate_align(sizeof(msgpack::object)*8));
+        o->via.array.ptr = static_cast<msgpack::object*>(z.allocate_align(sizeof(msgpack::object)*8, MSGPACK_ZONE_ALIGNOF(msgpack::object)));
         o->via.array.size = 8;
         
         o->via.array.ptr[0] = msgpack::object(a0, z);
@@ -497,7 +497,7 @@ struct define_array<A0, A1, A2, A3, A4, A5, A6, A7, A8> {
     void msgpack_object(msgpack::object* o, msgpack::zone& z) const
     {
         o->type = msgpack::type::ARRAY;
-        o->via.array.ptr = static_cast<msgpack::object*>(z.allocate_align(sizeof(msgpack::object)*9));
+        o->via.array.ptr = static_cast<msgpack::object*>(z.allocate_align(sizeof(msgpack::object)*9, MSGPACK_ZONE_ALIGNOF(msgpack::object)));
         o->via.array.size = 9;
         
         o->via.array.ptr[0] = msgpack::object(a0, z);
@@ -568,7 +568,7 @@ struct define_array<A0, A1, A2, A3, A4, A5, A6, A7, A8, A9> {
     void msgpack_object(msgpack::object* o, msgpack::zone& z) const
     {
         o->type = msgpack::type::ARRAY;
-        o->via.array.ptr = static_cast<msgpack::object*>(z.allocate_align(sizeof(msgpack::object)*10));
+        o->via.array.ptr = static_cast<msgpack::object*>(z.allocate_align(sizeof(msgpack::object)*10, MSGPACK_ZONE_ALIGNOF(msgpack::object)));
         o->via.array.size = 10;
         
         o->via.array.ptr[0] = msgpack::object(a0, z);
@@ -643,7 +643,7 @@ struct define_array<A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10> {
     void msgpack_object(msgpack::object* o, msgpack::zone& z) const
     {
         o->type = msgpack::type::ARRAY;
-        o->via.array.ptr = static_cast<msgpack::object*>(z.allocate_align(sizeof(msgpack::object)*11));
+        o->via.array.ptr = static_cast<msgpack::object*>(z.allocate_align(sizeof(msgpack::object)*11, MSGPACK_ZONE_ALIGNOF(msgpack::object)));
         o->via.array.size = 11;
         
         o->via.array.ptr[0] = msgpack::object(a0, z);
@@ -722,7 +722,7 @@ struct define_array<A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11> {
     void msgpack_object(msgpack::object* o, msgpack::zone& z) const
     {
         o->type = msgpack::type::ARRAY;
-        o->via.array.ptr = static_cast<msgpack::object*>(z.allocate_align(sizeof(msgpack::object)*12));
+        o->via.array.ptr = static_cast<msgpack::object*>(z.allocate_align(sizeof(msgpack::object)*12, MSGPACK_ZONE_ALIGNOF(msgpack::object)));
         o->via.array.size = 12;
         
         o->via.array.ptr[0] = msgpack::object(a0, z);
@@ -805,7 +805,7 @@ struct define_array<A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12> {
     void msgpack_object(msgpack::object* o, msgpack::zone& z) const
     {
         o->type = msgpack::type::ARRAY;
-        o->via.array.ptr = static_cast<msgpack::object*>(z.allocate_align(sizeof(msgpack::object)*13));
+        o->via.array.ptr = static_cast<msgpack::object*>(z.allocate_align(sizeof(msgpack::object)*13, MSGPACK_ZONE_ALIGNOF(msgpack::object)));
         o->via.array.size = 13;
         
         o->via.array.ptr[0] = msgpack::object(a0, z);
@@ -892,7 +892,7 @@ struct define_array<A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13> 
     void msgpack_object(msgpack::object* o, msgpack::zone& z) const
     {
         o->type = msgpack::type::ARRAY;
-        o->via.array.ptr = static_cast<msgpack::object*>(z.allocate_align(sizeof(msgpack::object)*14));
+        o->via.array.ptr = static_cast<msgpack::object*>(z.allocate_align(sizeof(msgpack::object)*14, MSGPACK_ZONE_ALIGNOF(msgpack::object)));
         o->via.array.size = 14;
         
         o->via.array.ptr[0] = msgpack::object(a0, z);
@@ -983,7 +983,7 @@ struct define_array<A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, 
     void msgpack_object(msgpack::object* o, msgpack::zone& z) const
     {
         o->type = msgpack::type::ARRAY;
-        o->via.array.ptr = static_cast<msgpack::object*>(z.allocate_align(sizeof(msgpack::object)*15));
+        o->via.array.ptr = static_cast<msgpack::object*>(z.allocate_align(sizeof(msgpack::object)*15, MSGPACK_ZONE_ALIGNOF(msgpack::object)));
         o->via.array.size = 15;
         
         o->via.array.ptr[0] = msgpack::object(a0, z);
@@ -1078,7 +1078,7 @@ struct define_array<A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, 
     void msgpack_object(msgpack::object* o, msgpack::zone& z) const
     {
         o->type = msgpack::type::ARRAY;
-        o->via.array.ptr = static_cast<msgpack::object*>(z.allocate_align(sizeof(msgpack::object)*16));
+        o->via.array.ptr = static_cast<msgpack::object*>(z.allocate_align(sizeof(msgpack::object)*16, MSGPACK_ZONE_ALIGNOF(msgpack::object)));
         o->via.array.size = 16;
         
         o->via.array.ptr[0] = msgpack::object(a0, z);
@@ -1177,7 +1177,7 @@ struct define_array<A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, 
     void msgpack_object(msgpack::object* o, msgpack::zone& z) const
     {
         o->type = msgpack::type::ARRAY;
-        o->via.array.ptr = static_cast<msgpack::object*>(z.allocate_align(sizeof(msgpack::object)*17));
+        o->via.array.ptr = static_cast<msgpack::object*>(z.allocate_align(sizeof(msgpack::object)*17, MSGPACK_ZONE_ALIGNOF(msgpack::object)));
         o->via.array.size = 17;
         
         o->via.array.ptr[0] = msgpack::object(a0, z);
@@ -1280,7 +1280,7 @@ struct define_array<A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, 
     void msgpack_object(msgpack::object* o, msgpack::zone& z) const
     {
         o->type = msgpack::type::ARRAY;
-        o->via.array.ptr = static_cast<msgpack::object*>(z.allocate_align(sizeof(msgpack::object)*18));
+        o->via.array.ptr = static_cast<msgpack::object*>(z.allocate_align(sizeof(msgpack::object)*18, MSGPACK_ZONE_ALIGNOF(msgpack::object)));
         o->via.array.size = 18;
         
         o->via.array.ptr[0] = msgpack::object(a0, z);
@@ -1387,7 +1387,7 @@ struct define_array<A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, 
     void msgpack_object(msgpack::object* o, msgpack::zone& z) const
     {
         o->type = msgpack::type::ARRAY;
-        o->via.array.ptr = static_cast<msgpack::object*>(z.allocate_align(sizeof(msgpack::object)*19));
+        o->via.array.ptr = static_cast<msgpack::object*>(z.allocate_align(sizeof(msgpack::object)*19, MSGPACK_ZONE_ALIGNOF(msgpack::object)));
         o->via.array.size = 19;
         
         o->via.array.ptr[0] = msgpack::object(a0, z);
@@ -1498,7 +1498,7 @@ struct define_array<A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, 
     void msgpack_object(msgpack::object* o, msgpack::zone& z) const
     {
         o->type = msgpack::type::ARRAY;
-        o->via.array.ptr = static_cast<msgpack::object*>(z.allocate_align(sizeof(msgpack::object)*20));
+        o->via.array.ptr = static_cast<msgpack::object*>(z.allocate_align(sizeof(msgpack::object)*20, MSGPACK_ZONE_ALIGNOF(msgpack::object)));
         o->via.array.size = 20;
         
         o->via.array.ptr[0] = msgpack::object(a0, z);
@@ -1613,7 +1613,7 @@ struct define_array<A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, 
     void msgpack_object(msgpack::object* o, msgpack::zone& z) const
     {
         o->type = msgpack::type::ARRAY;
-        o->via.array.ptr = static_cast<msgpack::object*>(z.allocate_align(sizeof(msgpack::object)*21));
+        o->via.array.ptr = static_cast<msgpack::object*>(z.allocate_align(sizeof(msgpack::object)*21, MSGPACK_ZONE_ALIGNOF(msgpack::object)));
         o->via.array.size = 21;
         
         o->via.array.ptr[0] = msgpack::object(a0, z);
@@ -1732,7 +1732,7 @@ struct define_array<A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, 
     void msgpack_object(msgpack::object* o, msgpack::zone& z) const
     {
         o->type = msgpack::type::ARRAY;
-        o->via.array.ptr = static_cast<msgpack::object*>(z.allocate_align(sizeof(msgpack::object)*22));
+        o->via.array.ptr = static_cast<msgpack::object*>(z.allocate_align(sizeof(msgpack::object)*22, MSGPACK_ZONE_ALIGNOF(msgpack::object)));
         o->via.array.size = 22;
         
         o->via.array.ptr[0] = msgpack::object(a0, z);
@@ -1855,7 +1855,7 @@ struct define_array<A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, 
     void msgpack_object(msgpack::object* o, msgpack::zone& z) const
     {
         o->type = msgpack::type::ARRAY;
-        o->via.array.ptr = static_cast<msgpack::object*>(z.allocate_align(sizeof(msgpack::object)*23));
+        o->via.array.ptr = static_cast<msgpack::object*>(z.allocate_align(sizeof(msgpack::object)*23, MSGPACK_ZONE_ALIGNOF(msgpack::object)));
         o->via.array.size = 23;
         
         o->via.array.ptr[0] = msgpack::object(a0, z);
@@ -1982,7 +1982,7 @@ struct define_array<A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, 
     void msgpack_object(msgpack::object* o, msgpack::zone& z) const
     {
         o->type = msgpack::type::ARRAY;
-        o->via.array.ptr = static_cast<msgpack::object*>(z.allocate_align(sizeof(msgpack::object)*24));
+        o->via.array.ptr = static_cast<msgpack::object*>(z.allocate_align(sizeof(msgpack::object)*24, MSGPACK_ZONE_ALIGNOF(msgpack::object)));
         o->via.array.size = 24;
         
         o->via.array.ptr[0] = msgpack::object(a0, z);
@@ -2113,7 +2113,7 @@ struct define_array<A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, 
     void msgpack_object(msgpack::object* o, msgpack::zone& z) const
     {
         o->type = msgpack::type::ARRAY;
-        o->via.array.ptr = static_cast<msgpack::object*>(z.allocate_align(sizeof(msgpack::object)*25));
+        o->via.array.ptr = static_cast<msgpack::object*>(z.allocate_align(sizeof(msgpack::object)*25, MSGPACK_ZONE_ALIGNOF(msgpack::object)));
         o->via.array.size = 25;
         
         o->via.array.ptr[0] = msgpack::object(a0, z);
@@ -2248,7 +2248,7 @@ struct define_array<A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, 
     void msgpack_object(msgpack::object* o, msgpack::zone& z) const
     {
         o->type = msgpack::type::ARRAY;
-        o->via.array.ptr = static_cast<msgpack::object*>(z.allocate_align(sizeof(msgpack::object)*26));
+        o->via.array.ptr = static_cast<msgpack::object*>(z.allocate_align(sizeof(msgpack::object)*26, MSGPACK_ZONE_ALIGNOF(msgpack::object)));
         o->via.array.size = 26;
         
         o->via.array.ptr[0] = msgpack::object(a0, z);
@@ -2387,7 +2387,7 @@ struct define_array<A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, 
     void msgpack_object(msgpack::object* o, msgpack::zone& z) const
     {
         o->type = msgpack::type::ARRAY;
-        o->via.array.ptr = static_cast<msgpack::object*>(z.allocate_align(sizeof(msgpack::object)*27));
+        o->via.array.ptr = static_cast<msgpack::object*>(z.allocate_align(sizeof(msgpack::object)*27, MSGPACK_ZONE_ALIGNOF(msgpack::object)));
         o->via.array.size = 27;
         
         o->via.array.ptr[0] = msgpack::object(a0, z);
@@ -2530,7 +2530,7 @@ struct define_array<A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, 
     void msgpack_object(msgpack::object* o, msgpack::zone& z) const
     {
         o->type = msgpack::type::ARRAY;
-        o->via.array.ptr = static_cast<msgpack::object*>(z.allocate_align(sizeof(msgpack::object)*28));
+        o->via.array.ptr = static_cast<msgpack::object*>(z.allocate_align(sizeof(msgpack::object)*28, MSGPACK_ZONE_ALIGNOF(msgpack::object)));
         o->via.array.size = 28;
         
         o->via.array.ptr[0] = msgpack::object(a0, z);
@@ -2677,7 +2677,7 @@ struct define_array<A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, 
     void msgpack_object(msgpack::object* o, msgpack::zone& z) const
     {
         o->type = msgpack::type::ARRAY;
-        o->via.array.ptr = static_cast<msgpack::object*>(z.allocate_align(sizeof(msgpack::object)*29));
+        o->via.array.ptr = static_cast<msgpack::object*>(z.allocate_align(sizeof(msgpack::object)*29, MSGPACK_ZONE_ALIGNOF(msgpack::object)));
         o->via.array.size = 29;
         
         o->via.array.ptr[0] = msgpack::object(a0, z);
@@ -2828,7 +2828,7 @@ struct define_array<A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, 
     void msgpack_object(msgpack::object* o, msgpack::zone& z) const
     {
         o->type = msgpack::type::ARRAY;
-        o->via.array.ptr = static_cast<msgpack::object*>(z.allocate_align(sizeof(msgpack::object)*30));
+        o->via.array.ptr = static_cast<msgpack::object*>(z.allocate_align(sizeof(msgpack::object)*30, MSGPACK_ZONE_ALIGNOF(msgpack::object)));
         o->via.array.size = 30;
         
         o->via.array.ptr[0] = msgpack::object(a0, z);
@@ -2983,7 +2983,7 @@ struct define_array<A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, 
     void msgpack_object(msgpack::object* o, msgpack::zone& z) const
     {
         o->type = msgpack::type::ARRAY;
-        o->via.array.ptr = static_cast<msgpack::object*>(z.allocate_align(sizeof(msgpack::object)*31));
+        o->via.array.ptr = static_cast<msgpack::object*>(z.allocate_align(sizeof(msgpack::object)*31, MSGPACK_ZONE_ALIGNOF(msgpack::object)));
         o->via.array.size = 31;
         
         o->via.array.ptr[0] = msgpack::object(a0, z);
@@ -3142,7 +3142,7 @@ struct define_array<A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, 
     void msgpack_object(msgpack::object* o, msgpack::zone& z) const
     {
         o->type = msgpack::type::ARRAY;
-        o->via.array.ptr = static_cast<msgpack::object*>(z.allocate_align(sizeof(msgpack::object)*32));
+        o->via.array.ptr = static_cast<msgpack::object*>(z.allocate_align(sizeof(msgpack::object)*32, MSGPACK_ZONE_ALIGNOF(msgpack::object)));
         o->via.array.size = 32;
         
         o->via.array.ptr[0] = msgpack::object(a0, z);

--- a/include/msgpack/v1/adaptor/detail/cpp03_define_map.hpp
+++ b/include/msgpack/v1/adaptor/detail/cpp03_define_map.hpp
@@ -83,7 +83,7 @@ struct define_map<A0, A1> {
     void msgpack_object(msgpack::object* o, msgpack::zone& z) const
     {
         o->type = msgpack::type::MAP;
-        o->via.map.ptr = static_cast<msgpack::object_kv*>(z.allocate_align(sizeof(msgpack::object_kv)*1));
+        o->via.map.ptr = static_cast<msgpack::object_kv*>(z.allocate_align(sizeof(msgpack::object_kv)*1, MSGPACK_ZONE_ALIGNOF(msgpack::object_kv)));
         o->via.map.size = 1;
         
         o->via.map.ptr[0].key = msgpack::object(a0, z);
@@ -142,7 +142,7 @@ struct define_map<A0, A1, A2, A3> {
     void msgpack_object(msgpack::object* o, msgpack::zone& z) const
     {
         o->type = msgpack::type::MAP;
-        o->via.map.ptr = static_cast<msgpack::object_kv*>(z.allocate_align(sizeof(msgpack::object_kv)*2));
+        o->via.map.ptr = static_cast<msgpack::object_kv*>(z.allocate_align(sizeof(msgpack::object_kv)*2, MSGPACK_ZONE_ALIGNOF(msgpack::object_kv)));
         o->via.map.size = 2;
         
         o->via.map.ptr[0].key = msgpack::object(a0, z);
@@ -215,7 +215,7 @@ struct define_map<A0, A1, A2, A3, A4, A5> {
     void msgpack_object(msgpack::object* o, msgpack::zone& z) const
     {
         o->type = msgpack::type::MAP;
-        o->via.map.ptr = static_cast<msgpack::object_kv*>(z.allocate_align(sizeof(msgpack::object_kv)*3));
+        o->via.map.ptr = static_cast<msgpack::object_kv*>(z.allocate_align(sizeof(msgpack::object_kv)*3, MSGPACK_ZONE_ALIGNOF(msgpack::object_kv)));
         o->via.map.size = 3;
         
         o->via.map.ptr[0].key = msgpack::object(a0, z);
@@ -302,7 +302,7 @@ struct define_map<A0, A1, A2, A3, A4, A5, A6, A7> {
     void msgpack_object(msgpack::object* o, msgpack::zone& z) const
     {
         o->type = msgpack::type::MAP;
-        o->via.map.ptr = static_cast<msgpack::object_kv*>(z.allocate_align(sizeof(msgpack::object_kv)*4));
+        o->via.map.ptr = static_cast<msgpack::object_kv*>(z.allocate_align(sizeof(msgpack::object_kv)*4, MSGPACK_ZONE_ALIGNOF(msgpack::object_kv)));
         o->via.map.size = 4;
         
         o->via.map.ptr[0].key = msgpack::object(a0, z);
@@ -403,7 +403,7 @@ struct define_map<A0, A1, A2, A3, A4, A5, A6, A7, A8, A9> {
     void msgpack_object(msgpack::object* o, msgpack::zone& z) const
     {
         o->type = msgpack::type::MAP;
-        o->via.map.ptr = static_cast<msgpack::object_kv*>(z.allocate_align(sizeof(msgpack::object_kv)*5));
+        o->via.map.ptr = static_cast<msgpack::object_kv*>(z.allocate_align(sizeof(msgpack::object_kv)*5, MSGPACK_ZONE_ALIGNOF(msgpack::object_kv)));
         o->via.map.size = 5;
         
         o->via.map.ptr[0].key = msgpack::object(a0, z);
@@ -518,7 +518,7 @@ struct define_map<A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11> {
     void msgpack_object(msgpack::object* o, msgpack::zone& z) const
     {
         o->type = msgpack::type::MAP;
-        o->via.map.ptr = static_cast<msgpack::object_kv*>(z.allocate_align(sizeof(msgpack::object_kv)*6));
+        o->via.map.ptr = static_cast<msgpack::object_kv*>(z.allocate_align(sizeof(msgpack::object_kv)*6, MSGPACK_ZONE_ALIGNOF(msgpack::object_kv)));
         o->via.map.size = 6;
         
         o->via.map.ptr[0].key = msgpack::object(a0, z);
@@ -647,7 +647,7 @@ struct define_map<A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13> {
     void msgpack_object(msgpack::object* o, msgpack::zone& z) const
     {
         o->type = msgpack::type::MAP;
-        o->via.map.ptr = static_cast<msgpack::object_kv*>(z.allocate_align(sizeof(msgpack::object_kv)*7));
+        o->via.map.ptr = static_cast<msgpack::object_kv*>(z.allocate_align(sizeof(msgpack::object_kv)*7, MSGPACK_ZONE_ALIGNOF(msgpack::object_kv)));
         o->via.map.size = 7;
         
         o->via.map.ptr[0].key = msgpack::object(a0, z);
@@ -790,7 +790,7 @@ struct define_map<A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
     void msgpack_object(msgpack::object* o, msgpack::zone& z) const
     {
         o->type = msgpack::type::MAP;
-        o->via.map.ptr = static_cast<msgpack::object_kv*>(z.allocate_align(sizeof(msgpack::object_kv)*8));
+        o->via.map.ptr = static_cast<msgpack::object_kv*>(z.allocate_align(sizeof(msgpack::object_kv)*8, MSGPACK_ZONE_ALIGNOF(msgpack::object_kv)));
         o->via.map.size = 8;
         
         o->via.map.ptr[0].key = msgpack::object(a0, z);
@@ -947,7 +947,7 @@ struct define_map<A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
     void msgpack_object(msgpack::object* o, msgpack::zone& z) const
     {
         o->type = msgpack::type::MAP;
-        o->via.map.ptr = static_cast<msgpack::object_kv*>(z.allocate_align(sizeof(msgpack::object_kv)*9));
+        o->via.map.ptr = static_cast<msgpack::object_kv*>(z.allocate_align(sizeof(msgpack::object_kv)*9, MSGPACK_ZONE_ALIGNOF(msgpack::object_kv)));
         o->via.map.size = 9;
         
         o->via.map.ptr[0].key = msgpack::object(a0, z);
@@ -1118,7 +1118,7 @@ struct define_map<A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
     void msgpack_object(msgpack::object* o, msgpack::zone& z) const
     {
         o->type = msgpack::type::MAP;
-        o->via.map.ptr = static_cast<msgpack::object_kv*>(z.allocate_align(sizeof(msgpack::object_kv)*10));
+        o->via.map.ptr = static_cast<msgpack::object_kv*>(z.allocate_align(sizeof(msgpack::object_kv)*10, MSGPACK_ZONE_ALIGNOF(msgpack::object_kv)));
         o->via.map.size = 10;
         
         o->via.map.ptr[0].key = msgpack::object(a0, z);
@@ -1303,7 +1303,7 @@ struct define_map<A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
     void msgpack_object(msgpack::object* o, msgpack::zone& z) const
     {
         o->type = msgpack::type::MAP;
-        o->via.map.ptr = static_cast<msgpack::object_kv*>(z.allocate_align(sizeof(msgpack::object_kv)*11));
+        o->via.map.ptr = static_cast<msgpack::object_kv*>(z.allocate_align(sizeof(msgpack::object_kv)*11, MSGPACK_ZONE_ALIGNOF(msgpack::object_kv)));
         o->via.map.size = 11;
         
         o->via.map.ptr[0].key = msgpack::object(a0, z);
@@ -1502,7 +1502,7 @@ struct define_map<A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
     void msgpack_object(msgpack::object* o, msgpack::zone& z) const
     {
         o->type = msgpack::type::MAP;
-        o->via.map.ptr = static_cast<msgpack::object_kv*>(z.allocate_align(sizeof(msgpack::object_kv)*12));
+        o->via.map.ptr = static_cast<msgpack::object_kv*>(z.allocate_align(sizeof(msgpack::object_kv)*12, MSGPACK_ZONE_ALIGNOF(msgpack::object_kv)));
         o->via.map.size = 12;
         
         o->via.map.ptr[0].key = msgpack::object(a0, z);
@@ -1715,7 +1715,7 @@ struct define_map<A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
     void msgpack_object(msgpack::object* o, msgpack::zone& z) const
     {
         o->type = msgpack::type::MAP;
-        o->via.map.ptr = static_cast<msgpack::object_kv*>(z.allocate_align(sizeof(msgpack::object_kv)*13));
+        o->via.map.ptr = static_cast<msgpack::object_kv*>(z.allocate_align(sizeof(msgpack::object_kv)*13, MSGPACK_ZONE_ALIGNOF(msgpack::object_kv)));
         o->via.map.size = 13;
         
         o->via.map.ptr[0].key = msgpack::object(a0, z);
@@ -1942,7 +1942,7 @@ struct define_map<A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
     void msgpack_object(msgpack::object* o, msgpack::zone& z) const
     {
         o->type = msgpack::type::MAP;
-        o->via.map.ptr = static_cast<msgpack::object_kv*>(z.allocate_align(sizeof(msgpack::object_kv)*14));
+        o->via.map.ptr = static_cast<msgpack::object_kv*>(z.allocate_align(sizeof(msgpack::object_kv)*14, MSGPACK_ZONE_ALIGNOF(msgpack::object_kv)));
         o->via.map.size = 14;
         
         o->via.map.ptr[0].key = msgpack::object(a0, z);
@@ -2183,7 +2183,7 @@ struct define_map<A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
     void msgpack_object(msgpack::object* o, msgpack::zone& z) const
     {
         o->type = msgpack::type::MAP;
-        o->via.map.ptr = static_cast<msgpack::object_kv*>(z.allocate_align(sizeof(msgpack::object_kv)*15));
+        o->via.map.ptr = static_cast<msgpack::object_kv*>(z.allocate_align(sizeof(msgpack::object_kv)*15, MSGPACK_ZONE_ALIGNOF(msgpack::object_kv)));
         o->via.map.size = 15;
         
         o->via.map.ptr[0].key = msgpack::object(a0, z);
@@ -2438,7 +2438,7 @@ struct define_map<A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
     void msgpack_object(msgpack::object* o, msgpack::zone& z) const
     {
         o->type = msgpack::type::MAP;
-        o->via.map.ptr = static_cast<msgpack::object_kv*>(z.allocate_align(sizeof(msgpack::object_kv)*16));
+        o->via.map.ptr = static_cast<msgpack::object_kv*>(z.allocate_align(sizeof(msgpack::object_kv)*16, MSGPACK_ZONE_ALIGNOF(msgpack::object_kv)));
         o->via.map.size = 16;
         
         o->via.map.ptr[0].key = msgpack::object(a0, z);

--- a/include/msgpack/v1/adaptor/detail/cpp03_msgpack_tuple.hpp
+++ b/include/msgpack/v1/adaptor/detail/cpp03_msgpack_tuple.hpp
@@ -13506,7 +13506,7 @@ struct object_with_zone<type::tuple<A0> > {
         msgpack::object::with_zone& o,
         const type::tuple<A0>& v) const {
         o.type = msgpack::type::ARRAY;
-        o.via.array.ptr = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object)*1));
+        o.via.array.ptr = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object)*1, MSGPACK_ZONE_ALIGNOF(msgpack::object)));
         o.via.array.size = 1;
         
         o.via.array.ptr[0] = msgpack::object(v.template get<0>(), o.zone);
@@ -13519,7 +13519,7 @@ struct object_with_zone<type::tuple<A0, A1> > {
         msgpack::object::with_zone& o,
         const type::tuple<A0, A1>& v) const {
         o.type = msgpack::type::ARRAY;
-        o.via.array.ptr = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object)*2));
+        o.via.array.ptr = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object)*2, MSGPACK_ZONE_ALIGNOF(msgpack::object)));
         o.via.array.size = 2;
         
         o.via.array.ptr[0] = msgpack::object(v.template get<0>(), o.zone);
@@ -13533,7 +13533,7 @@ struct object_with_zone<type::tuple<A0, A1, A2> > {
         msgpack::object::with_zone& o,
         const type::tuple<A0, A1, A2>& v) const {
         o.type = msgpack::type::ARRAY;
-        o.via.array.ptr = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object)*3));
+        o.via.array.ptr = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object)*3, MSGPACK_ZONE_ALIGNOF(msgpack::object)));
         o.via.array.size = 3;
         
         o.via.array.ptr[0] = msgpack::object(v.template get<0>(), o.zone);
@@ -13548,7 +13548,7 @@ struct object_with_zone<type::tuple<A0, A1, A2, A3> > {
         msgpack::object::with_zone& o,
         const type::tuple<A0, A1, A2, A3>& v) const {
         o.type = msgpack::type::ARRAY;
-        o.via.array.ptr = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object)*4));
+        o.via.array.ptr = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object)*4, MSGPACK_ZONE_ALIGNOF(msgpack::object)));
         o.via.array.size = 4;
         
         o.via.array.ptr[0] = msgpack::object(v.template get<0>(), o.zone);
@@ -13564,7 +13564,7 @@ struct object_with_zone<type::tuple<A0, A1, A2, A3, A4> > {
         msgpack::object::with_zone& o,
         const type::tuple<A0, A1, A2, A3, A4>& v) const {
         o.type = msgpack::type::ARRAY;
-        o.via.array.ptr = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object)*5));
+        o.via.array.ptr = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object)*5, MSGPACK_ZONE_ALIGNOF(msgpack::object)));
         o.via.array.size = 5;
         
         o.via.array.ptr[0] = msgpack::object(v.template get<0>(), o.zone);
@@ -13581,7 +13581,7 @@ struct object_with_zone<type::tuple<A0, A1, A2, A3, A4, A5> > {
         msgpack::object::with_zone& o,
         const type::tuple<A0, A1, A2, A3, A4, A5>& v) const {
         o.type = msgpack::type::ARRAY;
-        o.via.array.ptr = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object)*6));
+        o.via.array.ptr = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object)*6, MSGPACK_ZONE_ALIGNOF(msgpack::object)));
         o.via.array.size = 6;
         
         o.via.array.ptr[0] = msgpack::object(v.template get<0>(), o.zone);
@@ -13599,7 +13599,7 @@ struct object_with_zone<type::tuple<A0, A1, A2, A3, A4, A5, A6> > {
         msgpack::object::with_zone& o,
         const type::tuple<A0, A1, A2, A3, A4, A5, A6>& v) const {
         o.type = msgpack::type::ARRAY;
-        o.via.array.ptr = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object)*7));
+        o.via.array.ptr = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object)*7, MSGPACK_ZONE_ALIGNOF(msgpack::object)));
         o.via.array.size = 7;
         
         o.via.array.ptr[0] = msgpack::object(v.template get<0>(), o.zone);
@@ -13618,7 +13618,7 @@ struct object_with_zone<type::tuple<A0, A1, A2, A3, A4, A5, A6, A7> > {
         msgpack::object::with_zone& o,
         const type::tuple<A0, A1, A2, A3, A4, A5, A6, A7>& v) const {
         o.type = msgpack::type::ARRAY;
-        o.via.array.ptr = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object)*8));
+        o.via.array.ptr = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object)*8, MSGPACK_ZONE_ALIGNOF(msgpack::object)));
         o.via.array.size = 8;
         
         o.via.array.ptr[0] = msgpack::object(v.template get<0>(), o.zone);
@@ -13638,7 +13638,7 @@ struct object_with_zone<type::tuple<A0, A1, A2, A3, A4, A5, A6, A7, A8> > {
         msgpack::object::with_zone& o,
         const type::tuple<A0, A1, A2, A3, A4, A5, A6, A7, A8>& v) const {
         o.type = msgpack::type::ARRAY;
-        o.via.array.ptr = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object)*9));
+        o.via.array.ptr = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object)*9, MSGPACK_ZONE_ALIGNOF(msgpack::object)));
         o.via.array.size = 9;
         
         o.via.array.ptr[0] = msgpack::object(v.template get<0>(), o.zone);
@@ -13659,7 +13659,7 @@ struct object_with_zone<type::tuple<A0, A1, A2, A3, A4, A5, A6, A7, A8, A9> > {
         msgpack::object::with_zone& o,
         const type::tuple<A0, A1, A2, A3, A4, A5, A6, A7, A8, A9>& v) const {
         o.type = msgpack::type::ARRAY;
-        o.via.array.ptr = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object)*10));
+        o.via.array.ptr = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object)*10, MSGPACK_ZONE_ALIGNOF(msgpack::object)));
         o.via.array.size = 10;
         
         o.via.array.ptr[0] = msgpack::object(v.template get<0>(), o.zone);
@@ -13681,7 +13681,7 @@ struct object_with_zone<type::tuple<A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10>
         msgpack::object::with_zone& o,
         const type::tuple<A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10>& v) const {
         o.type = msgpack::type::ARRAY;
-        o.via.array.ptr = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object)*11));
+        o.via.array.ptr = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object)*11, MSGPACK_ZONE_ALIGNOF(msgpack::object)));
         o.via.array.size = 11;
         
         o.via.array.ptr[0] = msgpack::object(v.template get<0>(), o.zone);
@@ -13704,7 +13704,7 @@ struct object_with_zone<type::tuple<A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10,
         msgpack::object::with_zone& o,
         const type::tuple<A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11>& v) const {
         o.type = msgpack::type::ARRAY;
-        o.via.array.ptr = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object)*12));
+        o.via.array.ptr = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object)*12, MSGPACK_ZONE_ALIGNOF(msgpack::object)));
         o.via.array.size = 12;
         
         o.via.array.ptr[0] = msgpack::object(v.template get<0>(), o.zone);
@@ -13728,7 +13728,7 @@ struct object_with_zone<type::tuple<A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10,
         msgpack::object::with_zone& o,
         const type::tuple<A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12>& v) const {
         o.type = msgpack::type::ARRAY;
-        o.via.array.ptr = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object)*13));
+        o.via.array.ptr = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object)*13, MSGPACK_ZONE_ALIGNOF(msgpack::object)));
         o.via.array.size = 13;
         
         o.via.array.ptr[0] = msgpack::object(v.template get<0>(), o.zone);
@@ -13753,7 +13753,7 @@ struct object_with_zone<type::tuple<A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10,
         msgpack::object::with_zone& o,
         const type::tuple<A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13>& v) const {
         o.type = msgpack::type::ARRAY;
-        o.via.array.ptr = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object)*14));
+        o.via.array.ptr = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object)*14, MSGPACK_ZONE_ALIGNOF(msgpack::object)));
         o.via.array.size = 14;
         
         o.via.array.ptr[0] = msgpack::object(v.template get<0>(), o.zone);
@@ -13779,7 +13779,7 @@ struct object_with_zone<type::tuple<A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10,
         msgpack::object::with_zone& o,
         const type::tuple<A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14>& v) const {
         o.type = msgpack::type::ARRAY;
-        o.via.array.ptr = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object)*15));
+        o.via.array.ptr = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object)*15, MSGPACK_ZONE_ALIGNOF(msgpack::object)));
         o.via.array.size = 15;
         
         o.via.array.ptr[0] = msgpack::object(v.template get<0>(), o.zone);
@@ -13806,7 +13806,7 @@ struct object_with_zone<type::tuple<A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10,
         msgpack::object::with_zone& o,
         const type::tuple<A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15>& v) const {
         o.type = msgpack::type::ARRAY;
-        o.via.array.ptr = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object)*16));
+        o.via.array.ptr = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object)*16, MSGPACK_ZONE_ALIGNOF(msgpack::object)));
         o.via.array.size = 16;
         
         o.via.array.ptr[0] = msgpack::object(v.template get<0>(), o.zone);
@@ -13834,7 +13834,7 @@ struct object_with_zone<type::tuple<A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10,
         msgpack::object::with_zone& o,
         const type::tuple<A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16>& v) const {
         o.type = msgpack::type::ARRAY;
-        o.via.array.ptr = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object)*17));
+        o.via.array.ptr = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object)*17, MSGPACK_ZONE_ALIGNOF(msgpack::object)));
         o.via.array.size = 17;
         
         o.via.array.ptr[0] = msgpack::object(v.template get<0>(), o.zone);
@@ -13863,7 +13863,7 @@ struct object_with_zone<type::tuple<A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10,
         msgpack::object::with_zone& o,
         const type::tuple<A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17>& v) const {
         o.type = msgpack::type::ARRAY;
-        o.via.array.ptr = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object)*18));
+        o.via.array.ptr = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object)*18, MSGPACK_ZONE_ALIGNOF(msgpack::object)));
         o.via.array.size = 18;
         
         o.via.array.ptr[0] = msgpack::object(v.template get<0>(), o.zone);
@@ -13893,7 +13893,7 @@ struct object_with_zone<type::tuple<A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10,
         msgpack::object::with_zone& o,
         const type::tuple<A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18>& v) const {
         o.type = msgpack::type::ARRAY;
-        o.via.array.ptr = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object)*19));
+        o.via.array.ptr = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object)*19, MSGPACK_ZONE_ALIGNOF(msgpack::object)));
         o.via.array.size = 19;
         
         o.via.array.ptr[0] = msgpack::object(v.template get<0>(), o.zone);
@@ -13924,7 +13924,7 @@ struct object_with_zone<type::tuple<A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10,
         msgpack::object::with_zone& o,
         const type::tuple<A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19>& v) const {
         o.type = msgpack::type::ARRAY;
-        o.via.array.ptr = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object)*20));
+        o.via.array.ptr = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object)*20, MSGPACK_ZONE_ALIGNOF(msgpack::object)));
         o.via.array.size = 20;
         
         o.via.array.ptr[0] = msgpack::object(v.template get<0>(), o.zone);
@@ -13956,7 +13956,7 @@ struct object_with_zone<type::tuple<A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10,
         msgpack::object::with_zone& o,
         const type::tuple<A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20>& v) const {
         o.type = msgpack::type::ARRAY;
-        o.via.array.ptr = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object)*21));
+        o.via.array.ptr = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object)*21, MSGPACK_ZONE_ALIGNOF(msgpack::object)));
         o.via.array.size = 21;
         
         o.via.array.ptr[0] = msgpack::object(v.template get<0>(), o.zone);
@@ -13989,7 +13989,7 @@ struct object_with_zone<type::tuple<A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10,
         msgpack::object::with_zone& o,
         const type::tuple<A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21>& v) const {
         o.type = msgpack::type::ARRAY;
-        o.via.array.ptr = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object)*22));
+        o.via.array.ptr = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object)*22, MSGPACK_ZONE_ALIGNOF(msgpack::object)));
         o.via.array.size = 22;
         
         o.via.array.ptr[0] = msgpack::object(v.template get<0>(), o.zone);
@@ -14023,7 +14023,7 @@ struct object_with_zone<type::tuple<A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10,
         msgpack::object::with_zone& o,
         const type::tuple<A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21, A22>& v) const {
         o.type = msgpack::type::ARRAY;
-        o.via.array.ptr = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object)*23));
+        o.via.array.ptr = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object)*23, MSGPACK_ZONE_ALIGNOF(msgpack::object)));
         o.via.array.size = 23;
         
         o.via.array.ptr[0] = msgpack::object(v.template get<0>(), o.zone);
@@ -14058,7 +14058,7 @@ struct object_with_zone<type::tuple<A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10,
         msgpack::object::with_zone& o,
         const type::tuple<A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21, A22, A23>& v) const {
         o.type = msgpack::type::ARRAY;
-        o.via.array.ptr = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object)*24));
+        o.via.array.ptr = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object)*24, MSGPACK_ZONE_ALIGNOF(msgpack::object)));
         o.via.array.size = 24;
         
         o.via.array.ptr[0] = msgpack::object(v.template get<0>(), o.zone);
@@ -14094,7 +14094,7 @@ struct object_with_zone<type::tuple<A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10,
         msgpack::object::with_zone& o,
         const type::tuple<A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21, A22, A23, A24>& v) const {
         o.type = msgpack::type::ARRAY;
-        o.via.array.ptr = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object)*25));
+        o.via.array.ptr = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object)*25, MSGPACK_ZONE_ALIGNOF(msgpack::object)));
         o.via.array.size = 25;
         
         o.via.array.ptr[0] = msgpack::object(v.template get<0>(), o.zone);
@@ -14131,7 +14131,7 @@ struct object_with_zone<type::tuple<A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10,
         msgpack::object::with_zone& o,
         const type::tuple<A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21, A22, A23, A24, A25>& v) const {
         o.type = msgpack::type::ARRAY;
-        o.via.array.ptr = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object)*26));
+        o.via.array.ptr = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object)*26, MSGPACK_ZONE_ALIGNOF(msgpack::object)));
         o.via.array.size = 26;
         
         o.via.array.ptr[0] = msgpack::object(v.template get<0>(), o.zone);
@@ -14169,7 +14169,7 @@ struct object_with_zone<type::tuple<A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10,
         msgpack::object::with_zone& o,
         const type::tuple<A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21, A22, A23, A24, A25, A26>& v) const {
         o.type = msgpack::type::ARRAY;
-        o.via.array.ptr = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object)*27));
+        o.via.array.ptr = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object)*27, MSGPACK_ZONE_ALIGNOF(msgpack::object)));
         o.via.array.size = 27;
         
         o.via.array.ptr[0] = msgpack::object(v.template get<0>(), o.zone);
@@ -14208,7 +14208,7 @@ struct object_with_zone<type::tuple<A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10,
         msgpack::object::with_zone& o,
         const type::tuple<A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21, A22, A23, A24, A25, A26, A27>& v) const {
         o.type = msgpack::type::ARRAY;
-        o.via.array.ptr = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object)*28));
+        o.via.array.ptr = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object)*28, MSGPACK_ZONE_ALIGNOF(msgpack::object)));
         o.via.array.size = 28;
         
         o.via.array.ptr[0] = msgpack::object(v.template get<0>(), o.zone);
@@ -14248,7 +14248,7 @@ struct object_with_zone<type::tuple<A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10,
         msgpack::object::with_zone& o,
         const type::tuple<A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21, A22, A23, A24, A25, A26, A27, A28>& v) const {
         o.type = msgpack::type::ARRAY;
-        o.via.array.ptr = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object)*29));
+        o.via.array.ptr = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object)*29, MSGPACK_ZONE_ALIGNOF(msgpack::object)));
         o.via.array.size = 29;
         
         o.via.array.ptr[0] = msgpack::object(v.template get<0>(), o.zone);
@@ -14289,7 +14289,7 @@ struct object_with_zone<type::tuple<A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10,
         msgpack::object::with_zone& o,
         const type::tuple<A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21, A22, A23, A24, A25, A26, A27, A28, A29>& v) const {
         o.type = msgpack::type::ARRAY;
-        o.via.array.ptr = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object)*30));
+        o.via.array.ptr = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object)*30, MSGPACK_ZONE_ALIGNOF(msgpack::object)));
         o.via.array.size = 30;
         
         o.via.array.ptr[0] = msgpack::object(v.template get<0>(), o.zone);
@@ -14331,7 +14331,7 @@ struct object_with_zone<type::tuple<A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10,
         msgpack::object::with_zone& o,
         const type::tuple<A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21, A22, A23, A24, A25, A26, A27, A28, A29, A30>& v) const {
         o.type = msgpack::type::ARRAY;
-        o.via.array.ptr = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object)*31));
+        o.via.array.ptr = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object)*31, MSGPACK_ZONE_ALIGNOF(msgpack::object)));
         o.via.array.size = 31;
         
         o.via.array.ptr[0] = msgpack::object(v.template get<0>(), o.zone);
@@ -14374,7 +14374,7 @@ struct object_with_zone<type::tuple<A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10,
         msgpack::object::with_zone& o,
         const type::tuple<A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21, A22, A23, A24, A25, A26, A27, A28, A29, A30, A31>& v) const {
         o.type = msgpack::type::ARRAY;
-        o.via.array.ptr = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object)*32));
+        o.via.array.ptr = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object)*32, MSGPACK_ZONE_ALIGNOF(msgpack::object)));
         o.via.array.size = 32;
         
         o.via.array.ptr[0] = msgpack::object(v.template get<0>(), o.zone);

--- a/include/msgpack/v1/adaptor/detail/cpp11_define_array.hpp
+++ b/include/msgpack/v1/adaptor/detail/cpp11_define_array.hpp
@@ -77,7 +77,7 @@ struct define_array {
     void msgpack_object(msgpack::object* o, msgpack::zone& z) const
     {
         o->type = msgpack::type::ARRAY;
-        o->via.array.ptr = static_cast<msgpack::object*>(z.allocate_align(sizeof(msgpack::object)*sizeof...(Args)));
+        o->via.array.ptr = static_cast<msgpack::object*>(z.allocate_align(sizeof(msgpack::object)*sizeof...(Args), MSGPACK_ZONE_ALIGNOF(msgpack::object)));
         o->via.array.size = sizeof...(Args);
 
         define_array_imp<std::tuple<Args&...>, sizeof...(Args)>::object(o, z, a);

--- a/include/msgpack/v1/adaptor/detail/cpp11_define_map.hpp
+++ b/include/msgpack/v1/adaptor/detail/cpp11_define_map.hpp
@@ -83,7 +83,7 @@ struct define_map {
     {
         static_assert(sizeof...(Args) % 2 == 0, "");
         o->type = msgpack::type::MAP;
-        o->via.map.ptr = static_cast<msgpack::object_kv*>(z.allocate_align(sizeof(msgpack::object_kv)*sizeof...(Args)/2));
+        o->via.map.ptr = static_cast<msgpack::object_kv*>(z.allocate_align(sizeof(msgpack::object_kv)*sizeof...(Args)/2, MSGPACK_ZONE_ALIGNOF(msgpack::object_kv)));
         o->via.map.size = sizeof...(Args) / 2;
 
         define_map_imp<std::tuple<Args&...>, sizeof...(Args)>::object(o, z, a);

--- a/include/msgpack/v1/adaptor/detail/cpp11_msgpack_tuple.hpp
+++ b/include/msgpack/v1/adaptor/detail/cpp11_msgpack_tuple.hpp
@@ -203,7 +203,7 @@ template <typename... Args>
         msgpack::object::with_zone& o,
         msgpack::type::tuple<Args...> const& v) const {
         o.type = msgpack::type::ARRAY;
-        o.via.array.ptr = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object)*sizeof...(Args)));
+        o.via.array.ptr = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object)*sizeof...(Args), MSGPACK_ZONE_ALIGNOF(msgpack::object)));
         o.via.array.size = sizeof...(Args);
         MsgpackTupleToObjectWithZone<decltype(v), sizeof...(Args)>::convert(o, v);
     }

--- a/include/msgpack/v1/adaptor/list.hpp
+++ b/include/msgpack/v1/adaptor/list.hpp
@@ -81,7 +81,7 @@ struct object_with_zone<std::list<T, Alloc> > {
         }
         else {
             uint32_t size = checked_get_container_size(v.size());
-            msgpack::object* p = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object)*size));
+            msgpack::object* p = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object)*size, MSGPACK_ZONE_ALIGNOF(msgpack::object)));
             msgpack::object* const pend = p + size;
             o.via.array.ptr = p;
             o.via.array.size = size;

--- a/include/msgpack/v1/adaptor/map.hpp
+++ b/include/msgpack/v1/adaptor/map.hpp
@@ -109,7 +109,7 @@ struct object_with_zone<type::assoc_vector<K, V, Compare, Alloc> > {
         }
         else {
             uint32_t size = checked_get_container_size(v.size());
-            msgpack::object_kv* p = static_cast<msgpack::object_kv*>(o.zone.allocate_align(sizeof(msgpack::object_kv)*size));
+            msgpack::object_kv* p = static_cast<msgpack::object_kv*>(o.zone.allocate_align(sizeof(msgpack::object_kv)*size, MSGPACK_ZONE_ALIGNOF(msgpack::object_kv)));
             msgpack::object_kv* const pend = p + size;
             o.via.map.ptr  = p;
             o.via.map.size = size;
@@ -195,7 +195,7 @@ struct object_with_zone<std::map<K, V, Compare, Alloc> > {
         else {
             uint32_t size = checked_get_container_size(v.size());
 
-            msgpack::object_kv* p = static_cast<msgpack::object_kv*>(o.zone.allocate_align(sizeof(msgpack::object_kv)*size));
+            msgpack::object_kv* p = static_cast<msgpack::object_kv*>(o.zone.allocate_align(sizeof(msgpack::object_kv)*size, MSGPACK_ZONE_ALIGNOF(msgpack::object_kv)));
             msgpack::object_kv* const pend = p + size;
             o.via.map.ptr  = p;
             o.via.map.size = size;
@@ -288,7 +288,7 @@ struct object_with_zone<std::multimap<K, V, Compare, Alloc> > {
         }
         else {
             uint32_t size = checked_get_container_size(v.size());
-            msgpack::object_kv* p = static_cast<msgpack::object_kv*>(o.zone.allocate_align(sizeof(msgpack::object_kv)*size));
+            msgpack::object_kv* p = static_cast<msgpack::object_kv*>(o.zone.allocate_align(sizeof(msgpack::object_kv)*size, MSGPACK_ZONE_ALIGNOF(msgpack::object_kv)));
             msgpack::object_kv* const pend = p + size;
             o.via.map.ptr  = p;
             o.via.map.size = size;

--- a/include/msgpack/v1/adaptor/pair.hpp
+++ b/include/msgpack/v1/adaptor/pair.hpp
@@ -64,7 +64,7 @@ template <typename T1, typename T2>
 struct object_with_zone<std::pair<T1, T2> > {
     void operator()(msgpack::object::with_zone& o, const std::pair<T1, T2>& v) const {
         o.type = msgpack::type::ARRAY;
-        msgpack::object* p = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object)*2));
+        msgpack::object* p = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object)*2, MSGPACK_ZONE_ALIGNOF(msgpack::object)));
         o.via.array.ptr = p;
         o.via.array.size = 2;
         p[0] = msgpack::object(v.first, o.zone);

--- a/include/msgpack/v1/adaptor/set.hpp
+++ b/include/msgpack/v1/adaptor/set.hpp
@@ -87,7 +87,7 @@ struct object_with_zone<std::set<T, Compare, Alloc> > {
         }
         else {
             uint32_t size = checked_get_container_size(v.size());
-            msgpack::object* p = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object)*size));
+            msgpack::object* p = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object)*size, MSGPACK_ZONE_ALIGNOF(msgpack::object)));
             msgpack::object* const pend = p + size;
             o.via.array.ptr = p;
             o.via.array.size = size;
@@ -163,7 +163,7 @@ struct object_with_zone<std::multiset<T, Compare, Alloc> > {
             o.via.array.size = 0;
         } else {
             uint32_t size = checked_get_container_size(v.size());
-            msgpack::object* p = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object)*size));
+            msgpack::object* p = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object)*size, MSGPACK_ZONE_ALIGNOF(msgpack::object)));
             msgpack::object* const pend = p + size;
             o.via.array.ptr = p;
             o.via.array.size = size;

--- a/include/msgpack/v1/adaptor/tr1/unordered_map.hpp
+++ b/include/msgpack/v1/adaptor/tr1/unordered_map.hpp
@@ -84,7 +84,7 @@ struct object_with_zone<MSGPACK_STD_TR1::unordered_map<K, V, Hash, Pred, Alloc> 
             o.via.map.size = 0;
         } else {
             uint32_t size = checked_get_container_size(v.size());
-            msgpack::object_kv* p = static_cast<msgpack::object_kv*>(o.zone.allocate_align(sizeof(msgpack::object_kv)*size));
+            msgpack::object_kv* p = static_cast<msgpack::object_kv*>(o.zone.allocate_align(sizeof(msgpack::object_kv)*size, MSGPACK_ZONE_ALIGNOF(msgpack::object_kv)));
             msgpack::object_kv* const pend = p + size;
             o.via.map.ptr  = p;
             o.via.map.size = size;
@@ -141,7 +141,7 @@ struct object_with_zone<MSGPACK_STD_TR1::unordered_multimap<K, V, Hash, Pred, Al
             o.via.map.size = 0;
         } else {
             uint32_t size = checked_get_container_size(v.size());
-            msgpack::object_kv* p = static_cast<msgpack::object_kv*>(o.zone.allocate_align(sizeof(msgpack::object_kv)*size));
+            msgpack::object_kv* p = static_cast<msgpack::object_kv*>(o.zone.allocate_align(sizeof(msgpack::object_kv)*size, MSGPACK_ZONE_ALIGNOF(msgpack::object_kv)));
             msgpack::object_kv* const pend = p + size;
             o.via.map.ptr  = p;
             o.via.map.size = size;

--- a/include/msgpack/v1/adaptor/tr1/unordered_set.hpp
+++ b/include/msgpack/v1/adaptor/tr1/unordered_set.hpp
@@ -82,7 +82,7 @@ struct object_with_zone<MSGPACK_STD_TR1::unordered_set<T, Hash, Compare, Alloc> 
             o.via.array.size = 0;
         } else {
             uint32_t size = checked_get_container_size(v.size());
-            msgpack::object* p = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object)*size));
+            msgpack::object* p = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object)*size, MSGPACK_ZONE_ALIGNOF(msgpack::object)));
             msgpack::object* const pend = p + size;
             o.via.array.ptr = p;
             o.via.array.size = size;
@@ -136,7 +136,7 @@ struct object_with_zone<MSGPACK_STD_TR1::unordered_multiset<T, Hash, Compare, Al
             o.via.array.size = 0;
         } else {
             uint32_t size = checked_get_container_size(v.size());
-            msgpack::object* p = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object)*size));
+            msgpack::object* p = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object)*size, MSGPACK_ZONE_ALIGNOF(msgpack::object)));
             msgpack::object* const pend = p + size;
             o.via.array.ptr = p;
             o.via.array.size = size;

--- a/include/msgpack/v1/adaptor/vector.hpp
+++ b/include/msgpack/v1/adaptor/vector.hpp
@@ -89,7 +89,7 @@ struct object_with_zone<std::vector<T, Alloc> > {
         }
         else {
             uint32_t size = checked_get_container_size(v.size());
-            msgpack::object* p = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object)*size));
+            msgpack::object* p = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object)*size, MSGPACK_ZONE_ALIGNOF(msgpack::object)));
             msgpack::object* const pend = p + size;
             o.via.array.ptr = p;
             o.via.array.size = size;

--- a/include/msgpack/v1/adaptor/vector_bool.hpp
+++ b/include/msgpack/v1/adaptor/vector_bool.hpp
@@ -65,7 +65,7 @@ struct object_with_zone<std::vector<bool, Alloc> > {
             o.via.array.size = 0;
         } else {
             uint32_t size = checked_get_container_size(v.size());
-            msgpack::object* p = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object)*size));
+            msgpack::object* p = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object)*size, MSGPACK_ZONE_ALIGNOF(msgpack::object)));
             msgpack::object* const pend = p + size;
             o.via.array.ptr = p;
             o.via.array.size = size;

--- a/include/msgpack/v1/detail/cpp03_zone.hpp
+++ b/include/msgpack/v1/detail/cpp03_zone.hpp
@@ -345,7 +345,7 @@ inline std::size_t aligned_size(
 template <typename T>
 T* zone::allocate()
 {
-    void* x = allocate_align(sizeof(T));
+    void* x = allocate_align(sizeof(T), MSGPACK_ZONE_ALIGNOF(T));
     try {
         m_finalizer_array.push(&zone::object_destruct<T>, x);
     } catch (...) {
@@ -364,7 +364,7 @@ T* zone::allocate()
 template <typename T, typename A1>
 T* zone::allocate(A1 a1)
 {
-    void* x = allocate_align(sizeof(T));
+    void* x = allocate_align(sizeof(T), MSGPACK_ZONE_ALIGNOF(T));
     try {
         m_finalizer_array.push(&zone::object_destruct<T>, x);
     } catch (...) {
@@ -383,7 +383,7 @@ T* zone::allocate(A1 a1)
 template <typename T, typename A1, typename A2>
 T* zone::allocate(A1 a1, A2 a2)
 {
-    void* x = allocate_align(sizeof(T));
+    void* x = allocate_align(sizeof(T), MSGPACK_ZONE_ALIGNOF(T));
     try {
         m_finalizer_array.push(&zone::object_destruct<T>, x);
     } catch (...) {
@@ -402,7 +402,7 @@ T* zone::allocate(A1 a1, A2 a2)
 template <typename T, typename A1, typename A2, typename A3>
 T* zone::allocate(A1 a1, A2 a2, A3 a3)
 {
-    void* x = allocate_align(sizeof(T));
+    void* x = allocate_align(sizeof(T), MSGPACK_ZONE_ALIGNOF(T));
     try {
         m_finalizer_array.push(&zone::object_destruct<T>, x);
     } catch (...) {
@@ -421,7 +421,7 @@ T* zone::allocate(A1 a1, A2 a2, A3 a3)
 template <typename T, typename A1, typename A2, typename A3, typename A4>
 T* zone::allocate(A1 a1, A2 a2, A3 a3, A4 a4)
 {
-    void* x = allocate_align(sizeof(T));
+    void* x = allocate_align(sizeof(T), MSGPACK_ZONE_ALIGNOF(T));
     try {
         m_finalizer_array.push(&zone::object_destruct<T>, x);
     } catch (...) {
@@ -440,7 +440,7 @@ T* zone::allocate(A1 a1, A2 a2, A3 a3, A4 a4)
 template <typename T, typename A1, typename A2, typename A3, typename A4, typename A5>
 T* zone::allocate(A1 a1, A2 a2, A3 a3, A4 a4, A5 a5)
 {
-    void* x = allocate_align(sizeof(T));
+    void* x = allocate_align(sizeof(T), MSGPACK_ZONE_ALIGNOF(T));
     try {
         m_finalizer_array.push(&zone::object_destruct<T>, x);
     } catch (...) {
@@ -459,7 +459,7 @@ T* zone::allocate(A1 a1, A2 a2, A3 a3, A4 a4, A5 a5)
 template <typename T, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6>
 T* zone::allocate(A1 a1, A2 a2, A3 a3, A4 a4, A5 a5, A6 a6)
 {
-    void* x = allocate_align(sizeof(T));
+    void* x = allocate_align(sizeof(T), MSGPACK_ZONE_ALIGNOF(T));
     try {
         m_finalizer_array.push(&zone::object_destruct<T>, x);
     } catch (...) {
@@ -478,7 +478,7 @@ T* zone::allocate(A1 a1, A2 a2, A3 a3, A4 a4, A5 a5, A6 a6)
 template <typename T, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7>
 T* zone::allocate(A1 a1, A2 a2, A3 a3, A4 a4, A5 a5, A6 a6, A7 a7)
 {
-    void* x = allocate_align(sizeof(T));
+    void* x = allocate_align(sizeof(T), MSGPACK_ZONE_ALIGNOF(T));
     try {
         m_finalizer_array.push(&zone::object_destruct<T>, x);
     } catch (...) {
@@ -497,7 +497,7 @@ T* zone::allocate(A1 a1, A2 a2, A3 a3, A4 a4, A5 a5, A6 a6, A7 a7)
 template <typename T, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7, typename A8>
 T* zone::allocate(A1 a1, A2 a2, A3 a3, A4 a4, A5 a5, A6 a6, A7 a7, A8 a8)
 {
-    void* x = allocate_align(sizeof(T));
+    void* x = allocate_align(sizeof(T), MSGPACK_ZONE_ALIGNOF(T));
     try {
         m_finalizer_array.push(&zone::object_destruct<T>, x);
     } catch (...) {
@@ -516,7 +516,7 @@ T* zone::allocate(A1 a1, A2 a2, A3 a3, A4 a4, A5 a5, A6 a6, A7 a7, A8 a8)
 template <typename T, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7, typename A8, typename A9>
 T* zone::allocate(A1 a1, A2 a2, A3 a3, A4 a4, A5 a5, A6 a6, A7 a7, A8 a8, A9 a9)
 {
-    void* x = allocate_align(sizeof(T));
+    void* x = allocate_align(sizeof(T), MSGPACK_ZONE_ALIGNOF(T));
     try {
         m_finalizer_array.push(&zone::object_destruct<T>, x);
     } catch (...) {
@@ -535,7 +535,7 @@ T* zone::allocate(A1 a1, A2 a2, A3 a3, A4 a4, A5 a5, A6 a6, A7 a7, A8 a8, A9 a9)
 template <typename T, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7, typename A8, typename A9, typename A10>
 T* zone::allocate(A1 a1, A2 a2, A3 a3, A4 a4, A5 a5, A6 a6, A7 a7, A8 a8, A9 a9, A10 a10)
 {
-    void* x = allocate_align(sizeof(T));
+    void* x = allocate_align(sizeof(T), MSGPACK_ZONE_ALIGNOF(T));
     try {
         m_finalizer_array.push(&zone::object_destruct<T>, x);
     } catch (...) {
@@ -554,7 +554,7 @@ T* zone::allocate(A1 a1, A2 a2, A3 a3, A4 a4, A5 a5, A6 a6, A7 a7, A8 a8, A9 a9,
 template <typename T, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7, typename A8, typename A9, typename A10, typename A11>
 T* zone::allocate(A1 a1, A2 a2, A3 a3, A4 a4, A5 a5, A6 a6, A7 a7, A8 a8, A9 a9, A10 a10, A11 a11)
 {
-    void* x = allocate_align(sizeof(T));
+    void* x = allocate_align(sizeof(T), MSGPACK_ZONE_ALIGNOF(T));
     try {
         m_finalizer_array.push(&zone::object_destruct<T>, x);
     } catch (...) {
@@ -573,7 +573,7 @@ T* zone::allocate(A1 a1, A2 a2, A3 a3, A4 a4, A5 a5, A6 a6, A7 a7, A8 a8, A9 a9,
 template <typename T, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7, typename A8, typename A9, typename A10, typename A11, typename A12>
 T* zone::allocate(A1 a1, A2 a2, A3 a3, A4 a4, A5 a5, A6 a6, A7 a7, A8 a8, A9 a9, A10 a10, A11 a11, A12 a12)
 {
-    void* x = allocate_align(sizeof(T));
+    void* x = allocate_align(sizeof(T), MSGPACK_ZONE_ALIGNOF(T));
     try {
         m_finalizer_array.push(&zone::object_destruct<T>, x);
     } catch (...) {
@@ -592,7 +592,7 @@ T* zone::allocate(A1 a1, A2 a2, A3 a3, A4 a4, A5 a5, A6 a6, A7 a7, A8 a8, A9 a9,
 template <typename T, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7, typename A8, typename A9, typename A10, typename A11, typename A12, typename A13>
 T* zone::allocate(A1 a1, A2 a2, A3 a3, A4 a4, A5 a5, A6 a6, A7 a7, A8 a8, A9 a9, A10 a10, A11 a11, A12 a12, A13 a13)
 {
-    void* x = allocate_align(sizeof(T));
+    void* x = allocate_align(sizeof(T), MSGPACK_ZONE_ALIGNOF(T));
     try {
         m_finalizer_array.push(&zone::object_destruct<T>, x);
     } catch (...) {
@@ -611,7 +611,7 @@ T* zone::allocate(A1 a1, A2 a2, A3 a3, A4 a4, A5 a5, A6 a6, A7 a7, A8 a8, A9 a9,
 template <typename T, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7, typename A8, typename A9, typename A10, typename A11, typename A12, typename A13, typename A14>
 T* zone::allocate(A1 a1, A2 a2, A3 a3, A4 a4, A5 a5, A6 a6, A7 a7, A8 a8, A9 a9, A10 a10, A11 a11, A12 a12, A13 a13, A14 a14)
 {
-    void* x = allocate_align(sizeof(T));
+    void* x = allocate_align(sizeof(T), MSGPACK_ZONE_ALIGNOF(T));
     try {
         m_finalizer_array.push(&zone::object_destruct<T>, x);
     } catch (...) {
@@ -630,7 +630,7 @@ T* zone::allocate(A1 a1, A2 a2, A3 a3, A4 a4, A5 a5, A6 a6, A7 a7, A8 a8, A9 a9,
 template <typename T, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7, typename A8, typename A9, typename A10, typename A11, typename A12, typename A13, typename A14, typename A15>
 T* zone::allocate(A1 a1, A2 a2, A3 a3, A4 a4, A5 a5, A6 a6, A7 a7, A8 a8, A9 a9, A10 a10, A11 a11, A12 a12, A13 a13, A14 a14, A15 a15)
 {
-    void* x = allocate_align(sizeof(T));
+    void* x = allocate_align(sizeof(T), MSGPACK_ZONE_ALIGNOF(T));
     try {
         m_finalizer_array.push(&zone::object_destruct<T>, x);
     } catch (...) {

--- a/include/msgpack/v1/detail/cpp03_zone_decl.hpp
+++ b/include/msgpack/v1/detail/cpp03_zone_decl.hpp
@@ -24,6 +24,11 @@
 #define MSGPACK_ZONE_ALIGN sizeof(void*)
 #endif
 
+#if defined(_MSC_VER)
+#define MSGPACK_ZONE_ALIGNOF(type) __alignof(type)
+#else
+#define MSGPACK_ZONE_ALIGNOF(type) __alignof__(type)
+#endif
 
 namespace msgpack {
 

--- a/include/msgpack/v1/detail/cpp11_zone.hpp
+++ b/include/msgpack/v1/detail/cpp11_zone.hpp
@@ -184,7 +184,6 @@ public:
 
     void swap(zone& o);
 
-
     static void* operator new(std::size_t size)
     {
         void* p = ::malloc(size);
@@ -329,7 +328,7 @@ inline void zone::undo_allocate(size_t size)
 template <typename T, typename... Args>
 T* zone::allocate(Args... args)
 {
-    void* x = allocate_align(sizeof(T));
+    void* x = allocate_align(sizeof(T), MSGPACK_ZONE_ALIGNOF(T));
     try {
         m_finalizer_array.push(&zone::object_destruct<T>, x);
     } catch (...) {

--- a/include/msgpack/v1/detail/cpp11_zone_decl.hpp
+++ b/include/msgpack/v1/detail/cpp11_zone_decl.hpp
@@ -26,6 +26,12 @@
 #define MSGPACK_ZONE_ALIGN sizeof(void*)
 #endif
 
+#if defined(_MSC_VER)
+#define MSGPACK_ZONE_ALIGNOF(type) __alignof(type)
+#else
+#define MSGPACK_ZONE_ALIGNOF(type) __alignof__(type)
+#endif
+
 namespace msgpack {
 
 /// @cond

--- a/include/msgpack/v1/object.hpp
+++ b/include/msgpack/v1/object.hpp
@@ -155,13 +155,14 @@ inline std::size_t aligned_zone_size(msgpack::object const& obj) {
         break;
     case msgpack::type::EXT:
         s += msgpack::aligned_size(
-            detail::add_ext_type_size<sizeof(std::size_t)>(obj.via.ext.size));
+            detail::add_ext_type_size<sizeof(std::size_t)>(obj.via.ext.size),
+			MSGPACK_ZONE_ALIGNOF(msgpack::object));
         break;
     case msgpack::type::STR:
-        s += msgpack::aligned_size(obj.via.str.size);
+        s += msgpack::aligned_size(obj.via.str.size, MSGPACK_ZONE_ALIGNOF(msgpack::object));
         break;
     case msgpack::type::BIN:
-        s += msgpack::aligned_size(obj.via.bin.size);
+        s += msgpack::aligned_size(obj.via.bin.size, MSGPACK_ZONE_ALIGNOF(msgpack::object));
         break;
     default:
         break;
@@ -340,7 +341,7 @@ struct object_with_zone<msgpack::object> {
         }
 
         case msgpack::type::ARRAY:
-            o.via.array.ptr = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object) * v.via.array.size));
+            o.via.array.ptr = static_cast<msgpack::object*>(o.zone.allocate_align(sizeof(msgpack::object) * v.via.array.size, MSGPACK_ZONE_ALIGNOF(msgpack::object)));
             o.via.array.size = v.via.array.size;
             for (msgpack::object
                      * po(o.via.array.ptr),
@@ -353,7 +354,7 @@ struct object_with_zone<msgpack::object> {
             return;
 
         case msgpack::type::MAP:
-            o.via.map.ptr = (msgpack::object_kv*)o.zone.allocate_align(sizeof(msgpack::object_kv) * v.via.map.size);
+            o.via.map.ptr = (msgpack::object_kv*)o.zone.allocate_align(sizeof(msgpack::object_kv) * v.via.map.size, MSGPACK_ZONE_ALIGNOF(msgpack::object_kv));
             o.via.map.size = v.via.map.size;
             for(msgpack::object_kv
                     * po(o.via.map.ptr),

--- a/include/msgpack/v1/unpack.hpp
+++ b/include/msgpack/v1/unpack.hpp
@@ -203,7 +203,7 @@ struct unpack_array {
         if (n > u.limit().array()) throw msgpack::array_size_overflow("array size overflow");
         o.type = msgpack::type::ARRAY;
         o.via.array.size = 0;
-        o.via.array.ptr = static_cast<msgpack::object*>(u.zone().allocate_align(n*sizeof(msgpack::object)));
+        o.via.array.ptr = static_cast<msgpack::object*>(u.zone().allocate_align(n*sizeof(msgpack::object), MSGPACK_ZONE_ALIGNOF(msgpack::object)));
     }
 };
 
@@ -221,7 +221,7 @@ struct unpack_map {
         if (n > u.limit().map()) throw msgpack::map_size_overflow("map size overflow");
         o.type = msgpack::type::MAP;
         o.via.map.size = 0;
-        o.via.map.ptr = static_cast<msgpack::object_kv*>(u.zone().allocate_align(n*sizeof(msgpack::object_kv)));
+        o.via.map.ptr = static_cast<msgpack::object_kv*>(u.zone().allocate_align(n*sizeof(msgpack::object_kv), MSGPACK_ZONE_ALIGNOF(msgpack::object_kv)));
     }
 };
 
@@ -246,7 +246,7 @@ inline void unpack_str(unpack_user& u, const char* p, uint32_t l, msgpack::objec
     }
     else {
         if (l > u.limit().str()) throw msgpack::str_size_overflow("str size overflow");
-        char* tmp = static_cast<char*>(u.zone().allocate_align(l));
+        char* tmp = static_cast<char*>(u.zone().allocate_align(l, MSGPACK_ZONE_ALIGNOF(l)));
         std::memcpy(tmp, p, l);
         o.via.str.ptr = tmp;
     }
@@ -262,7 +262,7 @@ inline void unpack_bin(unpack_user& u, const char* p, uint32_t l, msgpack::objec
     }
     else {
         if (l > u.limit().bin()) throw msgpack::bin_size_overflow("bin size overflow");
-        char* tmp = static_cast<char*>(u.zone().allocate_align(l));
+        char* tmp = static_cast<char*>(u.zone().allocate_align(l, MSGPACK_ZONE_ALIGNOF(l)));
         std::memcpy(tmp, p, l);
         o.via.bin.ptr = tmp;
     }
@@ -278,7 +278,7 @@ inline void unpack_ext(unpack_user& u, const char* p, std::size_t l, msgpack::ob
     }
     else {
         if (l > u.limit().ext()) throw msgpack::ext_size_overflow("ext size overflow");
-        char* tmp = static_cast<char*>(u.zone().allocate_align(l));
+        char* tmp = static_cast<char*>(u.zone().allocate_align(l, MSGPACK_ZONE_ALIGNOF(l)));
         std::memcpy(tmp, p, l);
         o.via.ext.ptr = tmp;
     }

--- a/include/msgpack/v2/unpack.hpp
+++ b/include/msgpack/v2/unpack.hpp
@@ -209,6 +209,7 @@ public:
         if (num_elements > m_limit.array()) throw msgpack::array_size_overflow("array size overflow");
         if (m_stack.size() > m_limit.depth()) throw msgpack::depth_size_overflow("depth size overflow");
         msgpack::object* obj = m_stack.back();
+
         obj->type = msgpack::type::ARRAY;
         obj->via.array.size = num_elements;
         if (num_elements == 0) {
@@ -216,9 +217,10 @@ public:
         }
         else {
             obj->via.array.ptr =
-                static_cast<msgpack::object*>(m_zone->allocate_align(num_elements*sizeof(msgpack::object)));
+                static_cast<msgpack::object*>(m_zone->allocate_align(num_elements*sizeof(msgpack::object), MSGPACK_ZONE_ALIGNOF(msgpack::object)));
         }
         m_stack.push_back(obj->via.array.ptr);
+
         return true;
     }
     bool start_array_item() {
@@ -243,9 +245,10 @@ public:
         }
         else {
             obj->via.map.ptr =
-                static_cast<msgpack::object_kv*>(m_zone->allocate_align(num_kv_pairs*sizeof(msgpack::object_kv)));
+                static_cast<msgpack::object_kv*>(m_zone->allocate_align(num_kv_pairs*sizeof(msgpack::object_kv), MSGPACK_ZONE_ALIGNOF(msgpack::object_kv)));
         }
         m_stack.push_back(reinterpret_cast<msgpack::object*>(obj->via.map.ptr));
+
         return true;
     }
     bool start_map_key() {
@@ -273,7 +276,6 @@ public:
         throw msgpack::insufficient_bytes("insufficient bytes");
     }
 private:
-public:
     unpack_reference_func m_func;
     void* m_user_data;
     unpack_limit m_limit;

--- a/test/object.cpp
+++ b/test/object.cpp
@@ -181,7 +181,7 @@ TEST(object, cross_zone_copy_ext)
     msgpack::object::with_zone obj1(z1);
 
     obj1.type = msgpack::type::EXT;
-    char* ptr = static_cast<char*>(obj1.zone.allocate_align(2));
+    char* ptr = static_cast<char*>(obj1.zone.allocate_align(2, MSGPACK_ZONE_ALIGNOF(char)));
     ptr[0] = 1;
     ptr[1] = 2;
     obj1.via.ext.ptr = ptr;
@@ -204,7 +204,7 @@ TEST(object, cross_zone_copy_construct_ext)
     msgpack::object::with_zone obj1(z1);
 
     obj1.type = msgpack::type::EXT;
-    char* ptr = static_cast<char*>(obj1.zone.allocate_align(2));
+    char* ptr = static_cast<char*>(obj1.zone.allocate_align(2, MSGPACK_ZONE_ALIGNOF(char)));
     ptr[0] = 1;
     ptr[1] = 2;
     obj1.via.ext.ptr = ptr;


### PR DESCRIPTION
pass proper alignment size when use allocate_align(). This will
fix alignment trap issues on ARM.

Signed-off-by: Beilu Shao beilushao@gmail.com
