### PR TITLE
Add defines for QNX build

### DIFF
--- a/include/msgpack/vrefbuffer.h
+++ b/include/msgpack/vrefbuffer.h
@@ -13,7 +13,7 @@
 #include "zone.h"
 #include <stdlib.h>
 
-#if defined(unix) || defined(__unix) || defined(__APPLE__) || defined(__OpenBSD__)
+#if defined(unix) || defined(__unix) || defined(__APPLE__) || defined(__OpenBSD__) || defined(__QNX__) || defined(__QNXTO__)
 #include <sys/uio.h>
 #else
 struct iovec {


### PR DESCRIPTION
Using msgpack-c under QNX leads to an error because of the iovec strcut being redefined.
I added the defines for the QNX compilers to include the appropriate header.