### PR TITLE
vrefbuffer: set default ref_size and chunk_size

### DIFF
--- a/include/msgpack/pack.h
+++ b/include/msgpack/pack.h
@@ -89,15 +89,18 @@ static int msgpack_pack_map(msgpack_packer* pk, size_t n);
 
 static int msgpack_pack_str(msgpack_packer* pk, size_t l);
 static int msgpack_pack_str_body(msgpack_packer* pk, const void* b, size_t l);
+static int msgpack_pack_str_sugar(msgpack_packer* pk, const void* b, size_t l);
 
 static int msgpack_pack_v4raw(msgpack_packer* pk, size_t l);
 static int msgpack_pack_v4raw_body(msgpack_packer* pk, const void* b, size_t l);
 
 static int msgpack_pack_bin(msgpack_packer* pk, size_t l);
 static int msgpack_pack_bin_body(msgpack_packer* pk, const void* b, size_t l);
+static int msgpack_pack_bin_sugar(msgpack_packer* pk, const void* b, size_t l);
 
 static int msgpack_pack_ext(msgpack_packer* pk, size_t l, int8_t type);
 static int msgpack_pack_ext_body(msgpack_packer* pk, const void* b, size_t l);
+static int msgpack_pack_ext_sugar(msgpack_packer* pk, const void* b, size_t l, int8_t type);
 
 static int msgpack_pack_timestamp(msgpack_packer* pk, const msgpack_timestamp* d);
 
@@ -143,6 +146,26 @@ inline void msgpack_packer_free(msgpack_packer* pk)
     free(pk);
 }
 
+inline int msgpack_pack_str_sugar(msgpack_packer* pk, const void* b, size_t l)
+{
+    int ret = msgpack_pack_str(pk, l);
+    if (ret != 0) { return ret; }
+    return msgpack_pack_str_body(pk, b, l);
+}
+
+inline int msgpack_pack_bin_sugar(msgpack_packer* pk, const void* b, size_t l)
+{
+    int ret = msgpack_pack_bin(pk, l);
+    if (ret != 0) { return ret; }
+    return msgpack_pack_bin_body(pk, b, l);
+}
+
+inline int msgpack_pack_ext_sugar(msgpack_packer* pk, const void* b, size_t l, int8_t type)
+{
+    int ret = msgpack_pack_ext(pk, l, type);
+    if (ret != 0) { return ret; }
+    return msgpack_pack_ext_body(pk, b, l);
+}
 
 #ifdef __cplusplus
 }

--- a/src/vrefbuffer.c
+++ b/src/vrefbuffer.c
@@ -25,6 +25,12 @@ bool msgpack_vrefbuffer_init(msgpack_vrefbuffer* vbuf,
     struct iovec* array;
     msgpack_vrefbuffer_chunk* chunk;
 
+    if (ref_size == 0) {
+        ref_size = MSGPACK_VREFBUFFER_REF_SIZE;
+    }
+    if(chunk_size == 0) {
+        chunk_size = MSGPACK_VREFBUFFER_CHUNK_SIZE;
+    }
     vbuf->chunk_size = chunk_size;
     vbuf->ref_size =
         ref_size > MSGPACK_PACKER_MAX_BUFFER_SIZE + 1 ?

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -93,11 +93,11 @@ FOREACH (source_file ${check_PROGRAMS})
         ${source_file}
     )
 
