### PR TITLE
Pass wildcard precision of snprintf as int

### DIFF
--- a/src/objectc.c
+++ b/src/objectc.c
@@ -339,7 +339,7 @@ int msgpack_object_print_buffer(char *buffer, size_t buffer_size, msgpack_object
         ret = snprintf(aux_buffer, aux_buffer_size, "\"");
         aux_buffer = aux_buffer + ret;
         aux_buffer_size = aux_buffer_size - ret;
-        ret = snprintf(aux_buffer, aux_buffer_size, "%.*s", o.via.str.size, o.via.str.ptr);
+        ret = snprintf(aux_buffer, aux_buffer_size, "%.*s", (int)o.via.str.size, o.via.str.ptr);
         aux_buffer = aux_buffer + ret;
         aux_buffer_size = aux_buffer_size - ret;
         ret = snprintf(aux_buffer, aux_buffer_size, "\"");


### PR DESCRIPTION
This patch fix the following cross compile error:
src/objectc.c:342:9: error: field precision specifier '.*' expects argument of type 'int', but argument 4 has type 'uint32_t' [-Werror=format=]
