### PR TITLE
Add dll export for msvc

### DIFF
--- a/include/msgpack/pack.h
+++ b/include/msgpack/pack.h
@@ -98,6 +98,7 @@ static int msgpack_pack_bin_body(msgpack_packer* pk, const void* b, size_t l);
 static int msgpack_pack_ext(msgpack_packer* pk, size_t l, int8_t type);
 static int msgpack_pack_ext_body(msgpack_packer* pk, const void* b, size_t l);
 
+MSGPACK_DLLEXPORT
 int msgpack_pack_object(msgpack_packer* pk, msgpack_object d);
 
 


### PR DESCRIPTION
Without this patch, link error occurs below in "msvc".
```
error LNK2019: unresolved external symbol msgpack_pack_object referenced in function 
```

I think that it is correction omission of below commit.
https://github.com/msgpack/msgpack-c/commit/a4af97b32c018cbf0ce91153c937902c13e0d412