### PR TITLE
Fix compilation warnings about possible loss of data

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,10 +33,10 @@ build_script:
 - cmake --build . --config Release
 - cd ..
 - cd ..
-- appveyor DownloadFile http://zlib.net/zlib-1.2.10.tar.gz -FileName zlib-1.2.10.tar.gz
-- 7z x zlib-1.2.10.tar.gz > NUL
-- 7z x zlib-1.2.10.tar > NUL
-- cd zlib-1.2.10
+- appveyor DownloadFile http://zlib.net/zlib-1.2.11.tar.gz -FileName zlib-1.2.11.tar.gz
+- 7z x zlib-1.2.11.tar.gz > NUL
+- 7z x zlib-1.2.11.tar > NUL
+- cd zlib-1.2.11
 - md build
 - cd build
 - cmake -G %msvc% ..
@@ -46,9 +46,9 @@ build_script:
 - cd ..
 - md build
 - cd build
-- cmake -G %msvc% %cpp11% %boost% %x3_parse%  -DMSGPACK_BOOST_DIR=C:\Libraries\\boost_1_60_0 -DGTEST_LIBRARY=%APPVEYOR_BUILD_FOLDER%\googletest-release-1.7.0\build\Release\gtest.lib -DGTEST_MAIN_LIBRARY=%APPVEYOR_BUILD_FOLDER%\googletest-release-1.7.0\build\Release\gtest_main.lib -DGTEST_INCLUDE_DIR=%APPVEYOR_BUILD_FOLDER%\googletest-release-1.7.0\include -DZLIB_LIBRARY=%APPVEYOR_BUILD_FOLDER%\zlib-1.2.10\build\Release\zlib.lib -DZLIB_INCLUDE_DIR=%APPVEYOR_BUILD_FOLDER%\zlib-1.2.10 -DCMAKE_CXX_FLAGS='"/D_VARIADIC_MAX=10 /EHsc"' ..
+- cmake -G %msvc% %cpp11% %boost% %x3_parse%  -DMSGPACK_BOOST_DIR=C:\Libraries\\boost_1_60_0 -DGTEST_LIBRARY=%APPVEYOR_BUILD_FOLDER%\googletest-release-1.7.0\build\Release\gtest.lib -DGTEST_MAIN_LIBRARY=%APPVEYOR_BUILD_FOLDER%\googletest-release-1.7.0\build\Release\gtest_main.lib -DGTEST_INCLUDE_DIR=%APPVEYOR_BUILD_FOLDER%\googletest-release-1.7.0\include -DZLIB_LIBRARY=%APPVEYOR_BUILD_FOLDER%\zlib-1.2.11\build\Release\zlib.lib -DZLIB_INCLUDE_DIR=%APPVEYOR_BUILD_FOLDER%\zlib-1.2.11 -DCMAKE_CXX_FLAGS='"/D_VARIADIC_MAX=10 /EHsc"' ..
 - cmake --build . --config Release
 
 test_script:
-- set PATH=%PATH%;%APPVEYOR_BUILD_FOLDER%\googletest-release-1.7.0\build\Release;%APPVEYOR_BUILD_FOLDER%\zlib-1.2.10\build\Release;%APPVEYOR_BUILD_FOLDER%\build\release
+- set PATH=%PATH%;%APPVEYOR_BUILD_FOLDER%\googletest-release-1.7.0\build\Release;%APPVEYOR_BUILD_FOLDER%\zlib-1.2.11\build\Release;%APPVEYOR_BUILD_FOLDER%\build\release
 - ctest -V

