### PR TITLE
Add "defined(__HAIKU__)", closes #796

### DIFF
--- a/include/msgpack/vrefbuffer.h
+++ b/include/msgpack/vrefbuffer.h
@@ -13,7 +13,7 @@
 #include "zone.h"
 #include <stdlib.h>
 
-#if defined(unix) || defined(__unix) || defined(__APPLE__) || defined(__OpenBSD__) || defined(__NetBSD__) || defined(__QNX__) || defined(__QNXTO__)
+#if defined(unix) || defined(__unix) || defined(__APPLE__) || defined(__OpenBSD__) || defined(__NetBSD__) || defined(__QNX__) || defined(__QNXTO__) || defined(__HAIKU__)
 #include <sys/uio.h>
 #else
 struct iovec {


### PR DESCRIPTION
https://github.com/msgpack/msgpack-c/blob/f65c26e280f3f2e05c45d2d7b9e21a0b494b0fcd/include/msgpack/vrefbuffer.h#L16 needs `__HAIKU__`.

Reference:
https://github.com/haikuports/haikuports/issues/3980