### PR TITLE
Suppressed gcc 7.1 `maybe-uninitialized` warning.

### DIFF
--- a/test/user_class.cpp
+++ b/test/user_class.cpp
@@ -152,7 +152,7 @@ public:
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 #endif // (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 7)) && !defined(__clang__)
-        msgpack::type::tuple<bool, msgpack::object> tuple;
+        msgpack::type::tuple<bool, msgpack::object> tuple(false, msgpack::object());
         o.convert(tuple);
 
         is_double = tuple.get<0>();


### PR DESCRIPTION
When I execute cmake `-DMSGPACK_CXX11=OFF`, gcc 7.1 reports the warning.
I've already added the warning suppression pragma, but it doesn't work
in this case. So I added explicit initializing code even if it is redundant.