### PR TITLE
Split write into write and reserve

### DIFF
--- a/include/msgpack/v1/sbuffer.hpp
+++ b/include/msgpack/v1/sbuffer.hpp
@@ -67,14 +67,14 @@ public:
 #endif // !defined(MSGPACK_USE_CPP03)
 
     void* reserve(size_t len)
-	{
+    {
         if(m_alloc - m_size < len) {
             expand_buffer(len);
         }
         void* data = m_data + m_size;
         m_size += len;
-		return data;
-	}
+        return data;
+    }
 
     void write(const char* buf, size_t len)
     {

--- a/include/msgpack/v1/sbuffer.hpp
+++ b/include/msgpack/v1/sbuffer.hpp
@@ -66,12 +66,20 @@ public:
     }
 #endif // !defined(MSGPACK_USE_CPP03)
 
-    void write(const char* buf, size_t len)
-    {
+    void* reserve(size_t len)
+	{
         if(m_alloc - m_size < len) {
             expand_buffer(len);
         }
-        std::memcpy(m_data + m_size, buf, len);
+        void* data = m_data + m_size;
+        m_size += len;
+		return data;
+	}
+
+    void write(const char* buf, size_t len)
+    {
+        void* data = reserve(len);
+        std::memcpy(data, buf, len);
         m_size += len;
     }
 


### PR DESCRIPTION
When I need to mix msgpack with non-msgpack data, I want to use sbuffer to keep a piece of data for later refilling. Such as a crc32  in the file header.