### PR TITLE
use cache in github actions

### DIFF
--- a/.github/depends/boost.sh
+++ b/.github/depends/boost.sh
@@ -1,0 +1,56 @@
+#!/bin/sh
+
+usage()
+{
+  cat <<EOL
+  -b   - 32-bit or 64-bit library, maybe 32, 64 or both
+  -t   - the toolset, maybe gcc, clang or both
+EOL
+}
+
+build_boost()
+{
+  BASE=`pwd`/..
+  ./b2 -j4 --toolset=$1 --prefix=${BASE}/usr --libdir="${BASE}/usr/$1/lib$2" --with-chrono --with-context --with-filesystem --with-system --with-timer address-model=$2 install
+}
+
+bit="64"
+toolset="gcc"
+
+while getopts "b:t:" c; do
+  case "$c" in
+    b)
+      bit="$OPTARG"
+      [ "$bit" != "32" ] && [ "$bit" != "64" ] && [ "$bit" != "both" ] && usage && exit 1
+      ;;
+    t)
+      toolset="$OPTARG"
+      [ "$toolset" != "gcc" ] && [ "$toolset" != "clang" ] && [ "$toolset" != "both" ] && usage && exit 1
+      ;;
+    ?*)
+      echo "invalid arguments." && exit 1
+      ;;
+  esac
+done
+
+wget https://dl.bintray.com/boostorg/release/1.71.0/source/boost_1_71_0.tar.bz2
+tar xf boost_1_71_0.tar.bz2
+cd boost_1_71_0
+./bootstrap.sh
+
+build()
+{
+  if [ "$bit" = "both" ]; then
+    build_boost $1 32
+    build_boost $1 64
+  else
+    build_boost $1 $bit
+  fi
+}
+
+if [ "$toolset" = "both" ]; then
+  build gcc
+  build clang
+else
+  build $toolset
+fi

--- a/.github/workflows/gha.yml
+++ b/.github/workflows/gha.yml
@@ -17,9 +17,15 @@ jobs:
         pattern: [0, 1, 2, 3]
     steps:
     - uses: actions/checkout@v1
-    - name: install boost
-      run: |
-        brew install boost
+    - name: Cache boost
+      id: cache-boost
+      uses: actions/cache@v1
+      with:
+        path: usr
+        key: ${{ runner.os }}-boost-20200107
+    - name: Build boost
+      if: steps.cache-boost.outputs.cache-hit != 'true'
+      run: ./.github/depends/boost.sh -b 64 -t clang
     - name: build and test
       env:
         CC: clang
@@ -27,7 +33,6 @@ jobs:
       shell: bash
       run: |
         BASE=`pwd`;
-        mkdir ${BASE}/usr;
 
         # matrix config
         if [ ${{ matrix.pattern }} == 0 ]; then
@@ -79,7 +84,7 @@ jobs:
         cd ..
 
         # build and test
-        CMAKE_CXX_COMPILER="${CXX}" CMAKE_C_COMPILER="${CC}" CMAKE_LIBRARY_PATH="${BASE}/usr/lib:${BASE}/build" GTEST_ROOT="${BASE}/usr" BOOST_ROOT="${BASE}/usr" CFLAGS="-Werror -g" CXXFLAGS="-Werror -g" ${ACTION}
+        CMAKE_CXX_COMPILER="${CXX}" CMAKE_C_COMPILER="${CC}" CMAKE_LIBRARY_PATH="${BASE}/usr/lib:${BASE}/build" GTEST_ROOT="${BASE}/usr" CMAKE_PREFIX_PATH="${BASE}/usr/clang/lib${ARCH}/cmake" CFLAGS="-Werror -g" CXXFLAGS="-Werror -g" ${ACTION}
         cat Files.cmake| grep ".*\.[h|hpp]" | perl -pe 's/ //g' | sort > tmp1  && find include -name "*.h" -o -name "*.hpp" | sort > tmp2 && diff tmp1 tmp2
 
   linux:
@@ -91,7 +96,6 @@ jobs:
     - uses: actions/checkout@v1
     - name: install g++-multilib
       run: |
