### PR TITLE
Add cmake package config support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-CMAKE_MINIMUM_REQUIRED (VERSION 2.8.6)
+CMAKE_MINIMUM_REQUIRED (VERSION 2.8.12)
 
 IF ((CMAKE_VERSION VERSION_GREATER 3.1) OR
     (CMAKE_VERSION VERSION_EQUAL 3.1))
@@ -172,16 +172,19 @@ CONFIGURE_FILE (
     @ONLY
 )
 
-INCLUDE_DIRECTORIES (
-    ./
-    include/
-    ${CMAKE_CURRENT_BINARY_DIR}/include/
-)
-
 IF (MSGPACK_ENABLE_SHARED)
     ADD_LIBRARY (msgpackc SHARED
         ${msgpackc_SOURCES}
         ${msgpackc_HEADERS}
+    )
+
+    TARGET_INCLUDE_DIRECTORIES (msgpackc
+        PUBLIC
+            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+            $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>
+            $<INSTALL_INTERFACE:include>
+        PRIVATE
+            ${CMAKE_CURRENT_SOURCE_DIR}
     )
 ENDIF ()
 
@@ -189,6 +192,20 @@ ADD_LIBRARY (msgpackc-static STATIC
     ${msgpackc_SOURCES}
     ${msgpackc_HEADERS}
 )
+
+TARGET_INCLUDE_DIRECTORIES (msgpackc-static
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>
+        $<INSTALL_INTERFACE:include>
+    PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+IF (NOT MSGPACK_ENABLE_SHARED)
+    # Add alias for subdirectories
+    ADD_LIBRARY (msgpackc ALIAS msgpackc-static)
+ENDIF ()
 
 SET_TARGET_PROPERTIES (msgpackc-static PROPERTIES OUTPUT_NAME "msgpackc")
 IF (MSGPACK_ENABLE_SHARED)
@@ -253,9 +270,11 @@ ELSE()
     SET (MSGPACK_INSTALLTARGETS msgpackc-static)
 ENDIF ()
 
-INSTALL (TARGETS ${MSGPACK_INSTALLTARGETS} RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-                                           LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-                                           ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+INSTALL (TARGETS ${MSGPACK_INSTALLTARGETS} EXPORT msgpack-targets
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)
 FOREACH (file ${msgpackc_HEADERS})
     GET_FILENAME_COMPONENT (dir ${file} PATH)
     INSTALL (FILES ${file} DESTINATION ${CMAKE_INSTALL_PREFIX}/${dir})
@@ -310,3 +329,39 @@ IF (DOXYGEN_FOUND)
         DEPENDS doxygen_c doxygen_cpp
     )
 ENDIF ()
+
+INCLUDE (CMakePackageConfigHelpers)
+
+SET (CMAKE_INSTALL_CMAKEDIR "${CMAKE_INSTALL_LIBDIR}/cmake/msgpack")
+
+WRITE_BASIC_PACKAGE_VERSION_FILE (
+    msgpack-config-version.cmake
+    VERSION ${VERSION}
+    COMPATIBILITY SameMajorVersion
+)
+
+IF (NOT CMAKE_VERSION VERSION_LESS 3.0)
+    EXPORT (EXPORT msgpack-targets
+        FILE "${CMAKE_CURRENT_BINARY_DIR}/msgpack-targets.cmake"
+    )
+ENDIF ()
+
+CONFIGURE_PACKAGE_CONFIG_FILE (msgpack-config.cmake.in
+    msgpack-config.cmake
+    INSTALL_DESTINATION "${CMAKE_INSTALL_CMAKEDIR}"
+)
+
+INSTALL (EXPORT msgpack-targets
+    FILE
+        msgpack-targets.cmake
+    DESTINATION
+        "${CMAKE_INSTALL_CMAKEDIR}"
+)
+
+INSTALL (
+    FILES
+        "${CMAKE_CURRENT_BINARY_DIR}/msgpack-config.cmake"
+        "${CMAKE_CURRENT_BINARY_DIR}/msgpack-config-version.cmake"
+    DESTINATION
+        "${CMAKE_INSTALL_CMAKEDIR}"
+)

--- a/example/boost/CMakeLists.txt
+++ b/example/boost/CMakeLists.txt
@@ -11,6 +11,10 @@ FOREACH (source_file ${exec_PROGRAMS})
         ${source_file_we}
         ${source_file}
     )
+    TARGET_INCLUDE_DIRECTORIES (${source_file_we}
+        PRIVATE
+            $<TARGET_PROPERTY:msgpackc,INTERFACE_INCLUDE_DIRECTORIES>
+    )
     IF ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
         SET_PROPERTY (TARGET ${source_file_we} APPEND_STRING PROPERTY COMPILE_FLAGS "-Wall -Wextra -Werror -g -O3")
     ENDIF ()

--- a/example/cpp03/CMakeLists.txt
+++ b/example/cpp03/CMakeLists.txt
@@ -35,6 +35,10 @@ FOREACH (source_file ${exec_PROGRAMS})
         ${source_file_we}
         ${source_file}
     )
+    TARGET_INCLUDE_DIRECTORIES (${source_file_we}
+        PRIVATE
+            $<TARGET_PROPERTY:msgpackc,INTERFACE_INCLUDE_DIRECTORIES>
+    )
     IF ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
         SET_PROPERTY (TARGET ${source_file_we} APPEND_STRING PROPERTY COMPILE_FLAGS "-Wall -Wextra -Werror -g -O3")
     ENDIF ()
