### PR TITLE
Fix -Werror=class-memaccess with gcc8

### DIFF
--- a/include/msgpack/v1/object.hpp
+++ b/include/msgpack/v1/object.hpp
@@ -661,7 +661,7 @@ inline object::object(const msgpack_object& o)
 inline void operator<< (msgpack::object& o, const msgpack_object& v)
 {
     // FIXME beter way?
-    std::memcpy(&o, &v, sizeof(v));
+    std::memcpy(static_cast<void*>(&o), &v, sizeof(v));
 }
 
 inline object::operator msgpack_object() const


### PR DESCRIPTION
Casting to void* make gcc happy since its upset about
object types and rightly so

Fixes

'void* memcpy(void*, const void*, size_t)' copying an object of non-trivial type 'struct msgpack::v2::object' from an array of 'const msgpack_object' {aka 'const struct msgpack_object'} [-Werror=class-memaccess]

Signed-off-by: Khem Raj <raj.khem@gmail.com>