-        sudo apt-get update
         sudo apt-get install g++-multilib
     - name: install clang
       run: |
@@ -101,11 +105,19 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install valgrind
+    - name: Cache boost
+      id: cache-boost
+      uses: actions/cache@v1
+      with:
+        path: usr
+        key: ${{ runner.os }}-boost-20200107
+    - name: Build boost
+      if: steps.cache-boost.outputs.cache-hit != 'true'
+      run: ./.github/depends/boost.sh -b both -t gcc
     - name: build and test
       shell: bash
       run: |
         BASE=`pwd`;
-        mkdir ${BASE}/usr;
 
         # matrix config
         if [ ${{ matrix.pattern }} == 0 ]; then
@@ -225,14 +237,6 @@ jobs:
           export ARCH="64"
         fi
 
-        # install boost
-        wget https://dl.bintray.com/boostorg/release/1.71.0/source/boost_1_71_0.tar.bz2
-        tar xf boost_1_71_0.tar.bz2
-        cd boost_1_71_0
-        ./bootstrap.sh
-        ./b2 -j4 --prefix=${BASE}/usr --with-chrono --with-context --with-filesystem --with-system --with-timer address-model=${ARCH} install
-        cd ..
-
         # install gtest
         wget https://github.com/google/googletest/archive/release-1.7.0.zip -O googletest-release-1.7.0.zip
         unzip -q googletest-release-1.7.0.zip
@@ -253,7 +257,7 @@ jobs:
         fi
 
         # build and test
-        CMAKE_CXX_COMPILER="${CXX}" CMAKE_C_COMPILER="${CC}" CMAKE_LIBRARY_PATH="${BASE}/usr/lib:${BASE}/build" GTEST_ROOT="${BASE}/usr" BOOST_ROOT="${BASE}/usr" CFLAGS="-Werror -g" CXXFLAGS="-Werror -g" MSGPACK_SAN="${SAN}" ${ACTION}
+        CMAKE_CXX_COMPILER="${CXX}" CMAKE_C_COMPILER="${CC}" CMAKE_LIBRARY_PATH="${BASE}/usr/lib:${BASE}/build" GTEST_ROOT="${BASE}/usr" CMAKE_PREFIX_PATH="${BASE}/usr/gcc/lib${ARCH}/cmake" CFLAGS="-Werror -g" CXXFLAGS="-Werror -g" MSGPACK_SAN="${SAN}" ${ACTION}
         cat Files.cmake| grep ".*\.[h|hpp]" | perl -pe 's/ //g' | sort > tmp1  && find include -name "*.h" -o -name "*.hpp" | sort > tmp2 && diff tmp1 tmp2
   windows:
     runs-on: windows-2016
@@ -262,14 +266,44 @@ jobs:
         pattern: [0, 1, 2, 3]
     steps:
     - uses: actions/checkout@v1
-    - name: download
-      shell: bash
+    - name: Cache dependencies
+      id: cache-depends
+      uses: actions/cache@v1
+      with:
+        path: third_party
+        key: ${{ runner.os }}-depends
+    - name: Build dependencies
+      if: steps.cache-depends.outputs.cache-hit != 'true'
+      shell: powershell
       run: |
