### PR TITLE
Fixed #754.

### DIFF
--- a/include/msgpack/v1/object.hpp
+++ b/include/msgpack/v1/object.hpp
@@ -352,8 +352,8 @@ struct object_pack_visitor {
         return true;
     }
     bool visit_ext(const char* v, uint32_t size) {
-        m_packer.pack_ext(size, *v);
-        m_packer.pack_ext_body(v, size);
+        m_packer.pack_ext(size - 1, *v);
+        m_packer.pack_ext_body(v + 1, size - 1);
         return true;
     }
     bool start_array(uint32_t num_elements) {
@@ -938,7 +938,7 @@ struct object_equal_visitor {
     }
     bool visit_ext(const char* v, uint32_t size) {
         if (m_ptr->type != msgpack::type::EXT ||
-            m_ptr->via.ext.size != size ||
+            m_ptr->via.ext.size != size - 1 ||
             std::memcmp(m_ptr->via.ext.ptr, v, size) != 0) {
             m_result = false;
             return false;

--- a/test/msgpack_basic.cpp
+++ b/test/msgpack_basic.cpp
@@ -331,6 +331,16 @@ TEST(MSGPACK, simple_buffer_fixext1)
     EXPECT_EQ(1ul, oh.get().via.ext.size);
     EXPECT_EQ(1, oh.get().via.ext.type());
     EXPECT_EQ(2, oh.get().via.ext.data()[0]);
+
+    msgpack::sbuffer sbuf2;
+    msgpack::pack(sbuf2, oh.get());
+    msgpack::object_handle oh2 =
+        msgpack::unpack(sbuf2.data(), sbuf2.size());
+    EXPECT_EQ(1ul, oh2.get().via.ext.size);
+    EXPECT_EQ(1, oh2.get().via.ext.type());
+    EXPECT_EQ(2, oh2.get().via.ext.data()[0]);
+
+    EXPECT_EQ(oh.get(), oh2.get());
 }
 
 TEST(MSGPACK, simple_buffer_fixext2)
@@ -347,6 +357,17 @@ TEST(MSGPACK, simple_buffer_fixext2)
     EXPECT_EQ(0, oh.get().via.ext.type());
     EXPECT_TRUE(
         std::equal(buf, buf + sizeof(buf), oh.get().via.ext.data()));
+
+    msgpack::sbuffer sbuf2;
+    msgpack::pack(sbuf2, oh.get());
+    msgpack::object_handle oh2 =
+        msgpack::unpack(sbuf2.data(), sbuf2.size());
+    EXPECT_EQ(2ul, oh2.get().via.ext.size);
+    EXPECT_EQ(0, oh2.get().via.ext.type());
+    EXPECT_TRUE(
+        std::equal(buf, buf + sizeof(buf), oh2.get().via.ext.data()));
+
+    EXPECT_EQ(oh.get(), oh2.get());
 }
 
 TEST(MSGPACK, simple_buffer_fixext4)
@@ -363,6 +384,17 @@ TEST(MSGPACK, simple_buffer_fixext4)
     EXPECT_EQ(1, oh.get().via.ext.type());
     EXPECT_TRUE(
         std::equal(buf, buf + sizeof(buf), oh.get().via.ext.data()));
+
+    msgpack::sbuffer sbuf2;
+    msgpack::pack(sbuf2, oh.get());
+    msgpack::object_handle oh2 =
+        msgpack::unpack(sbuf2.data(), sbuf2.size());
+    EXPECT_EQ(4ul, oh2.get().via.ext.size);
+    EXPECT_EQ(1, oh2.get().via.ext.type());
+    EXPECT_TRUE(
+        std::equal(buf, buf + sizeof(buf), oh2.get().via.ext.data()));
+
+    EXPECT_EQ(oh.get(), oh2.get());
 }
 
 TEST(MSGPACK, simple_buffer_fixext8)
@@ -379,6 +411,17 @@ TEST(MSGPACK, simple_buffer_fixext8)
     EXPECT_EQ(1, oh.get().via.ext.type());
     EXPECT_TRUE(
         std::equal(buf, buf + sizeof(buf), oh.get().via.ext.data()));
+
+    msgpack::sbuffer sbuf2;
+    msgpack::pack(sbuf2, oh.get());
+    msgpack::object_handle oh2 =
+        msgpack::unpack(sbuf2.data(), sbuf2.size());
+    EXPECT_EQ(8ul, oh2.get().via.ext.size);
+    EXPECT_EQ(1, oh2.get().via.ext.type());
+    EXPECT_TRUE(
+        std::equal(buf, buf + sizeof(buf), oh2.get().via.ext.data()));
+
+    EXPECT_EQ(oh.get(), oh2.get());
 }
 
 TEST(MSGPACK, simple_buffer_fixext16)
