### PR TITLE
Comment the intentional fallthrough to default from _fixed_trail_again

### DIFF
--- a/include/msgpack/unpack_template.h
+++ b/include/msgpack/unpack_template.h
@@ -236,6 +236,7 @@ msgpack_unpack_func(int, _execute)(msgpack_unpack_struct(_context)* ctx, const c
 
             _fixed_trail_again:
                 ++p;
+                // fallthrough
 
             default:
                 if((size_t)(pe - p) < trail) { goto _out; }


### PR DESCRIPTION
GCC 7 added a new diagnostic, -Wimplicit-fallthrough, which is enabled
with -Wextra that warns about implicitly falling through a case
statement.

    [  4%] Building C object CMakeFiles/msgpackc-static.dir/src/unpack.c.o
    /usr/lib/gcc-snapshot/bin/gcc   -I/home/mccoyj1/src/msgpack-c/. -I/home/mccoyj1/src/msgpack-c/include -I/home/mccoyj1/src/msgpack-c/build/include  -g -O2 -fdebug-prefix-map=/home/mccoyj1/src/msgpack-c=. -specs=/usr/share/dpkg/no-pie-compile.specs -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2   -Wall -Wextra -Werror -g -O3 -o CMakeFiles/msgpackc-static.dir/src/unpack.c.o   -c /home/mccoyj1/src/msgpack-c/src/unpack.c
    In file included from /home/mccoyj1/src/msgpack-c/src/unpack.c:283:0:
    /home/mccoyj1/src/msgpack-c/include/msgpack/unpack_template.h: In function 'template_execute':
    /home/mccoyj1/src/msgpack-c/include/msgpack/unpack_template.h:238:17: error: this statement may fall through [-Werror=implicit-fallthrough=]
                     ++p;
                     ^~~
    /home/mccoyj1/src/msgpack-c/include/msgpack/unpack_template.h:240:13: note: here
                 default:
                 ^~~~~~~
    cc1: all warnings being treated as errors

Adding the comment makes it explicit that the fallthrough is
intentional, so gcc doesn't complain.