### PR TITLE
Fix MSGPACK_DEPRECATED for MSVC 1914 with /Zc:__cplusplus

### DIFF
--- a/include/msgpack/v1/cpp_config.hpp
+++ b/include/msgpack/v1/cpp_config.hpp
@@ -127,7 +127,11 @@ template<class T> struct is_pointer : detail::is_pointer_helper<typename remove_
 #endif // MSGPACK_USE_CPP03
 
 #if __cplusplus >= 201402L
+#if defined(_MSC_VER)
+#define MSGPACK_DEPRECATED(msg) __declspec(deprecated(msg))
+#else  // _MSC_VER 1914+ with /Zc:__cplusplus, @see https://docs.microsoft.com/cpp/build/reference/zc-cplusplus
 #define MSGPACK_DEPRECATED(msg) [[deprecated(msg)]]
+#endif
 #else  // __cplusplus >= 201402L
 #define MSGPACK_DEPRECATED(msg)
 #endif // __cplusplus >= 201402L


### PR DESCRIPTION
Fix MSGPACK_DEPRECATED for MSVC 1914 with /Zc:__cplusplus

@see https://docs.microsoft.com/cpp/build/reference/zc-cplusplus