### PR TITLE
Don't sudo with brew in QUICKSTART-C.md

### DIFF
--- a/QUICKSTART-C.md
+++ b/QUICKSTART-C.md
@@ -20,7 +20,7 @@ You might need to run `sudo port selfupdate` before installing to update the pac
 You can also install via Homebrew.
 
 ```
-$ sudo brew install msgpack
+$ brew install msgpack
 ```
 
 ## FreeBSD with Ports Collection


### PR DESCRIPTION
As per: https://github.com/Homebrew/brew/blob/master/docs/FAQ.md

> Homebrew is designed to work without using sudo. You can decide to use it but we strongly recommend not to do so. If you have used sudo and run into a bug then this is likely to be the cause. Please don’t file a bug report unless you can reproduce it after reinstalling Homebrew from scratch without using sudo.