### PR TITLE
vrefbuffer: set default ref_size and chunk_size

### DIFF
--- a/src/vrefbuffer.c
+++ b/src/vrefbuffer.c
@@ -25,6 +25,12 @@ bool msgpack_vrefbuffer_init(msgpack_vrefbuffer* vbuf,
     struct iovec* array;
     msgpack_vrefbuffer_chunk* chunk;
 
+    if (ref_size == 0) {
+        ref_size = MSGPACK_VREFBUFFER_REF_SIZE;
+    }
+    if(chunk_size == 0) {
+        chunk_size = MSGPACK_VREFBUFFER_CHUNK_SIZE;
+    }
     vbuf->chunk_size = chunk_size;
     vbuf->ref_size =
         ref_size > MSGPACK_PACKER_MAX_BUFFER_SIZE + 1 ?

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -8,6 +8,7 @@ INCLUDE_DIRECTORIES (
 )
 
 SET (tests_C
+    buffer_c.cpp
     fixint_c.cpp
     msgpack_c.cpp
     pack_unpack_c.cpp

--- a/test/buffer.cpp
+++ b/test/buffer.cpp
@@ -1,8 +1,6 @@
 #include <msgpack.hpp>
 #include <msgpack/fbuffer.hpp>
-#include <msgpack/fbuffer.h>
 #include <msgpack/zbuffer.hpp>
-#include <msgpack/zbuffer.h>
 
 #if defined(__GNUC__)
 #pragma GCC diagnostic push
@@ -73,7 +71,6 @@ TEST(buffer, vrefbuffer)
     EXPECT_TRUE( memcmp(sbuf.data(), "aaa", 3) == 0 );
 }
 
-
 TEST(buffer, zbuffer)
 {
     msgpack::zbuffer zbuf;
@@ -84,22 +81,6 @@ TEST(buffer, zbuffer)
 
     zbuf.flush();
 }
-
-
-TEST(buffer, zbuffer_c)
-{
-    msgpack_zbuffer zbuf;
-    EXPECT_TRUE(msgpack_zbuffer_init(&zbuf, 1, MSGPACK_ZBUFFER_INIT_SIZE));
-    EXPECT_EQ(0, msgpack_zbuffer_write(&zbuf, "a", 1));
-    EXPECT_EQ(0, msgpack_zbuffer_write(&zbuf, "a", 1));
-    EXPECT_EQ(0, msgpack_zbuffer_write(&zbuf, "a", 1));
-    EXPECT_EQ(0, msgpack_zbuffer_write(&zbuf, "", 0));
-
-    EXPECT_TRUE(msgpack_zbuffer_flush(&zbuf) != NULL);
-
-    msgpack_zbuffer_destroy(&zbuf);
-}
-
 
 TEST(buffer, fbuffer)
 {
@@ -124,34 +105,6 @@ TEST(buffer, fbuffer)
         int ch = fgetc(file);
         EXPECT_TRUE(ch != EOF);
         EXPECT_EQ('a', static_cast<char>(ch));
-    }
-    EXPECT_EQ(EOF, fgetc(file));
-    fclose(file);
-}
-
-
-TEST(buffer, fbuffer_c)
-{
-#if defined(_MSC_VER)
-    FILE* file;
-    tmpfile_s(&file);
-#else  // defined(_MSC_VER)
-    FILE* file = tmpfile();
-#endif // defined(_MSC_VER)
-
-    void* fbuf = (void*)file;
-
-    EXPECT_TRUE( file != NULL );
-    EXPECT_EQ(0, msgpack_fbuffer_write(fbuf, "a", 1));
-    EXPECT_EQ(0, msgpack_fbuffer_write(fbuf, "a", 1));
-    EXPECT_EQ(0, msgpack_fbuffer_write(fbuf, "a", 1));
-
-    fflush(file);
-    rewind(file);
-    for (size_t i=0; i < 3; ++i) {
-        int ch = fgetc(file);
-        EXPECT_TRUE(ch != EOF);
-        EXPECT_EQ('a', (char) ch);
     }
     EXPECT_EQ(EOF, fgetc(file));
     fclose(file);

--- a/test/buffer_c.cpp
+++ b/test/buffer_c.cpp
@@ -1,0 +1,148 @@
+#include <msgpack/fbuffer.h>
+#include <msgpack/zbuffer.h>
+#include <msgpack/sbuffer.h>
+#include <msgpack/vrefbuffer.h>
+
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wconversion"
+#endif //defined(__GNUC__)
+
+#include <gtest/gtest.h>
+
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif //defined(__GNUC__)
+
+#include <string.h>
+
+#if defined(unix) || defined(__unix) || defined(__linux__) || defined(__APPLE__) || defined(__OpenBSD__) || defined(__NetBSD__) || defined(__QNX__) || defined(__QNXTO__) || defined(__HAIKU__)
+#define HAVE_SYS_UIO_H 1
+#else
+#define HAVE_SYS_UIO_H 0
+#endif
+
+TEST(buffer, zbuffer_c)
+{
+    msgpack_zbuffer zbuf;
+    EXPECT_TRUE(msgpack_zbuffer_init(&zbuf, 1, MSGPACK_ZBUFFER_INIT_SIZE));
+    EXPECT_EQ(0, msgpack_zbuffer_write(&zbuf, "a", 1));
+    EXPECT_EQ(0, msgpack_zbuffer_write(&zbuf, "a", 1));
+    EXPECT_EQ(0, msgpack_zbuffer_write(&zbuf, "a", 1));
+    EXPECT_EQ(0, msgpack_zbuffer_write(&zbuf, "", 0));
+
+    EXPECT_TRUE(msgpack_zbuffer_flush(&zbuf) != NULL);
+
+    msgpack_zbuffer_destroy(&zbuf);
+}
+
+TEST(buffer, fbuffer_c)
+{
+#if defined(_MSC_VER)
+    FILE* file;
+    tmpfile_s(&file);
+#else  // defined(_MSC_VER)
+    FILE* file = tmpfile();
+#endif // defined(_MSC_VER)
+
+    void* fbuf = (void*)file;
+
+    EXPECT_TRUE( file != NULL );
+    EXPECT_EQ(0, msgpack_fbuffer_write(fbuf, "a", 1));
+    EXPECT_EQ(0, msgpack_fbuffer_write(fbuf, "a", 1));
+    EXPECT_EQ(0, msgpack_fbuffer_write(fbuf, "a", 1));
+
+    fflush(file);
+    rewind(file);
+    for (size_t i=0; i < 3; ++i) {
+        int ch = fgetc(file);
+        EXPECT_TRUE(ch != EOF);
+        EXPECT_EQ('a', (char) ch);
+    }
+    EXPECT_EQ(EOF, fgetc(file));
+    fclose(file);
+}
+
+TEST(buffer, sbuffer_c)
+{
+    msgpack_sbuffer *sbuf;
+    char *data;
+
+    sbuf = msgpack_sbuffer_new();
+    EXPECT_TRUE(sbuf != NULL);
+    EXPECT_EQ(0, msgpack_sbuffer_write(sbuf, "a", 1));
+    EXPECT_EQ(0, msgpack_sbuffer_write(sbuf, "b", 1));
+    EXPECT_EQ(0, msgpack_sbuffer_write(sbuf, "c", 1));
+    EXPECT_EQ(0, msgpack_sbuffer_write(sbuf, "", 0));
+    EXPECT_EQ(3U, sbuf->size);
+    EXPECT_EQ(0, memcmp(sbuf->data, "abc", 3));
+    data = msgpack_sbuffer_release(sbuf);
+    EXPECT_EQ(0, memcmp(data, "abc", 3));
+    EXPECT_EQ(0U, sbuf->size);
+    EXPECT_TRUE(sbuf->data == NULL);
+
+    free(data);
+    msgpack_sbuffer_free(sbuf);
+}
+
+TEST(buffer, vrefbuffer_c)
+{
+    const char *raw = "I was about to sail away in a junk,"
+                      "When suddenly I heard"
+                      "The sound of stamping and singing on the bank--"
+                      "It was you and your friends come to bid me farewell."
+                      "The Peach Flower Lake is a thousand fathoms deep,"
+                      "But it cannot compare, O Wang Lun,"
+                      "With the depth of your love for me.";
+    const size_t rawlen = strlen(raw);
+    msgpack_vrefbuffer *vbuf;
+    const int ref_size = 24, chunk_size = 128;
+    size_t slices[] = {0, 9, 10,
+                    MSGPACK_VREFBUFFER_REF_SIZE,
+                    MSGPACK_VREFBUFFER_REF_SIZE + 1,
+                    ref_size, chunk_size + 1};
+    size_t iovcnt;
+    const iovec *iov;
+    size_t len = 0, i;
+    char *buf;
+
+    vbuf = msgpack_vrefbuffer_new(ref_size, 0);
+    for (i = 0; i < sizeof(slices) / sizeof(slices[0]); i++) {
+        msgpack_vrefbuffer_write(vbuf, raw + len, slices[i]);
+        len += slices[i];
+    }
+    EXPECT_LT(len, rawlen);
+    iov = msgpack_vrefbuffer_vec(vbuf);
+    iovcnt = msgpack_vrefbuffer_veclen(vbuf);
+
+    buf = (char *)malloc(rawlen);
+#if HAVE_SYS_UIO_H
+    {
+        int fd;
+        char filename[] = "/tmp/mp.XXXXXX";
+
+        fd = mkstemp(filename);
+        EXPECT_LT(0, fd);
+        writev(fd, iov, (int)iovcnt);
+        len = (size_t)lseek(fd, 0, SEEK_END);
+        lseek(fd, 0, SEEK_SET);
+        read(fd, buf, len);
+        EXPECT_EQ(0, memcmp(buf, raw, len));
+        close(fd);
+        unlink(filename);
+    }
+#else
+    {
+        len = 0;
+        for (i = 0; i < iovcnt; i++)
+        {
+            EXPECT_LT(len, rawlen);
+            memcpy(buf + len, iov[i].iov_base, iov[i].iov_len);
+            len += iov[i].iov_len;
+        }
+        EXPECT_EQ(0, memcmp(buf, raw, len));
+    }
+#endif
+    free(buf);
+    msgpack_vrefbuffer_free(vbuf);
+}


### PR DESCRIPTION
- vrefbuffer: set default ref_size and chunk_size, and add test cases.

- divide `buffer.cpp` into `buffer.cpp` and `buffer_c.cpp` because `iovec` is redefined (in `include/msgpack/v1/vrefbuffer.hpp` and `include/msgpack/vrefbuffer.h` )