### PR TITLE
fix cannot find boost error

### DIFF
--- a/.github/workflows/gha.yml
+++ b/.github/workflows/gha.yml
@@ -294,9 +294,11 @@ jobs:
         $CUR=(Get-Location).Path
         md build
         cd build
-        cmake -A x64 -DCMAKE_TOOLCHAIN_FILE="C:/vcpkg/scripts/buildsystems/vcpkg.cmake" $CPP11 $BOOST "-DCMAKE_CXX_FLAGS=/D_VARIADIC_MAX=10 /EHsc /D_SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING" ..
+        cmake -A x64 -DBOOST_ROOT="$env:BOOST_ROOT_1_72_0" -DCMAKE_TOOLCHAIN_FILE="C:/vcpkg/scripts/buildsystems/vcpkg.cmake" $CPP11 $BOOST "-DCMAKE_CXX_FLAGS=/D_VARIADIC_MAX=10 /EHsc /D_SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING" ..
+        if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode) }
         cmake --build . --config Release
         $pathbak="$env:PATH"
         $env:PATH="C:\vcpkg\installed\x64-windows\bin;$CUR\build\Release;$pathbak"
         ctest -V
+        if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode) }
         $env:PATH=$pathbak


### PR DESCRIPTION
There was an error in this [test](https://github.com/msgpack/msgpack-c/runs/703562934?check_suite_focus=true), but it was not marked as a failure.
```
Could NOT find Boost (missing: Boost_INCLUDE_DIR chrono context system timer)
```
So we need to add `BOOST_ROOT` and check error.