### PR TITLE
check null pointer before using memcpy()

### DIFF
--- a/include/msgpack/sbuffer.h
+++ b/include/msgpack/sbuffer.h
@@ -12,6 +12,7 @@
 
 #include <stdlib.h>
 #include <string.h>
+#include <assert.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -59,6 +60,7 @@ static inline void msgpack_sbuffer_free(msgpack_sbuffer* sbuf)
 static inline int msgpack_sbuffer_write(void* data, const char* buf, size_t len)
 {
     msgpack_sbuffer* sbuf = (msgpack_sbuffer*)data;
+    assert(buf || len == 0);
 
     if(sbuf->alloc - sbuf->size < len) {
         void* tmp;
@@ -81,8 +83,10 @@ static inline int msgpack_sbuffer_write(void* data, const char* buf, size_t len)
         sbuf->alloc = nsize;
     }
 
-    memcpy(sbuf->data + sbuf->size, buf, len);
-    sbuf->size += len;
+    if(buf) {
+        memcpy(sbuf->data + sbuf->size, buf, len);
+        sbuf->size += len;
+    }
     return 0;
 }
 


### PR DESCRIPTION
Avoid passing null pointer to `memcpy()`.
Fixed the following error mentioned by @jamessan in issue #881:
```
runtime error: null pointer passed as argument 2, which is declared to never be null
```