### PR TITLE
Include <sys/uio.h> in NetBSD too.

### DIFF
--- a/include/msgpack/vrefbuffer.h
+++ b/include/msgpack/vrefbuffer.h
@@ -13,7 +13,7 @@
 #include "zone.h"
 #include <stdlib.h>
 
-#if defined(unix) || defined(__unix) || defined(__APPLE__) || defined(__OpenBSD__) || defined(__QNX__) || defined(__QNXTO__)
+#if defined(unix) || defined(__unix) || defined(__APPLE__) || defined(__OpenBSD__) || defined(__NetBSD__) || defined(__QNX__) || defined(__QNXTO__)
 #include <sys/uio.h>
 #else
 struct iovec {
@@ -138,4 +138,3 @@ static inline size_t msgpack_vrefbuffer_veclen(const msgpack_vrefbuffer* vref)
 #endif
 
 #endif /* msgpack/vrefbuffer.h */
-


### PR DESCRIPTION
This was needed for neovim
Hopefully, in the next release https://github.com/neovim/neovim/ will build in NetBSD without any errors. It downloads this as a dependency if not present in the system.