### PR TITLE
Fixed #794.

### DIFF
--- a/include/msgpack/v1/zbuffer.hpp
+++ b/include/msgpack/v1/zbuffer.hpp
@@ -69,6 +69,7 @@ public:
             case Z_STREAM_END:
                 return m_data;
             case Z_OK:
+            case Z_BUF_ERROR:
                 if(!expand()) {
                     throw std::bad_alloc();
                 }

--- a/include/msgpack/zbuffer.h
+++ b/include/msgpack/zbuffer.h
@@ -146,6 +146,7 @@ static inline char* msgpack_zbuffer_flush(msgpack_zbuffer* zbuf)
         case Z_STREAM_END:
             return zbuf->data;
         case Z_OK:
+        case Z_BUF_ERROR:
             if(!msgpack_zbuffer_expand(zbuf)) {
                 return NULL;
             }


### PR DESCRIPTION
Buffer is expanded not only Z_OK, but also Z_BUF_ERROR case.