### PR TITLE
Set `precise` explicitly to fix 32bit zlib missing problem.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: cpp
 sudo: false
+dist: precise
 
 install:
  - export BASE=`pwd`


### PR DESCRIPTION
It's temporary fix.
Need to find a way to install the 32 bit version of zlib on `trusty` dist in the future.