-    LIST (FIND tests_C ${source_file} idx)
-    IF (idx GREATER -1)
-        SET (link_target msgpackc)
-    ELSE ()
-        SET (link_target msgpackc-cxx)
+    IF (TARGET msgpackc)
+        list(APPEND link_target msgpackc)
+    ENDIF ()
+    IF (TARGET msgpackc-cxx)
+        list(APPEND link_target msgpackc-cxx)
     ENDIF ()
 
     TARGET_LINK_LIBRARIES (${source_file_we}

--- a/test/buffer.cpp
+++ b/test/buffer.cpp
@@ -3,6 +3,8 @@
 #include <msgpack/fbuffer.h>
 #include <msgpack/zbuffer.hpp>
 #include <msgpack/zbuffer.h>
+#include <msgpack/sbuffer.h>
+#include <msgpack/vrefbuffer.h>
 
 #if defined(__GNUC__)
 #pragma GCC diagnostic push
@@ -16,6 +18,12 @@
 #endif //defined(__GNUC__)
 
 #include <string.h>
+
+#if defined(unix) || defined(__unix) || defined(__linux__) || defined(__APPLE__) || defined(__OpenBSD__) || defined(__NetBSD__) || defined(__QNX__) || defined(__QNXTO__) || defined(__HAIKU__)
+#define HAVE_SYS_UIO_H 1
+#else
+#define HAVE_SYS_UIO_H 0
+#endif
 
 TEST(buffer, sbuffer)
 {
@@ -155,4 +163,83 @@ TEST(buffer, fbuffer_c)
     }
     EXPECT_EQ(EOF, fgetc(file));
     fclose(file);
+}
+
+TEST(buffer, sbuffer_c)
+{
+    msgpack_sbuffer *sbuf;
+
+    EXPECT_TRUE((sbuf = msgpack_sbuffer_new()));
+    EXPECT_EQ(0, msgpack_sbuffer_write(sbuf, "a", 1));
+    EXPECT_EQ(0, msgpack_sbuffer_write(sbuf, "b", 1));
+    EXPECT_EQ(0, msgpack_sbuffer_write(sbuf, "c", 1));
+    EXPECT_EQ(0, msgpack_sbuffer_write(sbuf, "", 0));
+    EXPECT_EQ(3, sbuf->size);
+    EXPECT_EQ(0, memcmp(sbuf->data, "abc", 3));
+    EXPECT_EQ(0, memcmp(msgpack_sbuffer_release(sbuf), "abc", 3));
+    EXPECT_EQ(0, sbuf->size);
+    EXPECT_EQ(NULL, sbuf->data);
+
+    msgpack_sbuffer_free(sbuf);
+}
+
+TEST(buffer, vrefbuffer_c)
+{
+    const char *raw = "I was about to sail away in a junk,"
+                      "When suddenly I heard"
+                      "The sound of stamping and singing on the bank--"
+                      "It was you and your friends come to bid me farewell."
+                      "The Peach Flower Lake is a thousand fathoms deep,"
+                      "But it cannot compare, O Wang Lun,"
+                      "With the depth of your love for me.";
+    const size_t rawlen = strlen(raw);
+    msgpack_vrefbuffer *vbuf;
+    const int ref_size = 24, chunk_size = 128;
+    size_t slices[] = {0, 9, 10,
+                    MSGPACK_VREFBUFFER_REF_SIZE,
+                    MSGPACK_VREFBUFFER_REF_SIZE + 1,
+                    ref_size, chunk_size + 1};
+    size_t iovcnt;
+    const iovec *iov;
+    size_t len = 0, i;
+    char *buf;
+
+    vbuf = msgpack_vrefbuffer_new(ref_size, 0);
+    for (i = 0; i < sizeof(slices) / sizeof(slices[0]); i++) {
+        msgpack_vrefbuffer_write(vbuf, raw + len, slices[i]);
+        len += slices[i];
+    }
+    EXPECT_LT(len, rawlen);
+    iov = msgpack_vrefbuffer_vec(vbuf);
+    iovcnt = msgpack_vrefbuffer_veclen(vbuf);
+
+    buf = (char *)malloc(rawlen);
+
+#if HAVE_SYS_UIO_H
+    {
+        int fd;
+        char filename[] = "/tmp/mp.XXXXXX";
+
+        fd = mkstemp(filename);
+        EXPECT_LT(0, fd);
+        writev(fd, iov, (int)iovcnt);
+        len = (size_t)lseek(fd, 0, SEEK_END);
+        lseek(fd, 0, SEEK_SET);
+        read(fd, buf, len);
+        EXPECT_EQ(0, memcmp(buf, raw, len));
+        close(fd);
+        unlink(filename);
+    }
+#else
+    {
+        len = 0;
+        for (i = 0; i < iovcnt; i++)
+        {
+            EXPECT_LT(len, rawlen);
+            memcpy(buf + len, iov[i].iov_base, iov[i].iov_len);
+            len += iov[i].iov_len;
+        }
+        EXPECT_EQ(0, memcmp(buf, raw, len));
+    }
+#endif
 }


### PR DESCRIPTION
- vrefbuffer: set default ref_size and chunk_size, and add test cases.

- add convenient interface for packing str/bin/ext.