--- a/include/msgpack/v1/adaptor/carray.hpp
+++ b/include/msgpack/v1/adaptor/carray.hpp
@@ -101,7 +101,7 @@ struct pack<char[N]> {
         char const* p = v;
         uint32_t size = checked_get_container_size(N);
         char const* p2 = static_cast<char const*>(std::memchr(p, '\0', size));
-        uint32_t adjusted_size = p2 ? p2 - p : size;
+        uint32_t adjusted_size = p2 ? static_cast<uint32_t>(p2 - p) : size;
         o.pack_str(adjusted_size);
         o.pack_str_body(p, adjusted_size);
         return o;
@@ -115,7 +115,7 @@ struct pack<const char[N]> {
         uint32_t size = checked_get_container_size(N);
         char const* p = v;
         char const* p2 = static_cast<char const*>(std::memchr(p, '\0', size));
-        uint32_t adjusted_size = p2 ? p2 - p : size;
+        uint32_t adjusted_size = p2 ? static_cast<uint32_t>(p2 - p) : size;
         o.pack_str(adjusted_size);
         o.pack_str_body(p, adjusted_size);
         return o;
@@ -167,7 +167,7 @@ struct object_with_zone<char[N]> {
         char const* p = v;
         uint32_t size = checked_get_container_size(N);
         char const* p2 = static_cast<char const*>(std::memchr(p, '\0', size));
-        uint32_t adjusted_size = p2 ? p2 - p : size;
+        uint32_t adjusted_size = p2 ? static_cast<uint32_t>(p2 - p) : size;
         o.type = msgpack::type::STR;
         char* ptr = static_cast<char*>(o.zone.allocate_align(adjusted_size));
         o.via.str.ptr = ptr;
@@ -182,7 +182,7 @@ struct object_with_zone<const char[N]> {
         char const* p = v;
         uint32_t size = checked_get_container_size(N);
         char const* p2 = static_cast<char const*>(std::memchr(p, '\0', size));
-        uint32_t adjusted_size = p2 ? p2 - p : size;
+        uint32_t adjusted_size = p2 ? static_cast<uint32_t>(p2 - p) : size;
         o.type = msgpack::type::STR;
         char* ptr = static_cast<char*>(o.zone.allocate_align(adjusted_size));
         o.via.str.ptr = ptr;
@@ -221,7 +221,7 @@ struct object<char[N]> {
         char const* p = v;
         uint32_t size = checked_get_container_size(N);
         char const* p2 = static_cast<char const*>(std::memchr(p, '\0', size));
-        uint32_t adjusted_size = p2 ? p2 - p : size;
+        uint32_t adjusted_size = p2 ? static_cast<uint32_t>(p2 - p) : size;
         o.type = msgpack::type::STR;
         o.via.str.ptr = p;
         o.via.str.size = adjusted_size;
@@ -234,7 +234,7 @@ struct object<const char[N]> {
         char const* p = v;
         uint32_t size = checked_get_container_size(N);
         char const* p2 = static_cast<char const*>(std::memchr(p, '\0', size));
-        uint32_t adjusted_size = p2 ? p2 - p : size;
+        uint32_t adjusted_size = p2 ? static_cast<uint32_t>(p2 - p) : size;
         o.type = msgpack::type::STR;
         o.via.str.ptr = p;
         o.via.str.size = adjusted_size;

--- a/include/msgpack/v2/parse.hpp
+++ b/include/msgpack/v2/parse.hpp
@@ -459,7 +459,7 @@ inline parse_return context<VisitorHolder>::execute(const char* data, std::size_
                 load<uint8_t>(tmp, n);
                 m_trail = tmp + 1;
                 if(m_trail == 0) {
-                    bool visret = holder().visitor().visit_ext(n, m_trail);
+                    bool visret = holder().visitor().visit_ext(n, static_cast<uint32_t>(m_trail));
                     parse_return upr = after_visit_proc(visret, off);
                     if (upr != PARSE_CONTINUE) return upr;
                 }
@@ -501,7 +501,7 @@ inline parse_return context<VisitorHolder>::execute(const char* data, std::size_
                 load<uint16_t>(tmp, n);
                 m_trail = tmp + 1;
                 if(m_trail == 0) {
-                    bool visret = holder().visitor().visit_ext(n, m_trail);
+                    bool visret = holder().visitor().visit_ext(n, static_cast<uint32_t>(m_trail));
                     parse_return upr = after_visit_proc(visret, off);
                     if (upr != PARSE_CONTINUE) return upr;
                 }
@@ -545,7 +545,7 @@ inline parse_return context<VisitorHolder>::execute(const char* data, std::size_
                 m_trail = tmp;
                 ++m_trail;
                 if(m_trail == 0) {
-                    bool visret = holder().visitor().visit_ext(n, m_trail);
+                    bool visret = holder().visitor().visit_ext(n, static_cast<uint32_t>(m_trail));
                     parse_return upr = after_visit_proc(visret, off);
                     if (upr != PARSE_CONTINUE) return upr;
                 }
@@ -555,7 +555,7 @@ inline parse_return context<VisitorHolder>::execute(const char* data, std::size_
                 }
             } break;
             case MSGPACK_ACS_STR_VALUE: {
-                bool visret = holder().visitor().visit_str(n, m_trail);
+                bool visret = holder().visitor().visit_str(n, static_cast<uint32_t>(m_trail));
                 parse_return upr = after_visit_proc(visret, off);
                 if (upr != PARSE_CONTINUE) return upr;
             } break;
@@ -565,7 +565,7 @@ inline parse_return context<VisitorHolder>::execute(const char* data, std::size_
                 if (upr != PARSE_CONTINUE) return upr;
             } break;
             case MSGPACK_ACS_EXT_VALUE: {
-                bool visret = holder().visitor().visit_ext(n, m_trail);
+                bool visret = holder().visitor().visit_ext(n, static_cast<uint32_t>(m_trail));
                 parse_return upr = after_visit_proc(visret, off);
                 if (upr != PARSE_CONTINUE) return upr;
             } break;


### PR DESCRIPTION
Other Visual Studio 2015 (64 bits) warnings about possible loss of value when converting from size_t to uint32_t