### PR TITLE
Fix UB in v4raw_ref::operator==

### DIFF
--- a/include/msgpack/v1/adaptor/v4raw.hpp
+++ b/include/msgpack/v1/adaptor/v4raw.hpp
@@ -33,7 +33,7 @@ struct v4raw_ref {
 
     bool operator== (const v4raw_ref& x) const
     {
-        return size == x.size && std::memcmp(ptr, x.ptr, size) == 0;
+        return size == x.size && (size == 0 || std::memcmp(ptr, x.ptr, size) == 0);
     }
 
     bool operator!= (const v4raw_ref& x) const


### PR DESCRIPTION
Behaviour of memcmp is undefined if any of pointers passed to it is null.
See https://en.cppreference.com/w/c/string/byte/memcmp for details.
UB was detected on test MSGPACK_V4RAW_REF.pack_unpack_fix_l with UB-sanitizer.