### PR TITLE
Fix msgpack_cpp11 tests on 32-bit architectures

### DIFF
--- a/test/msgpack_cpp11.cpp
+++ b/test/msgpack_cpp11.cpp
@@ -1082,7 +1082,7 @@ TEST(MSGPACK_TIMESPEC, timespec_object_with_zone_zero)
 TEST(MSGPACK_TIMESPEC, timespec_pack_convert_32bit_sec)
 {
     std::stringstream ss;
-    timespec val1{ 0xffffffffUL, 0 };
+    timespec val1{ std::numeric_limits<decltype(std::declval<timespec>().tv_sec)>::is_signed ? INT32_MAX : UINT32_MAX, 0 };
 
     msgpack::pack(ss, val1);
     std::string const& str = ss.str();
@@ -1098,7 +1098,7 @@ TEST(MSGPACK_TIMESPEC, timespec_pack_convert_32bit_sec)
 TEST(MSGPACK_TIMESPEC, timespec_object_with_zone_32bit_sec)
 {
     msgpack::zone z;
-    timespec val1{ 0xffffffffUL, 0 };
+    timespec val1{ std::numeric_limits<decltype(std::declval<timespec>().tv_sec)>::is_signed ? INT32_MAX : UINT32_MAX, 0 };
     msgpack::object obj(val1, z);
     timespec val2 = obj.as<timespec>();
     EXPECT_EQ(val1.tv_sec, val2.tv_sec);

--- a/test/msgpack_cpp11.cpp
+++ b/test/msgpack_cpp11.cpp
@@ -1188,6 +1188,7 @@ TEST(MSGPACK_TIMESPEC, timespec_object_with_zone_35bit_sec_max_nano)
 
 TEST(MSGPACK_TIMESPEC, timespec_pack_convert_64bit_sec_max_nano)
 {
+    if (sizeof(decltype(std::declval<timespec>().tv_sec)) <= 4) return;
     std::stringstream ss;
     timespec val1{ std::numeric_limits<decltype(std::declval<timespec>().tv_sec)>::max(), 999999999 };
 


### PR DESCRIPTION
I recently updated the Debian package for msgpack-c to 3.2.1 and found that there were a [number of build failures](https://buildd.debian.org/status/logs.php?pkg=msgpack-c&ver=3.2.1-1&suite=experimental).  It appears that all of the 32-bit architectures (except m68k) failed with this error:

```
[20/122] /usr/bin/c++   -I../build-gtest/install/include -I../include -Iinclude -DMSGPACK_DEFAULT_API_VERSION=3 -std=c++11 -g -O2 -fdebug-prefix-map=/<<PKGBUILDDIR>>=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2    -Wall -Wextra -Wconversion -MD -MT test/CMakeFiles/msgpack_cpp11.dir/msgpack_cpp11.cpp.o -MF test/CMakeFiles/msgpack_cpp11.dir/msgpack_cpp11.cpp.o.d -o test/CMakeFiles/msgpack_cpp11.dir/msgpack_cpp11.cpp.o -c ../test/msgpack_cpp11.cpp
FAILED: test/CMakeFiles/msgpack_cpp11.dir/msgpack_cpp11.cpp.o 
/usr/bin/c++   -I../build-gtest/install/include -I../include -Iinclude -DMSGPACK_DEFAULT_API_VERSION=3 -std=c++11 -g -O2 -fdebug-prefix-map=/<<PKGBUILDDIR>>=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2    -Wall -Wextra -Wconversion -MD -MT test/CMakeFiles/msgpack_cpp11.dir/msgpack_cpp11.cpp.o -MF test/CMakeFiles/msgpack_cpp11.dir/msgpack_cpp11.cpp.o.d -o test/CMakeFiles/msgpack_cpp11.dir/msgpack_cpp11.cpp.o -c ../test/msgpack_cpp11.cpp
../test/msgpack_cpp11.cpp: In member function ‘virtual void MSGPACK_TIMESPEC_timespec_pack_convert_32bit_sec_Test::TestBody()’:
../test/msgpack_cpp11.cpp:1081:36: error: narrowing conversion of ‘4294967295’ from ‘long unsigned int’ to ‘__time_t’ {aka ‘long int’} [-Wnarrowing]
 1081 |     timespec val1{ 0xffffffffUL, 0 };
      |                                    ^
../test/msgpack_cpp11.cpp: In member function ‘virtual void MSGPACK_TIMESPEC_timespec_object_with_zone_32bit_sec_Test::TestBody()’:
../test/msgpack_cpp11.cpp:1097:36: error: narrowing conversion of ‘4294967295’ from ‘long unsigned int’ to ‘__time_t’ {aka ‘long int’} [-Wnarrowing]
 1097 |     timespec val1{ 0xffffffffUL, 0 };
      |                                    ^
```

Since this test is only run as part of the c++11 suite, I created this PR to ensure there's c++11 coverage (both 64 and 32-bit) for the CI runs.

Please let me know if you'd rather add two new jobs to the matrix rather than re-purposing existing ones.