@@ -395,6 +438,17 @@ TEST(MSGPACK, simple_buffer_fixext16)
     EXPECT_EQ(1, oh.get().via.ext.type());
     EXPECT_TRUE(
         std::equal(buf, buf + sizeof(buf), oh.get().via.ext.data()));
+
+    msgpack::sbuffer sbuf2;
+    msgpack::pack(sbuf2, oh.get());
+    msgpack::object_handle oh2 =
+        msgpack::unpack(sbuf2.data(), sbuf2.size());
+    EXPECT_EQ(16ul, oh2.get().via.ext.size);
+    EXPECT_EQ(1, oh2.get().via.ext.type());
+    EXPECT_TRUE(
+        std::equal(buf, buf + sizeof(buf), oh2.get().via.ext.data()));
+
+    EXPECT_EQ(oh.get(), oh2.get());
 }
 
 TEST(MSGPACK, simple_buffer_fixext_1byte_0)
@@ -426,6 +480,17 @@ TEST(MSGPACK, simple_buffer_fixext_1byte_255)
     EXPECT_EQ(77, oh.get().via.ext.type());
     EXPECT_TRUE(
         std::equal(buf, buf + sizeof(buf), oh.get().via.ext.data()));
+
+    msgpack::sbuffer sbuf2;
+    msgpack::pack(sbuf2, oh.get());
+    msgpack::object_handle oh2 =
+        msgpack::unpack(sbuf2.data(), sbuf2.size());
+    EXPECT_EQ(size, oh2.get().via.ext.size);
+    EXPECT_EQ(77, oh2.get().via.ext.type());
+    EXPECT_TRUE(
+        std::equal(buf, buf + sizeof(buf), oh2.get().via.ext.data()));
+
+    EXPECT_EQ(oh.get(), oh2.get());
 }
 
 TEST(MSGPACK, simple_buffer_fixext_2byte_256)
@@ -444,6 +509,17 @@ TEST(MSGPACK, simple_buffer_fixext_2byte_256)
     EXPECT_EQ(77, oh.get().via.ext.type());
     EXPECT_TRUE(
         std::equal(buf, buf + sizeof(buf), oh.get().via.ext.data()));
+
+    msgpack::sbuffer sbuf2;
+    msgpack::pack(sbuf2, oh.get());
+    msgpack::object_handle oh2 =
+        msgpack::unpack(sbuf2.data(), sbuf2.size());
+    EXPECT_EQ(size, oh2.get().via.ext.size);
+    EXPECT_EQ(77, oh2.get().via.ext.type());
+    EXPECT_TRUE(
+        std::equal(buf, buf + sizeof(buf), oh2.get().via.ext.data()));
+
+    EXPECT_EQ(oh.get(), oh2.get());
 }
 
 TEST(MSGPACK, simple_buffer_fixext_2byte_65535)
@@ -462,6 +538,17 @@ TEST(MSGPACK, simple_buffer_fixext_2byte_65535)
     EXPECT_EQ(77, oh.get().via.ext.type());
     EXPECT_TRUE(
         std::equal(buf, buf + sizeof(buf), oh.get().via.ext.data()));
+
+    msgpack::sbuffer sbuf2;
+    msgpack::pack(sbuf2, oh.get());
+    msgpack::object_handle oh2 =
+        msgpack::unpack(sbuf2.data(), sbuf2.size());
+    EXPECT_EQ(size, oh2.get().via.ext.size);
+    EXPECT_EQ(77, oh2.get().via.ext.type());
+    EXPECT_TRUE(
+        std::equal(buf, buf + sizeof(buf), oh2.get().via.ext.data()));
+
+    EXPECT_EQ(oh.get(), oh2.get());
 }
 
 TEST(MSGPACK, simple_buffer_fixext_4byte_65536)
@@ -480,6 +567,17 @@ TEST(MSGPACK, simple_buffer_fixext_4byte_65536)
     EXPECT_EQ(77, oh.get().via.ext.type());
     EXPECT_TRUE(
         std::equal(buf, buf + sizeof(buf), oh.get().via.ext.data()));
+
+    msgpack::sbuffer sbuf2;
+    msgpack::pack(sbuf2, oh.get());
+    msgpack::object_handle oh2 =
+        msgpack::unpack(sbuf2.data(), sbuf2.size());
+    EXPECT_EQ(size, oh2.get().via.ext.size);
+    EXPECT_EQ(77, oh2.get().via.ext.type());
+    EXPECT_TRUE(
+        std::equal(buf, buf + sizeof(buf), oh2.get().via.ext.data()));
+
+    EXPECT_EQ(oh.get(), oh2.get());
 }
 
 TEST(MSGPACK, simple_buffer_ext_convert)


### PR DESCRIPTION
Fixed `msgpack::object` packing visitor and equal comparison visitor.

NOTE:
In the function `visit_ext(const char* v, uint32_t size)`, v contains
type and size means buffer `v` size. See #175.