### PR TITLE
Fixed #584.

### DIFF
--- a/include/msgpack/v2/parse.hpp
+++ b/include/msgpack/v2/parse.hpp
@@ -96,12 +96,10 @@ private:
             return PARSE_STOP_VISITOR;
         }
         parse_return ret = m_stack.consume(holder());
-        if (ret == PARSE_CONTINUE) {
-            m_cs = MSGPACK_CS_HEADER;
-        }
-        else {
+        if (ret != PARSE_CONTINUE) {
             off = m_current - m_start;
         }
+        m_cs = MSGPACK_CS_HEADER;
         return ret;
     }
 


### PR DESCRIPTION
Reset m_cs to MSGPACK_CS_HEADER after visitor called.

NOTE:

The problem happens only when parser is used directly. Unpacker doesn't have the same problem.
Because unpacker calls `reset()` function. See https://github.com/msgpack/msgpack-c/blob/master/include/msgpack/v2/unpack.hpp#L95

