### PR TITLE
Support building for CHERI/Morello

### DIFF
--- a/cmake/sysdep.h.in
+++ b/cmake/sysdep.h.in
@@ -33,6 +33,13 @@
     typedef unsigned __int32 uint32_t;
     typedef signed __int64 int64_t;
     typedef unsigned __int64 uint64_t;
+#   if defined(_WIN64)
+        typedef signed __int64 intptr_t;
+        typedef unsigned __int64 uintptr_t;
+#   else
+        typedef signed __int32 intptr_t;
+        typedef unsigned __int32 uintptr_t;
+#   endif
 #elif defined(_MSC_VER)  // && _MSC_VER >= 1600
 #   include <stdint.h>
 #else

--- a/include/msgpack/zone.h
+++ b/include/msgpack/zone.h
@@ -107,7 +107,7 @@ static inline void* msgpack_zone_malloc(msgpack_zone* zone, size_t size)
 {
     char* aligned =
         (char*)(
-            (size_t)(
+            (uintptr_t)(
                 zone->chunk_list.ptr + (MSGPACK_ZONE_ALIGN - 1)
             ) / MSGPACK_ZONE_ALIGN * MSGPACK_ZONE_ALIGN
         );
@@ -120,7 +120,7 @@ static inline void* msgpack_zone_malloc(msgpack_zone* zone, size_t size)
     {
         void* ptr = msgpack_zone_malloc_expand(zone, size + (MSGPACK_ZONE_ALIGN - 1));
         if (ptr) {
-            return (char*)((size_t)(ptr) / MSGPACK_ZONE_ALIGN * MSGPACK_ZONE_ALIGN);
+            return (char*)((uintptr_t)(ptr) / MSGPACK_ZONE_ALIGN * MSGPACK_ZONE_ALIGN);
         }
     }
     return NULL;

--- a/include/msgpack/zone.h
+++ b/include/msgpack/zone.h
@@ -109,7 +109,7 @@ static inline void* msgpack_zone_malloc(msgpack_zone* zone, size_t size)
         (char*)(
             (uintptr_t)(
                 zone->chunk_list.ptr + (MSGPACK_ZONE_ALIGN - 1)
-            ) / MSGPACK_ZONE_ALIGN * MSGPACK_ZONE_ALIGN
+            ) & ~(uintptr_t)(MSGPACK_ZONE_ALIGN - 1)
         );
     size_t adjusted_size = size + (size_t)(aligned - zone->chunk_list.ptr);
     if(zone->chunk_list.free >= adjusted_size) {
@@ -120,7 +120,7 @@ static inline void* msgpack_zone_malloc(msgpack_zone* zone, size_t size)
     {
         void* ptr = msgpack_zone_malloc_expand(zone, size + (MSGPACK_ZONE_ALIGN - 1));
         if (ptr) {
-            return (char*)((uintptr_t)(ptr) / MSGPACK_ZONE_ALIGN * MSGPACK_ZONE_ALIGN);
+            return (char*)((uintptr_t)(ptr) & ~(uintptr_t)(MSGPACK_ZONE_ALIGN - 1));
         }
     }
     return NULL;


### PR DESCRIPTION
These two commits improve the portability of the C implementation such that they can be successfully built for CHERI, and thus Arm's experimental Morello prototype. Please see the individual commits for the detailed rationale behind the changes.
