### PR TITLE
cmake: Enable all Boost tests on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ install:
 # valgrind
  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then wget http://valgrind.org/downloads/valgrind-3.12.0.tar.bz2 && tar xjf valgrind-3.12.0.tar.bz2 && cd valgrind-3.12.0 && ./configure --prefix=${BASE}/usr > /dev/null && make -j3 > /dev/null && make install > /dev/null && cd ..; fi
 # boost
- - if [ "$BOOST" == "ON" ]; then wget http://sourceforge.net/projects/boost/files/boost/1.63.0/boost_1_63_0.zip && unzip -q boost_1_63_0.zip && cd boost_1_63_0 && ./bootstrap.sh && ./b2 -j3 --prefix=${BASE}/usr --with-timer --with-chrono address-model=${ARCH} install > /dev/null && cd ..; fi
+ - if [ "$BOOST" == "ON" ]; then wget http://sourceforge.net/projects/boost/files/boost/1.63.0/boost_1_63_0.zip && unzip -q boost_1_63_0.zip && cd boost_1_63_0 && ./bootstrap.sh && ./b2 -j3 --prefix=${BASE}/usr --with-chrono --with-context --with-system --with-timer address-model=${ARCH} install > /dev/null && cd ..; fi
 
 matrix:
   include:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,6 +100,11 @@ IF (MSGPACK_BOOST)
          ${Boost_INCLUDE_DIRS}
    )
    ENDIF ()
+   IF (Boost_LIBRARY_DIRS)
+      LINK_DIRECTORIES (
+         ${Boost_LIBRARY_DIRS}
+   )
+   ENDIF ()
    IF (MSGPACK_BOOST_DIR)
       INCLUDE_DIRECTORIES (
          ${MSGPACK_BOOST_DIR}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,17 +94,13 @@ IF (MSGPACK_BOOST)
    SET (CMAKE_CXX_FLAGS "-DMSGPACK_USE_BOOST ${CMAKE_CXX_FLAGS}")
    SET (Boost_USE_MULTITHREADED      ON)
    SET (Boost_USE_STATIC_RUNTIME    OFF)
-   FIND_PACKAGE (Boost COMPONENTS chrono context timer system)
-   IF (Boost_INCLUDE_DIRS)
-      INCLUDE_DIRECTORIES (
-         ${Boost_INCLUDE_DIRS}
+   FIND_PACKAGE (Boost REQUIRED COMPONENTS chrono context system timer)
+   INCLUDE_DIRECTORIES (
+      ${Boost_INCLUDE_DIRS}
    )
-   ENDIF ()
-   IF (Boost_LIBRARY_DIRS)
-      LINK_DIRECTORIES (
-         ${Boost_LIBRARY_DIRS}
+   LINK_DIRECTORIES (
+      ${Boost_LIBRARY_DIRS}
    )
-   ENDIF ()
    IF (MSGPACK_BOOST_DIR)
       INCLUDE_DIRECTORIES (
          ${MSGPACK_BOOST_DIR}

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,15 +1,19 @@
 version: 2.1.0.{build}
 
+image:
+- Visual Studio 2015
 environment:
+  global:
+    BOOST_ROOT: C:\Libraries\boost_1_60_0
   matrix:
     - cpp11: -DMSGPACK_CXX11=OFF
-      boost: -DMSGPACK_BOOST=ON
+      boost: -DMSGPACK_BOOST=OFF
       msvc: '"Visual Studio 10 2010"'
     - cpp11: -DMSGPACK_CXX11=OFF
-      boost: -DMSGPACK_BOOST=ON
+      boost: -DMSGPACK_BOOST=OFF
       msvc: '"Visual Studio 11 2012"'
     - cpp11: -DMSGPACK_CXX11=OFF
-      boost: -DMSGPACK_BOOST=ON
+      boost: -DMSGPACK_BOOST=OFF
       msvc: '"Visual Studio 12 2013"'
     - cpp11: -DMSGPACK_CXX11=ON
       boost: -DMSGPACK_BOOST=ON
@@ -46,7 +50,7 @@ build_script:
 - cd ..
 - md build
 - cd build
-- cmake -G %msvc% %cpp11% %boost% %x3_parse%  -DMSGPACK_BOOST_DIR=C:\Libraries\\boost_1_60_0 -DGTEST_LIBRARY=%APPVEYOR_BUILD_FOLDER%\googletest-release-1.7.0\build\Release\gtest.lib -DGTEST_MAIN_LIBRARY=%APPVEYOR_BUILD_FOLDER%\googletest-release-1.7.0\build\Release\gtest_main.lib -DGTEST_INCLUDE_DIR=%APPVEYOR_BUILD_FOLDER%\googletest-release-1.7.0\include -DZLIB_LIBRARY=%APPVEYOR_BUILD_FOLDER%\zlib-1.2.11\build\Release\zlib.lib -DZLIB_INCLUDE_DIR=%APPVEYOR_BUILD_FOLDER%\zlib-1.2.11 -DCMAKE_CXX_FLAGS='"/D_VARIADIC_MAX=10 /EHsc"' ..
+- cmake -G %msvc% %cpp11% %boost% %x3_parse% -DGTEST_LIBRARY=%APPVEYOR_BUILD_FOLDER%\googletest-release-1.7.0\build\Release\gtest.lib -DGTEST_MAIN_LIBRARY=%APPVEYOR_BUILD_FOLDER%\googletest-release-1.7.0\build\Release\gtest_main.lib -DGTEST_INCLUDE_DIR=%APPVEYOR_BUILD_FOLDER%\googletest-release-1.7.0\include -DZLIB_LIBRARY=%APPVEYOR_BUILD_FOLDER%\zlib-1.2.11\build\Release\zlib.lib -DZLIB_INCLUDE_DIR=%APPVEYOR_BUILD_FOLDER%\zlib-1.2.11 -DCMAKE_CXX_FLAGS='"/D_VARIADIC_MAX=10 /EHsc"' ..
 - cmake --build . --config Release
 
 test_script:

--- a/example/cpp03/CMakeLists.txt
+++ b/example/cpp03/CMakeLists.txt
@@ -22,7 +22,7 @@ IF (NOT MSVC)
     )
 ENDIF ()
 
-IF (Boost_TIMER_LIBRARY AND Boost_CHRONO_LIBRARY AND Boost_SYSTEM_LIBRARY)
+IF (MSGPACK_BOOST)
     LIST (APPEND with_boost_lib_PROGRAMS
         speed_test.cpp
         speed_test_nested_array.cpp

--- a/example/x3/CMakeLists.txt
+++ b/example/x3/CMakeLists.txt
@@ -7,7 +7,7 @@ IF (MSGPACK_USE_X3_PARSE)
         unpack.cpp
         parse.cpp
     )
-    IF (Boost_CONTEXT_LIBRARY AND Boost_SYSTEM_LIBRARY AND CMAKE_THREAD_LIBS_INIT)
+    IF (MSGPACK_BOOST)
         LIST (APPEND with_boost_PROGRAMS
             stream_unpack.cpp
         )


### PR DESCRIPTION
At the moment the CI doesn't test all Boost test and examples. Make all Boost components mandatory if MSGPACK_BOOST is ON. Additionally disable boost on AppVeyor when the compiler don't match the default compiler because the pre-installed software is only compiled with the default compiler.