### PR TITLE
prevent segfaults when packing damaged msgpack_objects

### DIFF
--- a/src/objectc.c
+++ b/src/objectc.c
@@ -90,7 +90,7 @@ int msgpack_pack_object(msgpack_packer* pk, msgpack_object d)
             }
             else {
                 msgpack_object* o = d.via.array.ptr;
-                if (o == nil) { return -1 }
+                if (o == NULL) { return -1; }
                 msgpack_object* const oend = d.via.array.ptr + d.via.array.size;
                 for(; o != oend; ++o) {
                     ret = msgpack_pack_object(pk, *o);
@@ -109,7 +109,7 @@ int msgpack_pack_object(msgpack_packer* pk, msgpack_object d)
             }
             else {
                 msgpack_object_kv* kv = d.via.map.ptr;
-                if (kv == nil) { return -1 }
+                if (kv == NULL) { return -1; }
                 msgpack_object_kv* const kvend = d.via.map.ptr + d.via.map.size;
                 for(; kv != kvend; ++kv) {
                     ret = msgpack_pack_object(pk, kv->key);

--- a/src/objectc.c
+++ b/src/objectc.c
@@ -90,6 +90,7 @@ int msgpack_pack_object(msgpack_packer* pk, msgpack_object d)
             }
             else {
                 msgpack_object* o = d.via.array.ptr;
+                if (o == nil) { return -1 }
                 msgpack_object* const oend = d.via.array.ptr + d.via.array.size;
                 for(; o != oend; ++o) {
                     ret = msgpack_pack_object(pk, *o);
@@ -108,6 +109,7 @@ int msgpack_pack_object(msgpack_packer* pk, msgpack_object d)
             }
             else {
                 msgpack_object_kv* kv = d.via.map.ptr;
+                if (kv == nil) { return -1 }
                 msgpack_object_kv* const kvend = d.via.map.ptr + d.via.map.size;
                 for(; kv != kvend; ++kv) {
                     ret = msgpack_pack_object(pk, kv->key);


### PR DESCRIPTION
We have been experiencing Segfaults when running fluent-bit which looks to be ocurring in the msgpack-c code: -

```
Sep 10 14:53:32 ip-10-17-16-247.us-west-2.compute.internal docker[85350]: [engine] caught signal (SIGSEGV)
#0  0x56098b412d0b      in  msgpack_pack_object() at lib/msgpack-3.2.0/src/objectc.c:113
#1  0x56098b15f696      in  splunk_format() at plugins/out_splunk/splunk.c:119
#2  0x56098b15f877      in  cb_splunk_flush() at plugins/out_splunk/splunk.c:176
#3  0x56098b10dcda      in  output_pre_cb_flush() at include/fluent-bit/flb_output.h:316
#4  0x56098b430606      in  co_init() at lib/monkey/deps/flb_libco/amd64.c:117
#5  0x7f13477cf708      in  ???() at ???:0
```

The issue appears to be trying to dereference msgpack_object_kv* which is `nil`

```
    case MSGPACK_OBJECT_MAP:
        {
            int ret = msgpack_pack_map(pk, d.via.map.size);
            if(ret < 0) {
                return ret;
            }
            else {
                msgpack_object_kv* kv = d.via.map.ptr;
                msgpack_object_kv* const kvend = d.via.map.ptr + d.via.map.size;
                for(; kv != kvend; ++kv) {
113 ->              ret = msgpack_pack_object(pk, kv->key);
                    if(ret < 0) { return ret; }
                    ret = msgpack_pack_object(pk, kv->val);
                    if(ret < 0) { return ret; }
                }

                return 0;
            }
        }
```

Rather than segfaulting, if we add a check for nil pointer we can return an error instead?