### PR TITLE
Fixed warning in Visual Studio

### DIFF
--- a/example/c/simple_c.c
+++ b/example/c/simple_c.c
@@ -1,7 +1,7 @@
 #include <msgpack.h>
 #include <stdio.h>
 
-void print(char const* buf, unsigned int len)
+void print(char const* buf,size_t len)
 {
     size_t i = 0;
     for(; i < len ; ++i)


### PR DESCRIPTION
unsigned int and size_t are not the same type on x64 platforms. The compiler gave a warning that was treated as an error.