### PR TITLE
unpack_template: Include unpack.h for missing msgpack_unpack_return type

### DIFF
--- a/include/msgpack/unpack_template.h
+++ b/include/msgpack/unpack_template.h
@@ -8,6 +8,8 @@
  *    http://www.boost.org/LICENSE_1_0.txt)
  */
 
+#include "msgpack/unpack.h"
+
 #ifndef msgpack_unpack_func
 #error msgpack_unpack_func template is not defined
 #endif


### PR DESCRIPTION
9a113bb0cae7c3b5e4a79ac6c5ede8a1ca5df889 added uses of
MSGPACK_UNPACK_{NOMEM,PARSE}_ERROR to unpack_template.h.  It didn't
include unpack.h though, which is where these values are defined.

src/unpack.c already includes unpack.h, so this doesn't affect
msgpack-c.  However, msgpack-perl also uses unpack_template.h and can't
build against cpp-2.1.0 due to this change.

Signed-off-by: James McCoy <jamessan@jamessan.com>