### PR TITLE
adding int overflow checks to vrefbuffer

### DIFF
--- a/include/msgpack/v1/vrefbuffer.hpp
+++ b/include/msgpack/v1/vrefbuffer.hpp
@@ -71,6 +71,12 @@ public:
         m_end   = array + nfirst;
         m_array = array;
 
+        
+        if((sizeof(chunk) + chunk_size) < chunk_size){
+            throw std::bad_alloc();
+        }
+        
+
         chunk* c = static_cast<chunk*>(::malloc(sizeof(chunk) + chunk_size));
         if(!c) {
             ::free(array);
@@ -141,7 +147,11 @@ public:
             if(sz < len) {
                 sz = len;
             }
-
+             
+            if(sizeof(chunk) + sz < sz){
+                throw std::bad_alloc();
+            }
+            
             chunk* c = static_cast<chunk*>(::malloc(sizeof(chunk) + sz));
             if(!c) {
                 throw std::bad_alloc();
@@ -182,6 +192,10 @@ public:
     void migrate(vrefbuffer* to)
     {
         size_t sz = m_chunk_size;
+
+        if((sizeof(chunk) + sz) < sz){
+            throw std::bad_alloc();
+        }
 
         chunk* empty = static_cast<chunk*>(::malloc(sizeof(chunk) + sz));
         if(!empty) {

--- a/include/msgpack/v1/vrefbuffer.hpp
+++ b/include/msgpack/v1/vrefbuffer.hpp
@@ -73,6 +73,7 @@ public:
 
         
         if((sizeof(chunk) + chunk_size) < chunk_size){
+            ::free(array); 
             throw std::bad_alloc();
         }
         

--- a/src/vrefbuffer.c
+++ b/src/vrefbuffer.c
@@ -43,6 +43,10 @@ bool msgpack_vrefbuffer_init(msgpack_vrefbuffer* vbuf,
     vbuf->end   = array + nfirst;
     vbuf->array = array;
 
+    if((sizeof(msgpack_vrefbuffer_chunk) + chunk_size) < chunk_size){
+        return false;
+    }
+
     chunk = (msgpack_vrefbuffer_chunk*)malloc(
             sizeof(msgpack_vrefbuffer_chunk) + chunk_size);
     if(chunk == NULL) {
@@ -135,6 +139,9 @@ int msgpack_vrefbuffer_append_copy(msgpack_vrefbuffer* vbuf,
             sz = len;
         }
 
+        if((sizeof(msgpack_vrefbuffer_chunk) + sz) < sz){
+            return -1;
+        }
         chunk = (msgpack_vrefbuffer_chunk*)malloc(
                 sizeof(msgpack_vrefbuffer_chunk) + sz);
         if(chunk == NULL) {
@@ -164,6 +171,10 @@ int msgpack_vrefbuffer_append_copy(msgpack_vrefbuffer* vbuf,
 int msgpack_vrefbuffer_migrate(msgpack_vrefbuffer* vbuf, msgpack_vrefbuffer* to)
 {
     size_t sz = vbuf->chunk_size;
+
+    if((sizeof(msgpack_vrefbuffer_chunk) + sz) < sz){
+        return -1;
+    }
 
     msgpack_vrefbuffer_chunk* empty = (msgpack_vrefbuffer_chunk*)malloc(
             sizeof(msgpack_vrefbuffer_chunk) + sz);

--- a/src/vrefbuffer.c
+++ b/src/vrefbuffer.c
@@ -171,12 +171,13 @@ int msgpack_vrefbuffer_append_copy(msgpack_vrefbuffer* vbuf,
 int msgpack_vrefbuffer_migrate(msgpack_vrefbuffer* vbuf, msgpack_vrefbuffer* to)
 {
     size_t sz = vbuf->chunk_size;
+    msgpack_vrefbuffer_chunk* empty = NULL;
 
     if((sizeof(msgpack_vrefbuffer_chunk) + sz) < sz){
         return -1;
     }
 
-    msgpack_vrefbuffer_chunk* empty = (msgpack_vrefbuffer_chunk*)malloc(
+    empty = (msgpack_vrefbuffer_chunk*)malloc(
             sizeof(msgpack_vrefbuffer_chunk) + sz);
     if(empty == NULL) {
         return -1;

--- a/src/vrefbuffer.c
+++ b/src/vrefbuffer.c
@@ -44,6 +44,7 @@ bool msgpack_vrefbuffer_init(msgpack_vrefbuffer* vbuf,
     vbuf->array = array;
 
     if((sizeof(msgpack_vrefbuffer_chunk) + chunk_size) < chunk_size){
+        free(array);
         return false;
     }
 

--- a/test/msgpack_c.cpp
+++ b/test/msgpack_c.cpp
@@ -1354,7 +1354,7 @@ TEST(MSGPACKC, unpack_array_uint64)
 }
 
 
-TEST(MSGPACKC, vreff_buffer_overflow)
+TEST(MSGPACKC, vref_buffer_overflow)
 {
     msgpack_vrefbuffer vbuf;
     msgpack_vrefbuffer to;

--- a/test/msgpack_c.cpp
+++ b/test/msgpack_c.cpp
@@ -1352,3 +1352,16 @@ TEST(MSGPACKC, unpack_array_uint64)
     EXPECT_EQ(0xFFF0000000000001LL, obj.via.array.ptr[0].via.u64);
     msgpack_zone_destroy(&z);
 }
+
+
+TEST(MSGPACKC, vreff_buffer_overflow)
+{
+    msgpack_vrefbuffer vbuf;
+    msgpack_vrefbuffer to;
+    size_t ref_size = 0;
+    size_t len = 0x1000;
+    size_t chunk_size = std::numeric_limits<size_t>::max();
+    char *buf = (char *)malloc(len);
+    EXPECT_FALSE(msgpack_vrefbuffer_init(&vbuf, ref_size, chunk_size));
+    EXPECT_EQ(-1, msgpack_vrefbuffer_migrate(&vbuf, &to));
+}

--- a/test/msgpack_c.cpp
+++ b/test/msgpack_c.cpp
@@ -1359,9 +1359,7 @@ TEST(MSGPACKC, vreff_buffer_overflow)
     msgpack_vrefbuffer vbuf;
     msgpack_vrefbuffer to;
     size_t ref_size = 0;
-    size_t len = 0x1000;
     size_t chunk_size = std::numeric_limits<size_t>::max();
-    char *buf = (char *)malloc(len);
     EXPECT_FALSE(msgpack_vrefbuffer_init(&vbuf, ref_size, chunk_size));
     EXPECT_EQ(-1, msgpack_vrefbuffer_migrate(&vbuf, &to));
 }

--- a/test/msgpack_vref.cpp
+++ b/test/msgpack_vref.cpp
@@ -264,3 +264,12 @@ TEST(MSGPACK, vrefbuffer_small_int64)
     msgpack::vrefbuffer vbuf(0, 0);
     GEN_TEST_VREF(int64_t, vbuf);
 }
+
+TEST(MSGPACK, vref_buffer_overflow)
+{   
+    size_t chunk_size = std::numeric_limits<size_t>::max();
+    char *buf = (char *)malloc(chunk_size);
+    ASSERT_THROW(msgpack::vrefbuffer vbuf(0, chunk_size), std::bad_alloc);
+    msgpack::vrefbuffer vbuf(0,0x1000);
+    ASSERT_THROW(vbuf.append_copy(buf, chunk_size), std::bad_alloc);
+}

--- a/test/msgpack_vref.cpp
+++ b/test/msgpack_vref.cpp
@@ -268,8 +268,8 @@ TEST(MSGPACK, vrefbuffer_small_int64)
 TEST(MSGPACK, vref_buffer_overflow)
 {   
     size_t chunk_size = std::numeric_limits<size_t>::max();
-    char *buf = (char *)malloc(chunk_size);
-    ASSERT_THROW(msgpack::vrefbuffer vbuf(0, chunk_size), std::bad_alloc);
+    char * buf=(char *)malloc(0x1000);
+    ASSERT_THROW(msgpack::vrefbuffer vbuf(0, chunk_size), std::bad_alloc); 
     msgpack::vrefbuffer vbuf(0,0x1000);
     ASSERT_THROW(vbuf.append_copy(buf, chunk_size), std::bad_alloc);
     free(buf);

--- a/test/msgpack_vref.cpp
+++ b/test/msgpack_vref.cpp
@@ -272,4 +272,5 @@ TEST(MSGPACK, vref_buffer_overflow)
     ASSERT_THROW(msgpack::vrefbuffer vbuf(0, chunk_size), std::bad_alloc);
     msgpack::vrefbuffer vbuf(0,0x1000);
     ASSERT_THROW(vbuf.append_copy(buf, chunk_size), std::bad_alloc);
+    free(buf);
 }


### PR DESCRIPTION
`chunk_size` is not validated properly so if a sufficiently large `chunk_size` were provided, a small heap chunk could be allocated for a `msgpack_vrefbuffer` object, which later could be written into through a function like `msgpack_vrefbuffer_append_copy()`. If the developer is not aware of the integer wrapping/overflow issue, they could `memcpy()` a large number of bytes to a small heap chunk, leading to a heap overflow. This minor commit just adds some extra checks to mitigate the chances of this happening. 

The following POC will trigger a SIGABRT due to memory corruption.
```C
#include <stdlib.h>
#include <msgpack.h>
 
int main(void) {
    msgpack_vrefbuffer vbuf1;
    msgpack_vrefbuffer vbuf2;
    msgpack_vrefbuffer vbuf3;
    size_t ref_size = 0;
    size_t chunk_size = 0xffffffff;
    size_t len = 0x1000;
    char* buf = (char *)malloc(len);
    
    memset(buf, 'A', 1000);

    msgpack_vrefbuffer_init(&vbuf1, ref_size, 0x200);
    msgpack_vrefbuffer_init(&vbuf2, ref_size, 0x200);
    msgpack_vrefbuffer_destroy(&vbuf1);

    msgpack_vrefbuffer_init(&vbuf3, ref_size, chunk_size);
    msgpack_vrefbuffer_append_copy(&vbuf3, buf, len); 
    msgpack_vrefbuffer_destroy(&vbuf2);
  
    return 0;
}
```
```
*** Error in `/home/jwang/msgpack-c/afl/vuln': double free or corruption (out): 0x0804c2b8 ***                            

Program received signal SIGABRT, Aborted.
[----------------------------------registers-----------------------------------]                                                             
EAX: 0x0
EBX: 0x59b5
ECX: 0x59b5
EDX: 0x6
ESI: 0x72 ('r')
EDI: 0xf7fae000 --> 0x1acda8
EBP: 0xffffd418 --> 0x494603f0
ESP: 0xffffd154 --> 0xffffd418 --> 0x494603f0
EIP: 0xf7fdacd9 (pop    ebp)
EFLAGS: 0x206 (carry PARITY adjust zero sign trap INTERRUPT direction overflow)                                                              
[-------------------------------------code-------------------------------------]                                                             
   0xf7fdacd3:  mov    ebp,esp
   0xf7fdacd5:  sysenter 
   0xf7fdacd7:  int    0x80
=> 0xf7fdacd9:  pop    ebp
   0xf7fdacda:  pop    edx
   0xf7fdacdb:  pop    ecx
   0xf7fdacdc:  ret    
   0xf7fdacdd:  and    edi,edx
[------------------------------------stack-------------------------------------]                                                             
0000| 0xffffd154 --> 0xffffd418 --> 0x494603f0
0004| 0xffffd158 --> 0x6
0008| 0xffffd15c --> 0x59b5
0012| 0xffffd160 --> 0xf7e2f687 (<__GI_raise+71>:       xchg   ebx,edi)
0016| 0xffffd164 --> 0xf7fae000 --> 0x1acda8
0020| 0xffffd168 --> 0xffffd204 --> 0x0
0024| 0xffffd16c --> 0xf7e32ab3 (<__GI_abort+323>:      mov    edx,DWORD PTR gs:0x8)                                                         
0028| 0xffffd170 --> 0x6
[------------------------------------------------------------------------------]                                                             
Legend: code, data, rodata, value
Stopped reason: SIGABRT
0xf7fdacd9 in ?? ()
gdb-peda$ bt
#0  0xf7fdacd9 in ?? ()
#1  0xf7e744ca in malloc_printerr (action=<optimized out>, str=0xf7f69314 "double free or corruption (out)", ptr=0x804c2b8) at malloc.c:4998 
#2  0xf7e751bd in _int_free (av=0xf7fae420 <main_arena>, p=<optimized out>, have_lock=0x0) at malloc.c:3842                                  
#3  0x080486ac in msgpack_vrefbuffer_destroy ()
#4  0x080485b2 in main (argc=0x1, argv=0xffffd624) at ./afl/vuln.c:21
#5  0xf7e1aaf3 in __libc_start_main (main=0x80484dd <main>, argc=0x1, argv=0xffffd624, init=0x8048b30 <__libc_csu_init>,                     
    fini=0x8048ba0 <__libc_csu_fini>, rtld_fini=0xf7feb300 <_dl_fini>, stack_end=0xffffd61c) at libc-start.c:287                             
#6  0x08048401 in _start ()
```