### PR TITLE
Enable building against dynamically-linked Boost

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,7 +94,6 @@ IF (MSGPACK_BOOST)
    SET (CMAKE_CXX_FLAGS "-DMSGPACK_USE_BOOST ${CMAKE_CXX_FLAGS}")
 ENDIF ()
 
-SET (Boost_USE_STATIC_LIBS        ON) # only find static libs
 SET (Boost_USE_MULTITHREADED      ON)
 SET (Boost_USE_STATIC_RUNTIME    OFF)
 FIND_PACKAGE (Boost COMPONENTS chrono context timer system)


### PR DESCRIPTION
It's nice to be able to build against the distro-provided dynamically-linked version of a library instead of having to build the static version to run examples/tests.