### PR TITLE
Save the flags of the stream

### DIFF
--- a/include/msgpack/v1/object.hpp
+++ b/include/msgpack/v1/object.hpp
@@ -802,7 +802,9 @@ inline std::ostream& operator<< (std::ostream& s, const msgpack::object& o)
             default: {
                 unsigned int code = static_cast<unsigned int>(c);
                 if (code < 0x20 || code == 0x7f) {
+                    std::ios::fmtflags flags(s.flags());
                     s << "\\u" << std::hex << std::setw(4) << std::setfill('0') << (code & 0xff);
+                    s.flags(flags);
                 }
                 else {
                     s << c;


### PR DESCRIPTION
Changing the stream to `std::hex` mode should only affect the current character; otherwise printing some msgpack with a list like this: `[123, "string\\u0003", 123]` (123 decimal) ends up printing `[123, "string\\u0003", 7b]`, as `std::hex` is sticky.