### PR TITLE
Make sure to pass `unsigned char` to `isprint()`

### DIFF
--- a/src/objectc.c
+++ b/src/objectc.c
@@ -122,7 +122,7 @@ static void msgpack_object_bin_print(FILE* out, const char *ptr, size_t size)
     for (i = 0; i < size; ++i) {
         if (ptr[i] == '"') {
             fputs("\\\"", out);
-        } else if (isprint(ptr[i])) {
+        } else if (isprint((unsigned char)ptr[i])) {
             fputc(ptr[i], out);
         } else {
             fprintf(out, "\\x%02x", (unsigned char)ptr[i]);
@@ -142,7 +142,7 @@ static int msgpack_object_bin_print_buffer(char *buffer, size_t buffer_size, con
             ret = snprintf(aux_buffer, aux_buffer_size, "\\\"");
             aux_buffer = aux_buffer + ret;
             aux_buffer_size = aux_buffer_size - ret;
-        } else if (isprint(ptr[i])) {
+        } else if (isprint((unsigned char)ptr[i])) {
             if (aux_buffer_size > 0) {
                 memcpy(aux_buffer, ptr + i, 1);
                 aux_buffer = aux_buffer + 1;


### PR DESCRIPTION
This change make safe for `char = signed char`.

As the spec, argment of `isprintf()` must be representabe as an
`unsigned char` (or equal to EOF, not expected here).
Additionally, some implementation define it as a macro using array,
then it cause warning "array subscript has type `char` [-Wchar-subscripts]"
with `char` argments.