### PR TITLE
replace codecov with coveralls

### DIFF
--- a/.github/depends/boost.sh
+++ b/.github/depends/boost.sh
@@ -10,8 +10,8 @@ EOL
 
 build_boost()
 {
-  BASE=`pwd`/..
-  ./b2 -j4 --toolset=$1 --prefix=${BASE}/usr --libdir="${BASE}/usr/$1/lib$2" --with-chrono --with-context --with-filesystem --with-system --with-timer address-model=$2 install
+  prefix=$HOME/boost
+  ./b2 -j4 --toolset=$1 --prefix=$prefix --libdir="$prefix/$1/lib$2" --with-chrono --with-context --with-filesystem --with-system --with-timer address-model=$2 install
 }
 
 bit="64"

--- a/.github/depends/gtest.sh
+++ b/.github/depends/gtest.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+
+usage()
+{
+  cat <<EOL
+  -b   - 32-bit or 64-bit library, maybe 32, 64 or both
+EOL
+}
+
+bit="64"
+
+while getopts "b:" c; do
+  case "$c" in
+    b)
+      bit="$OPTARG"
+      [ "$bit" != "32" ] && [ "$bit" != "64" ] && [ "$bit" != "both" ] && usage && exit 1
+      ;;
+    ?*)
+      echo "invalid arguments." && exit 1
+      ;;
+  esac
+done
+
+[ -z "$CXX" ] && CXX=g++
+
+wget https://github.com/google/googletest/archive/release-1.7.0.zip -O googletest-release-1.7.0.zip
+unzip -q googletest-release-1.7.0.zip
+cd googletest-release-1.7.0
+$CXX -m$bit src/gtest-all.cc -I. -Iinclude -c -fPIC
+$CXX -m$bit src/gtest_main.cc -I. -Iinclude -c -fPIC
+ar -rv libgtest.a gtest-all.o
+ar -rv libgtest_main.a gtest_main.o
+cp -r include/gtest /usr/local/include
+mv *.a /usr/local/lib

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,54 +1,45 @@
 name: coverage
 
-on: push
+on:
+  pull_request:
+    types: [opened, synchronize]
+  push:
+    branches:
+    - master
+    tags:
+    - '*'
 
 jobs:
-
-  codecov:
+  coveralls:
     timeout-minutes: 30
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2.0.0
     - name: install depends
       run: |
         sudo apt-get update
-        sudo apt-get install g++-multilib lcov
+        sudo apt-get install g++-multilib lcov 
     - name: Cache boost
       id: cache-boost
-      uses: actions/cache@v1
+      uses: actions/cache@v1.1.0
       with:
-        path: usr
-        key: ${{ runner.os }}-boost-20200107
+        path: ~/boost
+        key: ${{ runner.os }}-boost-20200130
     - name: Build boost
       if: steps.cache-boost.outputs.cache-hit != 'true'
       run: ./.github/depends/boost.sh -b both -t gcc
     - name: Compile tests
       run: |
-        # install gtest
-        BASE=`pwd`
-        wget https://github.com/google/googletest/archive/release-1.7.0.zip -O googletest-release-1.7.0.zip
-        unzip -q googletest-release-1.7.0.zip
-        cd googletest-release-1.7.0
-        g++ -m64 src/gtest-all.cc -I. -Iinclude -c -fPIC
-        g++ -m64 src/gtest_main.cc -I. -Iinclude -c -fPIC
-        ar -rv libgtest.a gtest-all.o
-        ar -rv libgtest_main.a gtest_main.o
-        mkdir -p ${BASE}/usr/include
-        cp -r include/gtest ${BASE}/usr/include
-        mkdir -p ${BASE}/usr/lib
-        mv *.a ${BASE}/usr/lib
-        cd ..
+        # install gtest to /usr/local
+        sudo ./.github/depends/gtest.sh -b 64
         
         mkdir build && cd build
