### PR TITLE
C: Increase tests visibility (Issue #943)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -184,6 +184,7 @@ ENDIF ()
 
 IF (MSGPACK_BUILD_TESTS)
     ENABLE_TESTING ()
+    list(APPEND CMAKE_CTEST_ARGUMENTS "--output-on-failure")
     # MEMORYCHECK_COMMAND_OPTIONS needs to place prior to CTEST_MEMORYCHECK_COMMAND
     SET (MEMORYCHECK_COMMAND_OPTIONS "--leak-check=full --show-leak-kinds=definite,possible --error-exitcode=1")
     FIND_PROGRAM(CTEST_MEMORYCHECK_COMMAND NAMES valgrind)

--- a/README.md
+++ b/README.md
@@ -84,6 +84,9 @@ How to build:
 
 How to run tests:
 
+In order to run tests you must have the [GoogleTest](https://github.com/google/googletest) framework installed. If you do not currently have it, install it and re-run `cmake`.
+Then:
+
     $ make test
 
 When you use the C part of `msgpack-c`, you need to build and link the library. By default, both static/shared libraries are built. If you want to build only static library, set `BUILD_SHARED_LIBS=OFF` to cmake. If you want to build only shared library, set `BUILD_SHARED_LIBS=ON`.

--- a/README.md
+++ b/README.md
@@ -82,6 +82,10 @@ How to build:
     $ make
     $ sudo make install
 
+How to run tests:
+
+    $ make test
+
 When you use the C part of `msgpack-c`, you need to build and link the library. By default, both static/shared libraries are built. If you want to build only static library, set `BUILD_SHARED_LIBS=OFF` to cmake. If you want to build only shared library, set `BUILD_SHARED_LIBS=ON`.
 
 #### GUI on Windows


### PR DESCRIPTION
This is an attempt at increasing the visibility of tests for the C branch (c_master).

- Small addition to README to mention gtest and show how to run tests
- Turn on output-on-failure by default for tests

Note: see how I turned on output-on-failure in the root `CMakeLists.txt`. I don't know much about CMake and I'm not quite sure it is the right way (but it is very helpful :) ).
