### PR TITLE
Include <sys/uio.h> in Linux

### DIFF
--- a/include/msgpack/vrefbuffer.h
+++ b/include/msgpack/vrefbuffer.h
@@ -13,7 +13,7 @@
 #include "zone.h"
 #include <stdlib.h>
 
-#if defined(unix) || defined(__unix) || defined(__APPLE__) || defined(__OpenBSD__) || defined(__NetBSD__) || defined(__QNX__) || defined(__QNXTO__) || defined(__HAIKU__)
+#if defined(unix) || defined(__unix) || defined(__linux__) || defined(__APPLE__) || defined(__OpenBSD__) || defined(__NetBSD__) || defined(__QNX__) || defined(__QNXTO__) || defined(__HAIKU__)
 #include <sys/uio.h>
 #else
 struct iovec {


### PR DESCRIPTION
This is needed when cross-compiling msgpack-c for OpenWrt.

Without it, compilation fails:
```
In file included from /build/staging_dir/target-powerpc_8540_musl/usr/include/msgpack.h:22:0,
                 from main.c:35:
/build/staging_dir/target-powerpc_8540_musl/usr/include/msgpack/vrefbuffer.h:19:8: error: redefinition of 'struct iovec'
 struct iovec {
        ^~~~~
```