-        CMAKE_LIBRARY_PATH="${BASE}/build" GTEST_ROOT="${BASE}/usr" CMAKE_PREFIX_PATH="${BASE}/usr/gcc/lib64/cmake" cmake -DMSGPACK_CXX17=ON -DMSGPACK_32BIT=OFF -DMSGPACK_BOOST=ON -DBUILD_SHARED_LIBS=ON -DMSGPACK_CHAR_SIGN=signed -DMSGPACK_USE_X3_PARSE=ON -DMSGPACK_ENABLE_CXX=ON -DMSGPACK_BUILD_EXAMPLES=ON -DMSGPACK_BUILD_TESTS=ON -DCMAKE_BUILD_TYPE=Debug -DMSGPACK_GEN_COVERAGE=ON ..
+        cmake -DCMAKE_PREFIX_PATH="${HOME}/boost/gcc/lib64/cmake" -DMSGPACK_CXX17=ON -DMSGPACK_32BIT=OFF -DMSGPACK_BOOST=ON -DBUILD_SHARED_LIBS=ON -DMSGPACK_CHAR_SIGN=signed -DMSGPACK_USE_X3_PARSE=ON -DMSGPACK_ENABLE_CXX=ON -DMSGPACK_BUILD_EXAMPLES=ON -DMSGPACK_BUILD_TESTS=ON -DCMAKE_BUILD_TYPE=Debug -DMSGPACK_GEN_COVERAGE=ON ..
         make -j4
-        make test
-    - name: Upload coverage to Codecov
-      working-directory: build
-      env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-      run: |
-        wget https://codecov.io/bash -O codecov
-        chmod +x codecov
-        ./codecov -t $CODECOV_TOKEN -B $GITHUB_REF -s .
+        make coverage
+    - name: Coveralls GitHub Action
+      uses: coverallsapp/github-action@v1.0.1
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        path-to-lcov: ./build/coverage.info.cleaned

--- a/.github/workflows/gha.yml
+++ b/.github/workflows/gha.yml
@@ -16,13 +16,13 @@ jobs:
       matrix:
         pattern: [0, 1, 2, 3]
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2.0.0
     - name: Cache boost
       id: cache-boost
-      uses: actions/cache@v1
+      uses: actions/cache@v1.1.0
       with:
-        path: usr
-        key: ${{ runner.os }}-boost-20200107
+        path: ~/boost
+        key: ${{ runner.os }}-boost-20200130
     - name: Build boost
       if: steps.cache-boost.outputs.cache-hit != 'true'
       run: ./.github/depends/boost.sh -b 64 -t clang
@@ -32,8 +32,6 @@ jobs:
         CXX: clang++
       shell: bash
       run: |
-        BASE=`pwd`;
-
         # matrix config
         if [ ${{ matrix.pattern }} == 0 ]; then
           ACTION="ci/build_cmake.sh"
@@ -69,22 +67,11 @@ jobs:
           export API_VERSION="2"
         fi
 
-        # install gtest
-        wget https://github.com/google/googletest/archive/release-1.7.0.zip -O googletest-release-1.7.0.zip
-        unzip -q googletest-release-1.7.0.zip
-        cd googletest-release-1.7.0
-        $CXX -m${ARCH} src/gtest-all.cc -I. -Iinclude -c
-        $CXX -m${ARCH} src/gtest_main.cc -I. -Iinclude -c
-        ar -rv libgtest.a gtest-all.o
-        ar -rv libgtest_main.a gtest_main.o
-        mkdir -p ${BASE}/usr/include
-        cp -r include/gtest ${BASE}/usr/include
-        mkdir -p ${BASE}/usr/lib
-        mv *.a ${BASE}/usr/lib
-        cd ..
+        # install gtest to /usr/local
+        sudo ./.github/depends/gtest.sh -b ${ARCH}
 
         # build and test
-        CMAKE_CXX_COMPILER="${CXX}" CMAKE_C_COMPILER="${CC}" CMAKE_LIBRARY_PATH="${BASE}/usr/lib:${BASE}/build" GTEST_ROOT="${BASE}/usr" CMAKE_PREFIX_PATH="${BASE}/usr/clang/lib${ARCH}/cmake" CFLAGS="-Werror -g" CXXFLAGS="-Werror -g" ${ACTION}
+        CMAKE_CXX_COMPILER="${CXX}" CMAKE_C_COMPILER="${CC}" CMAKE_PREFIX_PATH="${HOME}/boost/clang/lib${ARCH}/cmake" CFLAGS="-Werror -g" CXXFLAGS="-Werror -g" ${ACTION}
         cat Files.cmake| grep ".*\.[h|hpp]" | perl -pe 's/ //g' | sort > tmp1  && find include -name "*.h" -o -name "*.hpp" | sort > tmp2 && diff tmp1 tmp2
 
   linux:
