### PR TITLE
Removed MSGPACK_ENABLE_GCC_CXX_ATOMIC macro

### DIFF
--- a/include/msgpack/gcc_atomic.hpp
+++ b/include/msgpack/gcc_atomic.hpp
@@ -11,7 +11,6 @@
 #ifndef MSGPACK_GCC_ATOMIC_HPP
 #define MSGPACK_GCC_ATOMIC_HPP
 
-#ifdef MSGPACK_ENABLE_GCC_CXX_ATOMIC
 #if defined(__GNUC__) && ((__GNUC__*10 + __GNUC_MINOR__) < 41)
 
 #include "msgpack/gcc_atomic.h"
@@ -28,6 +27,5 @@ int _msgpack_sync_incr_and_fetch(volatile _msgpack_atomic_counter_t* ptr)
 }
 
 #endif // old gcc workaround
-#endif // MSGPACK_ENABLE_GCC_CXX_ATOMIC
 
 #endif /* gcc_atomic.hpp */


### PR DESCRIPTION
Removed MSGPACK_ENABLE_GCC_CXX_ATOMIC macro in gcc_atomic.hpp since it is not defined in user code but the header is included. So this code would not be active then.