### PR TITLE
Lower limits for the fuzzer inputs

### DIFF
--- a/fuzz/unpack_pack_fuzzer.cpp
+++ b/fuzz/unpack_pack_fuzzer.cpp
@@ -4,7 +4,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
   try {
     // NOTE(derwolfe): by default the limits are set at 2^32-1 length. I'm
     // setting these at far smaller values to avoid OOMs
-    const int test_limit = 10000;
+    const int test_limit = 1000;
     msgpack::object_handle unpacked = msgpack::unpack(reinterpret_cast<const char *>(data),
                                                       size,
                                                       nullptr,


### PR DESCRIPTION
This is an attempt to keep the fuzzer from OOMing while running. The limit of 10,000 looks to allow memory usage to be right around the limits that OSS-fuzz provides. Lowering this by a factor of 10 should keep us healthily under the limit while still providing useful data.

Thanks!