### PR TITLE
Install version/config files under CMAKE_INSTALL_LIBDIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -191,6 +191,8 @@ IF (MSGPACK_BUILD_DOCS)
     ENDIF ()
 ENDIF ()
 
+include (GNUInstallDirs)
+
 # Install library.
 INSTALL (TARGETS msgpackc-cxx
          EXPORT msgpackc-cxx-targets
@@ -211,7 +213,7 @@ INCLUDE (CMakePackageConfigHelpers)
 IF (NOT (CMAKE_VERSION VERSION_LESS 3.14))
     SET (extra_version_file_args ARCH_INDEPENDENT)
 ENDIF ()
-SET (cmake_config_path "lib/cmake/msgpackc-cxx")
+SET (cmake_config_path "${CMAKE_INSTALL_LIBDIR}/cmake/msgpackc-cxx")
 
 # Configure the main package file from source tree.
 CONFIGURE_PACKAGE_CONFIG_FILE (


### PR DESCRIPTION
Prior to the c_master/cpp_master split, this is where the files were installed (c.f., https://github.com/msgpack/msgpack-c/blob/6e7deb809120881634b3ca895e66b2a946084f34/CMakeLists.txt#L454) but this was changed to use "lib/" directly when updating the C++-only packaging.

Re-instate the use of CMAKE_INSTALL_LIBDIR so the user can control where they are installed and they follow the typical convention for location.