### PR TITLE
Add support for Windows Drivers

### DIFF
--- a/include/msgpack/object.h
+++ b/include/msgpack/object.h
@@ -97,8 +97,10 @@ typedef struct msgpack_object_kv {
     msgpack_object val;
 } msgpack_object_kv;
 
+#if !defined(_KERNEL_MODE)
 MSGPACK_DLLEXPORT
 void msgpack_object_print(FILE* out, msgpack_object o);
+#endif
 
 MSGPACK_DLLEXPORT
 int msgpack_object_print_buffer(char *buffer, size_t buffer_size, msgpack_object o);

--- a/include/msgpack/pack_template.h
+++ b/include/msgpack/pack_template.h
@@ -34,6 +34,10 @@
 #error msgpack_pack_append_buffer callback is not defined
 #endif
 
+#if defined(_MSC_VER)
+#   pragma warning(push)
+#   pragma warning(disable : 4204)   /* nonstandard extension used: non-constant aggregate initializer */
+#endif
 
 /*
  * Integer
@@ -935,3 +939,7 @@ msgpack_pack_inline_func(_timestamp)(msgpack_pack_user x, const msgpack_timestam
 #undef msgpack_pack_real_int16
 #undef msgpack_pack_real_int32
 #undef msgpack_pack_real_int64
+
+#if defined(_MSC_VER)
+#   pragma warning(pop)
+#endif

--- a/include/msgpack/sysdep.h
+++ b/include/msgpack/sysdep.h
@@ -42,10 +42,14 @@
 #endif
 
 #ifdef _WIN32
-#   define _msgpack_atomic_counter_header <windows.h>
-#   if !defined(WIN32_LEAN_AND_MEAN)
-#       define WIN32_LEAN_AND_MEAN
-#   endif /* WIN32_LEAN_AND_MEAN */
+#   if defined(_KERNEL_MODE)
+#       define _msgpack_atomic_counter_header <ntddk.h>
+#   else
+#       define _msgpack_atomic_counter_header <windows.h>
+#       if !defined(WIN32_LEAN_AND_MEAN)
+#           define WIN32_LEAN_AND_MEAN
+#       endif /* WIN32_LEAN_AND_MEAN */
+#   endif
     typedef long _msgpack_atomic_counter_t;
 #   define _msgpack_sync_decr_and_fetch(ptr) InterlockedDecrement(ptr)
 #   define _msgpack_sync_incr_and_fetch(ptr) InterlockedIncrement(ptr)
@@ -180,11 +184,13 @@
 
 
 #if !defined(__cplusplus) && defined(_MSC_VER)
-#  if !defined(FALSE)
-#    define FALSE (0)
-#  endif
-#  if !defined(TRUE)
-#    define TRUE (!FALSE)
+#  if !defined(_KERNEL_MODE)
+#    if !defined(FALSE)
+#      define FALSE (0)
+#    endif
+#    if !defined(TRUE)
+#      define TRUE (!FALSE)
+#    endif
 #  endif
 #  if _MSC_VER >= 1800
 #    include <stdbool.h>

--- a/include/msgpack/unpack_template.h
+++ b/include/msgpack/unpack_template.h
@@ -38,6 +38,11 @@
 #endif
 #endif
 
+#if defined(_KERNEL_MODE)
+#undef  assert
+#define assert NT_ASSERT
+#endif
+
 msgpack_unpack_struct_decl(_stack) {
     msgpack_unpack_object obj;
     size_t count;


### PR DESCRIPTION
This commit enables msgpack to be compiled as a part of Windows Driver. MSVC automatically creates macro `_KERNEL_MODE` when source code is compiled with `/kernel` switch (this compiler switch is turned on when driver is compiled).

Changes:

- `msgpack_object_print` and `msgpack_object_bin_print` are disabled, because there is no `printf` in kernel mode
- `msgpack_object_print` and `msgpack_object_bin_print` are moved so they are together (so that one `#if defined(...)` can wrap them)
- Return value is explicitly casted from `size_t` to `int` to disable compiler warning
- Warning `4204` is disabled when compiling with MSVC
- `_msgpack_atomic_counter_header` is set to `<ntddk.h>` if `_KERNEL_MODE` is defined (it contains prototypes for `InterlockedIncrement` and `InterlockedDecrement`)
- `TRUE` and `FALSE` macros are disabled if `_KERNEL_MODE` is defined (they are defined unconditionally in `<ntddk.h>`)
- `assert` is redefined to `NT_ASSERT` (assert specific to Windows Drivers)
- `_NO_CRT_STDIO_INLINE` is unconditionally defined (it makes `_snprintf` symbol to be imported from ntoskrnl.exe)
- `snprintf` is redefined to `_snprintf` (because ntoskrnl.exe does not export `snprintf`, only `_snprintf`, but they have same behavior)