-        curl -L -o googletest-release-1.7.0.zip https://github.com/google/googletest/archive/release-1.7.0.zip
-        curl -L -O http://zlib.net/zlib-1.2.11.tar.gz
-        pwd
-        ls -l
-    - name: build and test
+        $CUR=(Get-Location).Path
+        
+        Invoke-WebRequest -Uri https://github.com/google/googletest/archive/release-1.7.0.zip -OutFile googletest-release-1.7.0.zip
+        7z x googletest-release-1.7.0.zip
+        cd googletest-release-1.7.0
+        md build
+        cd build
+        cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_CXX_FLAGS="/D_VARIADIC_MAX=10 /D_SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING" ..
+        cmake --build . --config Release
+        New-Item -ItemType Directory -Path "$CUR\third_party\googletest\lib"
+        Copy-Item "Release\*" -Destination "$CUR\third_party\googletest\lib"
+        Copy-Item -Path "..\include" -Destination "$CUR\third_party\googletest" -Recurse
+        cd ..
+        cd ..
+        
+        Invoke-WebRequest -Uri http://zlib.net/zlib-1.2.11.tar.gz -OutFile zlib-1.2.11.tar.gz
+        7z x zlib-1.2.11.tar.gz
+        7z x zlib-1.2.11.tar
+        cd zlib-1.2.11
+        md build
+        cd build
+        cmake -DCMAKE_INSTALL_PREFIX="$CUR\third_party\zlib" ..
+        cmake --build . --config Release
+        New-Item -ItemType Directory -Path "$CUR\third_party\zlib\lib"
+        Copy-Item "Release\*" -Destination "$CUR\third_party\zlib\lib"
+        Copy-Item "..\zlib.h" -Destination "$CUR\third_party\zlib"
+        Copy-Item zconf.h -Destination "$CUR\third_party\zlib"
+    - name: Build and test
       shell: powershell
       run: |
         if (${{ matrix.pattern }} -eq 0) {
@@ -290,31 +324,11 @@ jobs:
         }
 
         $CUR=(Get-Location).Path
-        7z x googletest-release-1.7.0.zip
-        cd googletest-release-1.7.0
-        md build
-        cd build
-        cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_CXX_FLAGS="/D_VARIADIC_MAX=10 /D_SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING" ..
-        cmake --build . --config Release
-        cd ..
-        cd ..
-
-        7z x zlib-1.2.11.tar.gz
-        7z x zlib-1.2.11.tar
-        cd zlib-1.2.11
-        md build
-        cd build
-        cmake ..
-        cmake --build . --config Release
-        copy zconf.h ..
-        cd ..
-        cd ..
-
         md build
         cd build
         echo $env:BOOST_ROOT
-        $env:DBOOST_ROOT="$env:Boost_ROOT"
-        Start-Process cmake -ArgumentList "-DBOOST_ROOT=""$env:BOOST_ROOT"" $CPP11 $BOOST $X3_PARSE -DGTEST_LIBRARY=""$CUR\googletest-release-1.7.0\build\Release\gtest.lib"" -DGTEST_MAIN_LIBRARY=""$CUR\googletest-release-1.7.0\build\Release\gtest_main.lib"" -DGTEST_INCLUDE_DIR=""$CUR\googletest-release-1.7.0\include"" -DZLIB_LIBRARY=""$CUR\zlib-1.2.11\build\Release\zlib.lib"" -DZLIB_INCLUDE_DIR=""$CUR\zlib-1.2.11"" -DCMAKE_CXX_FLAGS=""/D_VARIADIC_MAX=10 /EHsc /D_SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING"" .." -NoNewWindow -Wait
-        cmake --build . --config Release -v
-        $env:PATH="$env:PATH;$CUR\googletest-release-1.7.0\build\Release;$CUR\zlib-1.2.11\build\Release;$CUR\build\release"
+        $env:BOOST_ROOT="$env:Boost_ROOT"
+        cmake -DBOOST_ROOT="$env:BOOST_ROOT" $CPP11 $BOOST $X3_PARSE -DGTEST_LIBRARY="$CUR\third_party\googletest\lib\gtest.lib" -DGTEST_MAIN_LIBRARY="$CUR\third_party\googletest\lib\gtest_main.lib" -DGTEST_INCLUDE_DIR="$CUR\third_party\googletest\include" -DZLIB_LIBRARY="$CUR\third_party\zlib\lib\zlib.lib" -DZLIB_INCLUDE_DIR="$CUR\third_party\zlib" -DCMAKE_CXX_FLAGS="/D_VARIADIC_MAX=10 /EHsc /D_SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING" ..
+        cmake --build . --config Release
+        $env:PATH="$env:PATH;$CUR\third_party\googletest\lib;$CUR\third_party\zlib\lib;$CUR\build\Release"
         ctest -V


### PR DESCRIPTION
Caching `boost` can save running time of CI.
On Mac, we reduced the time from 40s (install package) to 7s (restore cache),
and on Linux, from 1m 50s (install package) to 7s (restore cache).

Also, caching depends on Windows can save about 50 seconds.