@@ -52,6 +56,10 @@ FOREACH (source_file ${with_pthread_PROGRAMS})
     ADD_EXECUTABLE (
         ${source_file_we}
         ${source_file}
+    )
+    TARGET_INCLUDE_DIRECTORIES (${source_file_we}
+        PRIVATE
+            $<TARGET_PROPERTY:msgpackc,INTERFACE_INCLUDE_DIRECTORIES>
     )
     TARGET_LINK_LIBRARIES (${source_file_we}
         ${CMAKE_THREAD_LIBS_INIT}
@@ -77,6 +85,10 @@ FOREACH (source_file ${with_boost_lib_PROGRAMS})
     ADD_EXECUTABLE (
         ${source_file_we}
         ${source_file}
+    )
+    TARGET_INCLUDE_DIRECTORIES (${source_file_we}
+        PRIVATE
+            $<TARGET_PROPERTY:msgpackc,INTERFACE_INCLUDE_DIRECTORIES>
     )
     LINK_DIRECTORIES(${Boost_LIBRARY_DIRS})
     TARGET_LINK_LIBRARIES (${source_file_we}

--- a/example/cpp11/CMakeLists.txt
+++ b/example/cpp11/CMakeLists.txt
@@ -20,6 +20,10 @@ IF (MSGPACK_CXX11)
             ${source_file_we}
             ${source_file}
         )
+        TARGET_INCLUDE_DIRECTORIES (${source_file_we}
+            PRIVATE
+                $<TARGET_PROPERTY:msgpackc,INTERFACE_INCLUDE_DIRECTORIES>
+        )
         IF ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
             SET_PROPERTY (TARGET ${source_file_we} APPEND_STRING PROPERTY COMPILE_FLAGS "-Wall -Wextra -Werror -g -O3 ")
         ENDIF ()

--- a/example/x3/CMakeLists.txt
+++ b/example/x3/CMakeLists.txt
@@ -18,6 +18,10 @@ IF (MSGPACK_USE_X3_PARSE)
             ${source_file_we}
             ${source_file}
         )
+        TARGET_INCLUDE_DIRECTORIES (${source_file_we}
+            PRIVATE
+                $<TARGET_PROPERTY:msgpackc,INTERFACE_INCLUDE_DIRECTORIES>
+        )
         IF ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
             SET_PROPERTY (TARGET ${source_file_we} APPEND_STRING PROPERTY COMPILE_FLAGS "-Wall -Wextra -Werror -g ")
         ENDIF ()
@@ -39,6 +43,10 @@ IF (MSGPACK_USE_X3_PARSE)
         ADD_EXECUTABLE (
             ${source_file_we}
             ${source_file}
+        )
+        TARGET_INCLUDE_DIRECTORIES (${source_file_we}
+            PRIVATE
+                $<TARGET_PROPERTY:msgpackc,INTERFACE_INCLUDE_DIRECTORIES>
         )
         TARGET_LINK_LIBRARIES (${source_file_we}
             ${Boost_CONTEXT_LIBRARY}

--- a/msgpack-config.cmake.in
+++ b/msgpack-config.cmake.in
@@ -1,0 +1,23 @@
+#.rst:
+# msgpack
+# -------
+#
+# The following import targets are created
+#
+# ::
+#
+#   msgpackc-static
+#   msgpackc
+#
+
+@PACKAGE_INIT@
+
+include(CMakeFindDependencyMacro)
+
+if(NOT TARGET msgpackc AND NOT TARGET msgpackc-static)
+  include("${CMAKE_CURRENT_LIST_DIR}/msgpack-targets.cmake")
+
+  if(NOT @MSGPACK_ENABLE_SHARED@)
+    add_library(msgpackc ALIAS msgpackc-static)
+  endif()
+endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -66,12 +66,6 @@ IF (MSGPACK_CXX11)
     )
 ENDIF ()
 
-IF (MSGPACK_ENABLE_SHARED)
-    SET (MSGPACK_TEST_LIB msgpackc)
-ELSE ()
-    SET (MSGPACK_TEST_LIB msgpackc-static)
-ENDIF ()
-
 FOREACH (source_file ${check_PROGRAMS})
     GET_FILENAME_COMPONENT (source_file_we ${source_file} NAME_WE)
     ADD_EXECUTABLE (
@@ -79,7 +73,7 @@ FOREACH (source_file ${check_PROGRAMS})
         ${source_file}
     )
     TARGET_LINK_LIBRARIES (${source_file_we}
-        ${MSGPACK_TEST_LIB}
+        msgpackc
         ${GTEST_BOTH_LIBRARIES}
         ${ZLIB_LIBRARIES}
         ${CMAKE_THREAD_LIBS_INIT}
@@ -104,5 +98,9 @@ ENDFOREACH ()
 ADD_EXECUTABLE (
     multi_file
     multi_file1.cpp multi_file2.cpp
+)
+TARGET_INCLUDE_DIRECTORIES (multi_file
+    PRIVATE
+        $<TARGET_PROPERTY:msgpackc,INTERFACE_INCLUDE_DIRECTORIES>
 )
 ADD_TEST (multi_file multi_file)


### PR DESCRIPTION
Add support for CMake find_package command to msgpack. The package
exports the two targets msgpackc-static and msgpackc if shared is
enabled. The CMake find_package command works after installation
of msgpack and during build of another project which adds msgpack
as sub project via add_subdirectory command.
