### PR TITLE
Fix name conflicts

### DIFF
--- a/include/msgpack/v1/vrefbuffer.hpp
+++ b/include/msgpack/v1/vrefbuffer.hpp
@@ -26,11 +26,16 @@
 
 #if defined(unix) || defined(__unix) || defined(__APPLE__) || defined(__OpenBSD__)
 #include <sys/uio.h>
+namespace msgpack {
+typedef ::iovec iovec;
+} // namespace msgpack
 #else
+namespace msgpack {
 struct iovec {
     void  *iov_base;
     size_t iov_len;
 };
+} // namespace msgpack
 #endif
 
 namespace msgpack {
@@ -183,7 +188,7 @@ public:
         }
     }
 
-    const struct iovec* vector() const
+    const iovec* vector() const
     {
         return m_array;
     }


### PR DESCRIPTION
Previously `struct iovec` was explicitly defined on non-Unix systems, which caused name conflicts when other libraries (e.g. Cyrus SASL) did the same. Using `struct iovec` as `msgpack::iovec` solves the problem.

Example build representing the problem: https://github.com/kovdan01/melon/runs/2523055779#step:23:35