### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,20 @@ execute the following commands:
 
 When you use the C part of `msgpack-c`, you need to build and link the library. By default, both static/shared libraries are built. If you want to build only static library, set `BUILD_SHARED_LIBS=OFF` to cmake. If you want to build only shared library, set `BUILD_SHARED_LIBS=ON`.
 
+
+##### Using the VCPKG
+
+Alternatively, you can build and install msgpack using [vcpkg](https://github.com/microsoft/vcpkg/) dependency manager:
+
+    $ git clone https://github.com/Microsoft/vcpkg.git
+    $ cd vcpkg
+    $ ./bootstrap-vcpkg.sh
+    $ ./vcpkg integrate install
+    $ ./vcpkg install msgpack
+
+The msgpack port in vcpkg is kept up to date by microsoft team members and community contributors.
+If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
 #### GUI on Windows
 
 Clone msgpack-c git repository.


### PR DESCRIPTION
msgpack is available as a port in VCPKG , documenting the install process here will help users get started by providing a single set of commands to build msgpack, ready to be included in their projects.

VCPKG is a C++ library manager that simplifies installation for msgpack and other project dependencies, we also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, UWP, ARM) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and here is what the port script looks like. We try to keep the library maintained as close as possible to the original library.
