### PR TITLE
Fix gcc-8 error about "copying an object of non-trivial type" (-Werror=class-memaccess)

### DIFF
--- a/include/msgpack/object.hpp
+++ b/include/msgpack/object.hpp
@@ -614,7 +614,7 @@ inline object::object(const msgpack_object& o)
 inline void operator<< (msgpack::object& o, const msgpack_object& v)
 {
     // FIXME beter way?
-    std::memcpy(&o, &v, sizeof(v));
+    std::memcpy(static_cast<void*>(&o), &v, sizeof(v));
 }
 
 inline object::operator msgpack_object() const


### PR DESCRIPTION
This problem was already fixed on master (#659) and this merge request just backports the (trivial) change to the cpp-1.4 branch.