### PR TITLE
Strip the build path from generated documentation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -307,6 +307,7 @@ IF (DOXYGEN_FOUND)
         COMMAND ${CMAKE_COMMAND} -E echo "INPUT              = ${CMAKE_CURRENT_SOURCE_DIR}/include" >> ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile_c
         COMMAND ${CMAKE_COMMAND} -E echo "EXTRACT_ALL        = YES" >> ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile_c
         COMMAND ${CMAKE_COMMAND} -E echo "PROJECT_NAME       = \"MessagePack for C\"" >> ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile_c
+        COMMAND ${CMAKE_COMMAND} -E echo "STRIP_FROM_PATH    = ${CMAKE_CURRENT_SOURCE_DIR}/include" >> ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile_c
     )
     IF (DOXYGEN_DOT_FOUND)
         LIST (APPEND Doxyfile_c_CONTENT
@@ -325,6 +326,7 @@ IF (DOXYGEN_FOUND)
         COMMAND ${CMAKE_COMMAND} -E echo "OUTPUT_DIRECTORY   = doc_cpp" >> ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile_cpp
         COMMAND ${CMAKE_COMMAND} -E echo "INPUT              = ${CMAKE_CURRENT_SOURCE_DIR}/include" >> ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile_cpp
         COMMAND ${CMAKE_COMMAND} -E echo "EXTRACT_ALL        = YES" >> ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile_cpp
+        COMMAND ${CMAKE_COMMAND} -E echo "STRIP_FROM_PATH    = ${CMAKE_CURRENT_SOURCE_DIR}/include" >> ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile_cpp
     )
     IF (DOXYGEN_DOT_FOUND)
         LIST (APPEND Doxyfile_cpp_CONTENT


### PR DESCRIPTION
Since FULL_PATH_NAMES = YES, Doxygen includes the full build path to the
file in the documentation.  This is most prevalent in the <title>
attribute for a file.

Setting STRIP_FROM_PATH = ${CMAKE_CURRENT_SOURCE_DIR}/include means that
only the relevant portion of the path (that which the user would need to
use) is included.

```diff
--- a/msgpack_8h.html	2018-05-12 14:03:34.098715879 -0400
+++ b/msgpack_8h.html	2018-05-12 14:04:17.386349607 -0400
@@ -5,7 +5,7 @@
 <meta http-equiv="X-UA-Compatible" content="IE=9"/>
 <meta name="generator" content="Doxygen 1.8.13"/>
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
-<title>MessagePack for C: /home/jamessan/src/debian.org/pkg-vim/msgpack-c/include/msgpack.h File Reference</title>
+<title>MessagePack for C: msgpack.h File Reference</title>
 <link href="tabs.css" rel="stylesheet" type="text/css"/>
 <script type="text/javascript" src="jquery.js"></script>
 <script type="text/javascript" src="dynsections.js"></script>
```