### PR TITLE
Fix 'WinSock.h has already been included' compiler error.

### DIFF
--- a/include/msgpack/sysdep.h
+++ b/include/msgpack/sysdep.h
@@ -45,6 +45,9 @@
 
 #ifdef _WIN32
 #   define _msgpack_atomic_counter_header <windows.h>
+#   if !defined(WIN32_LEAN_AND_MEAN)
+#       define WIN32_LEAN_AND_MEAN
+#   endif /* WIN32_LEAN_AND_MEAN */
     typedef long _msgpack_atomic_counter_t;
 #   define _msgpack_sync_decr_and_fetch(ptr) InterlockedDecrement(ptr)
 #   define _msgpack_sync_incr_and_fetch(ptr) InterlockedIncrement(ptr)


### PR DESCRIPTION
There is a compiler error if Boost.Asio and Msgpack-c are both used in the same project on Win32 plarform. The root cause is 'WinSock.h' header file is included indirectly by Msgpack library when '<windows.h>' is included. The fix prevents including such unnecessary header files.