### PR TITLE
fix github actions failure and use C style casts instead of C++ style casts in zbuffer.h

### DIFF
--- a/.github/workflows/gha.yml
+++ b/.github/workflows/gha.yml
@@ -94,17 +94,10 @@ jobs:
         pattern: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
     steps:
     - uses: actions/checkout@v1
-    - name: install g++-multilib
-      run: |
-        sudo apt-get install g++-multilib
-    - name: install clang
+    - name: install depends
       run: |
         sudo apt-get update
-        sudo apt-get install clang-8
-    - name: install valgrind
-      run: |
-        sudo apt-get update
-        sudo apt-get install valgrind
+        sudo apt-get install g++-multilib clang-8 valgrind
     - name: Cache boost
       id: cache-boost
       uses: actions/cache@v1

--- a/include/msgpack/zbuffer.h
+++ b/include/msgpack/zbuffer.h
@@ -100,7 +100,7 @@ static inline void msgpack_zbuffer_free(msgpack_zbuffer* zbuf)
 
 static inline bool msgpack_zbuffer_expand(msgpack_zbuffer* zbuf)
 {
-    size_t used = static_cast<size_t>(reinterpret_cast<char*>(zbuf->stream.next_out) - zbuf->data);
+    size_t used = (size_t)((char *)(zbuf->stream.next_out) - zbuf->data);
     size_t csize = used + zbuf->stream.avail_out;
 
     size_t nsize = (csize == 0) ? zbuf->init_size : csize * 2;
@@ -112,7 +112,7 @@ static inline bool msgpack_zbuffer_expand(msgpack_zbuffer* zbuf)
 
     zbuf->data = tmp;
     zbuf->stream.next_out  = (Bytef*)(tmp + used);
-    zbuf->stream.avail_out = static_cast<uInt>(nsize - used);
+    zbuf->stream.avail_out = (uInt)(nsize - used);
 
     return true;
 }
@@ -122,7 +122,7 @@ static inline int msgpack_zbuffer_write(void* data, const char* buf, size_t len)
     msgpack_zbuffer* zbuf = (msgpack_zbuffer*)data;
 
     zbuf->stream.next_in = (Bytef*)buf;
-    zbuf->stream.avail_in = static_cast<uInt>(len);
+    zbuf->stream.avail_in = (uInt)len;
 
     while(zbuf->stream.avail_in > 0) {
         if(zbuf->stream.avail_out < MSGPACK_ZBUFFER_RESERVE_SIZE) {
@@ -164,7 +164,7 @@ static inline const char* msgpack_zbuffer_data(const msgpack_zbuffer* zbuf)
 
 static inline size_t msgpack_zbuffer_size(const msgpack_zbuffer* zbuf)
 {
-    return static_cast<size_t>(reinterpret_cast<char*>(zbuf->stream.next_out) - zbuf->data);
+    return (size_t)((char *)(zbuf->stream.next_out) - zbuf->data);
 }
 
 static inline void msgpack_zbuffer_reset_buffer(msgpack_zbuffer* zbuf)


### PR DESCRIPTION
- fix github actions failure

`apt-get update` downloads the package lists from the repositories and updates them to get information on the newest versions of packages and their dependencies.
Fix the CI errors that mentioned in this issue: https://github.com/msgpack/msgpack-c/issues/857

- use C style casts instead of C++ style casts in zbuffer.h

`static_cast` and `reinterpret_cast` are invalid in pure C projects.
Fix: https://github.com/msgpack/msgpack-c/issues/858