### PR TITLE
Fix misspelled words in comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 ## << breaking changes >>
 
-  * Change offset parameter updating rule. If parse error is happend, offset is updated to the error position. (#639, #666)
+  * Change offset parameter updating rule. If parse error happens, offset is updated to the error position. (#639, #666)
 
 ## << other updates >>
 

--- a/Doxyfile
+++ b/Doxyfile
@@ -281,7 +281,7 @@ TYPEDEF_HIDES_STRUCT   = NO
 # causing a significant performance penality.
 # If the system has enough physical memory increasing the cache will improve the
 # performance by keeping more symbols in memory. Note that the value works on
-# a logarithmic scale so increasing the size by one will rougly double the
+# a logarithmic scale so increasing the size by one will roughly double the
 # memory usage. The cache size is given by this formula:
 # 2^(16+SYMBOL_CACHE_SIZE). The valid range is 0..9, the default is 0,
 # corresponding to a cache size of 2^16 = 65536 symbols

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ the binaries:' text box.
 
 ### Documentation
 
-You can get addtional information on the
+You can get additional information on the
 [wiki](https://github.com/msgpack/msgpack-c/wiki).
 
 Contributing

--- a/include/msgpack/v2/parse_decl.hpp
+++ b/include/msgpack/v2/parse_decl.hpp
@@ -39,7 +39,7 @@ class parser;
  * @param off The offset position of the buffer. It is read and overwritten.
  * @param v The visitor that satisfies visitor concept. https://github.com/msgpack/msgpack-c/wiki/v2_0_cpp_visitor#visitor-concept
  *
- * @return if unpacking process finishs without error then return true, otherwise return false.
+ * @return if unpacking process finishes without error then return true, otherwise return false.
  *
  */
 template <typename Visitor>
@@ -52,7 +52,7 @@ bool parse(const char* data, size_t len, size_t& off, Visitor& v);
  * @param len The length of the buffer.
  * @param v The visitor that satisfies visitor concept. https://github.com/msgpack/msgpack-c/wiki/v2_0_cpp_visitor#visitor-concept
  *
- * @return if unpacking process finishs without error then return true, otherwise return false.
+ * @return if unpacking process finishes without error then return true, otherwise return false.
  *
  */
 template <typename Visitor>

--- a/test/boost_variant.cpp
+++ b/test/boost_variant.cpp
@@ -329,7 +329,7 @@ TEST(MSGPACK_BOOST, object_with_zone_variant_str_ref)
     EXPECT_EQ(val1.as_boost_string_ref(), "ABC");
     msgpack::object obj(val1, z);
     msgpack::type::variant val2 = obj.as<msgpack::type::variant>();
-    // Coverted as std::string.
+    // Converted as std::string.
     EXPECT_TRUE(val2.is_string());
     EXPECT_EQ(val2.as_string(), "ABC");
     EXPECT_NO_THROW(boost::get<std::string>(val2));
@@ -399,7 +399,7 @@ TEST(MSGPACK_BOOST, object_with_zone_variant_raw_ref)
     EXPECT_EQ(val1.as_raw_ref(), msgpack::type::raw_ref(&v.front(), v.size()));
     msgpack::object obj(val1, z);
     msgpack::type::variant val2 = obj.as<msgpack::type::variant>();
-    // Coverted as std::vector<char>.
+    // Converted as std::vector<char>.
     EXPECT_TRUE(val2.is_vector_char());
     EXPECT_EQ(val2.as_vector_char(), v);
     EXPECT_NO_THROW(boost::get<std::vector<char> >(val2));
@@ -469,7 +469,7 @@ TEST(MSGPACK_BOOST, object_with_zone_variant_ext_ref)
     EXPECT_EQ(val1.as_ext_ref(), e);
     msgpack::object obj(val1, z);
     msgpack::type::variant val2 = obj.as<msgpack::type::variant>();
-    // Coverted as msgpack::type::ext.
+    // Converted as msgpack::type::ext.
     EXPECT_TRUE(val2.is_ext());
     EXPECT_EQ(val2.as_ext(), e);
     EXPECT_NO_THROW(boost::get<msgpack::type::ext>(val2));


### PR DESCRIPTION
This pull request fixes the minor typos detected by github.com/client9/misspell.