@@ -93,7 +80,7 @@ jobs:
       matrix:
         pattern: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2.0.0
     - name: install g++-multilib
       run: |
         sudo apt-get install g++-multilib
@@ -107,18 +94,16 @@ jobs:
         sudo apt-get install valgrind
     - name: Cache boost
       id: cache-boost
-      uses: actions/cache@v1
+      uses: actions/cache@v1.1.0
       with:
-        path: usr
-        key: ${{ runner.os }}-boost-20200107
+        path: ~/boost
+        key: ${{ runner.os }}-boost-20200130
     - name: Build boost
       if: steps.cache-boost.outputs.cache-hit != 'true'
       run: ./.github/depends/boost.sh -b both -t gcc
     - name: build and test
       shell: bash
       run: |
-        BASE=`pwd`;
-
         # matrix config
         if [ ${{ matrix.pattern }} == 0 ]; then
           export CC=clang
@@ -237,19 +222,8 @@ jobs:
           export ARCH="64"
         fi
 
-        # install gtest
-        wget https://github.com/google/googletest/archive/release-1.7.0.zip -O googletest-release-1.7.0.zip
-        unzip -q googletest-release-1.7.0.zip
-        cd googletest-release-1.7.0
-        $CXX -m${ARCH} src/gtest-all.cc -I. -Iinclude -c -fPIC
-        $CXX -m${ARCH} src/gtest_main.cc -I. -Iinclude -c -fPIC
-        ar -rv libgtest.a gtest-all.o
-        ar -rv libgtest_main.a gtest_main.o
-        mkdir -p ${BASE}/usr/include
-        cp -r include/gtest ${BASE}/usr/include
-        mkdir -p ${BASE}/usr/lib
-        mv *.a ${BASE}/usr/lib
-        cd ..
+        # install gtest to /usr/local
+        sudo ./.github/depends/gtest.sh -b ${ARCH}
 
         # install zlib
         if [ ${ARCH} == 32 ]; then
@@ -257,7 +231,7 @@ jobs:
         fi
 
         # build and test
-        CMAKE_CXX_COMPILER="${CXX}" CMAKE_C_COMPILER="${CC}" CMAKE_LIBRARY_PATH="${BASE}/usr/lib:${BASE}/build" GTEST_ROOT="${BASE}/usr" CMAKE_PREFIX_PATH="${BASE}/usr/gcc/lib${ARCH}/cmake" CFLAGS="-Werror -g" CXXFLAGS="-Werror -g" MSGPACK_SAN="${SAN}" ${ACTION}
+        CMAKE_CXX_COMPILER="${CXX}" CMAKE_C_COMPILER="${CC}" CMAKE_PREFIX_PATH="${HOME}/boost/gcc/lib${ARCH}/cmake" CFLAGS="-Werror -g" CXXFLAGS="-Werror -g" MSGPACK_SAN="${SAN}" ${ACTION}
         cat Files.cmake| grep ".*\.[h|hpp]" | perl -pe 's/ //g' | sort > tmp1  && find include -name "*.h" -o -name "*.hpp" | sort > tmp2 && diff tmp1 tmp2
   windows:
     runs-on: windows-2016


### PR DESCRIPTION
- Replace codecov with coveralls

It works for my repo. But I'm not sure whether it works for the `msgpack` repo.
- Install dependencies in the folders outside the workspace

The reports generated by `coveralls` will include dependencies if the dependencies are installed inside the workspace . So I installed `gtest` to `/usr/local/` and `boost` to `~/boost/`.
Why not install `boost` to `/usr/local/`? The `actions/cache` has no permission to do it.
- Extract function (installing gtest) into a script (gtest.sh)