### PR TITLE
Fix the fuzzer by setting limits for depth and ext.

### DIFF
--- a/fuzz/unpack_pack_fuzzer.cpp
+++ b/fuzz/unpack_pack_fuzzer.cpp
@@ -12,6 +12,8 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
                                                       msgpack::unpack_limit(test_limit,
                                                                             test_limit,
                                                                             test_limit,
+                                                                            test_limit,
+                                                                            test_limit,
                                                                             test_limit));
     msgpack::sbuffer sbuf;
     msgpack::pack(sbuf, unpacked.get());


### PR DESCRIPTION
This is a short lived bug in the fuzzer implementation in which the limits were not set correctly. It adds limits for depth and ext as detailed in https://github.com/msgpack/msgpack-c/blob/c6c31dc5cd56ad0f8bafd0db82e013aa92cea5c3/include/msgpack/v1/unpack_decl.hpp#L94-L95.

Credit to OSS-Fuzz