### PR TITLE
Fix header circular reference

### DIFF
--- a/include/msgpack/v1/adaptor/array_ref.hpp
+++ b/include/msgpack/v1/adaptor/array_ref.hpp
@@ -10,7 +10,6 @@
 #ifndef MSGPACK_V1_TYPE_ARRAY_REF_HPP
 #define MSGPACK_V1_TYPE_ARRAY_REF_HPP
 
-#include "msgpack/v1/adaptor/array_ref.hpp"
 #include "msgpack/adaptor/check_container_size.hpp"
 #include "msgpack/cpp_config.hpp"
 #include <cstring>


### PR DESCRIPTION
I found this self-including header using IWYU ( https://github.com/include-what-you-use/include-what-you-use ), as it tripped an assertion.