### PR TITLE
make some headers self-contained

### DIFF
--- a/include/msgpack/adaptor/tr1/unordered_map.hpp
+++ b/include/msgpack/adaptor/tr1/unordered_map.hpp
@@ -12,6 +12,7 @@
 
 #include "msgpack/versioning.hpp"
 #include "msgpack/adaptor/adaptor_base.hpp"
+#include "msgpack/object.hpp"
 #include "msgpack/adaptor/check_container_size.hpp"
 
 #if defined(_LIBCPP_VERSION) || (_MSC_VER >= 1700)

--- a/include/msgpack/adaptor/tr1/unordered_set.hpp
+++ b/include/msgpack/adaptor/tr1/unordered_set.hpp
@@ -12,6 +12,7 @@
 
 #include "msgpack/versioning.hpp"
 #include "msgpack/adaptor/adaptor_base.hpp"
+#include "msgpack/object.hpp"
 #include "msgpack/adaptor/check_container_size.hpp"
 
 #if defined(_LIBCPP_VERSION) || (_MSC_VER >= 1700)

--- a/include/msgpack/v1/adaptor/array_ref_decl.hpp
+++ b/include/msgpack/v1/adaptor/array_ref_decl.hpp
@@ -12,6 +12,7 @@
 
 #include "msgpack/versioning.hpp"
 #include "msgpack/adaptor/adaptor_base.hpp"
+#include "msgpack/object.hpp"
 
 namespace msgpack {
 

--- a/include/msgpack/v1/adaptor/bool.hpp
+++ b/include/msgpack/v1/adaptor/bool.hpp
@@ -12,6 +12,7 @@
 
 #include "msgpack/versioning.hpp"
 #include "msgpack/adaptor/adaptor_base.hpp"
+#include "msgpack/object.hpp"
 
 namespace msgpack {
 

--- a/include/msgpack/v1/adaptor/boost/fusion.hpp
+++ b/include/msgpack/v1/adaptor/boost/fusion.hpp
@@ -12,6 +12,7 @@
 
 #include "msgpack/versioning.hpp"
 #include "msgpack/adaptor/adaptor_base.hpp"
+#include "msgpack/object.hpp"
 #include "msgpack/adaptor/check_container_size.hpp"
 #include "msgpack/meta.hpp"
 

--- a/include/msgpack/v1/adaptor/boost/msgpack_variant_decl.hpp
+++ b/include/msgpack/v1/adaptor/boost/msgpack_variant_decl.hpp
@@ -12,6 +12,7 @@
 
 #include "msgpack/versioning.hpp"
 #include "msgpack/adaptor/adaptor_base.hpp"
+#include "msgpack/object.hpp"
 #include "msgpack/adaptor/check_container_size.hpp"
 #include "msgpack/adaptor/boost/string_ref.hpp"
 #include "msgpack/adaptor/ext.hpp"

--- a/include/msgpack/v1/adaptor/boost/optional.hpp
+++ b/include/msgpack/v1/adaptor/boost/optional.hpp
@@ -12,6 +12,7 @@
 
 #include "msgpack/versioning.hpp"
 #include "msgpack/adaptor/adaptor_base.hpp"
+#include "msgpack/object.hpp"
 #include "msgpack/adaptor/check_container_size.hpp"
 
 #if defined(__GNUC__)

--- a/include/msgpack/v1/adaptor/boost/string_ref.hpp
+++ b/include/msgpack/v1/adaptor/boost/string_ref.hpp
@@ -15,6 +15,7 @@
 
 #include "msgpack/versioning.hpp"
 #include "msgpack/adaptor/adaptor_base.hpp"
+#include "msgpack/object.hpp"
 #include "msgpack/adaptor/check_container_size.hpp"
 
 #include <boost/utility/string_ref.hpp>

--- a/include/msgpack/v1/adaptor/boost/string_view.hpp
+++ b/include/msgpack/v1/adaptor/boost/string_view.hpp
@@ -15,6 +15,7 @@
 
 #include "msgpack/versioning.hpp"
 #include "msgpack/adaptor/adaptor_base.hpp"
+#include "msgpack/object.hpp"
 #include "msgpack/adaptor/check_container_size.hpp"
 
 #include <boost/utility/string_view.hpp>

--- a/include/msgpack/v1/adaptor/cpp11/array.hpp
+++ b/include/msgpack/v1/adaptor/cpp11/array.hpp
@@ -13,6 +13,7 @@
 
 #include "msgpack/versioning.hpp"
 #include "msgpack/adaptor/adaptor_base.hpp"
+#include "msgpack/object.hpp"
 #include "msgpack/adaptor/check_container_size.hpp"
 #include "msgpack/meta.hpp"
 

--- a/include/msgpack/v1/adaptor/cpp11/array_char.hpp
+++ b/include/msgpack/v1/adaptor/cpp11/array_char.hpp
@@ -12,6 +12,7 @@
 
 #include "msgpack/versioning.hpp"
 #include "msgpack/adaptor/adaptor_base.hpp"
+#include "msgpack/object.hpp"
 #include "msgpack/adaptor/check_container_size.hpp"
 
 #include <array>

--- a/include/msgpack/v1/adaptor/cpp11/array_unsigned_char.hpp
+++ b/include/msgpack/v1/adaptor/cpp11/array_unsigned_char.hpp
@@ -12,6 +12,7 @@
 
 #include "msgpack/versioning.hpp"
 #include "msgpack/adaptor/adaptor_base.hpp"
+#include "msgpack/object.hpp"
 #include "msgpack/adaptor/check_container_size.hpp"
 
 #include <array>

--- a/include/msgpack/v1/adaptor/cpp11/chrono.hpp
+++ b/include/msgpack/v1/adaptor/cpp11/chrono.hpp
@@ -13,6 +13,7 @@
 
 #include "msgpack/versioning.hpp"
 #include "msgpack/adaptor/adaptor_base.hpp"
+#include "msgpack/object.hpp"
 #include "msgpack/adaptor/check_container_size.hpp"
 
 #include <chrono>

--- a/include/msgpack/v1/adaptor/cpp11/forward_list.hpp
+++ b/include/msgpack/v1/adaptor/cpp11/forward_list.hpp
@@ -13,6 +13,7 @@
 
 #include "msgpack/versioning.hpp"
 #include "msgpack/adaptor/adaptor_base.hpp"
+#include "msgpack/object.hpp"
 #include "msgpack/adaptor/check_container_size.hpp"
 
 #include <forward_list>

--- a/include/msgpack/v1/adaptor/cpp11/reference_wrapper.hpp
+++ b/include/msgpack/v1/adaptor/cpp11/reference_wrapper.hpp
@@ -13,6 +13,7 @@
 
 #include "msgpack/versioning.hpp"
 #include "msgpack/adaptor/adaptor_base.hpp"
+#include "msgpack/object.hpp"
 #include "msgpack/adaptor/check_container_size.hpp"
 
 #include <memory>

--- a/include/msgpack/v1/adaptor/cpp11/shared_ptr.hpp
+++ b/include/msgpack/v1/adaptor/cpp11/shared_ptr.hpp
@@ -13,6 +13,7 @@
 
 #include "msgpack/versioning.hpp"
 #include "msgpack/adaptor/adaptor_base.hpp"
+#include "msgpack/object.hpp"
 #include "msgpack/adaptor/check_container_size.hpp"
 
 #include <memory>

--- a/include/msgpack/v1/adaptor/cpp11/timespec.hpp
+++ b/include/msgpack/v1/adaptor/cpp11/timespec.hpp
@@ -13,6 +13,7 @@
 #include "msgpack/versioning.hpp"
 #include "msgpack/adaptor/adaptor_base.hpp"
 #include "msgpack/object.hpp"
+#include "msgpack/object.hpp"
 
 #include <ctime>
 

--- a/include/msgpack/v1/adaptor/cpp11/tuple.hpp
+++ b/include/msgpack/v1/adaptor/cpp11/tuple.hpp
@@ -12,6 +12,7 @@
 
 #include "msgpack/versioning.hpp"
 #include "msgpack/adaptor/adaptor_base.hpp"
+#include "msgpack/object.hpp"
 #include "msgpack/adaptor/check_container_size.hpp"
 #include "msgpack/meta.hpp"
 

--- a/include/msgpack/v1/adaptor/cpp11/unique_ptr.hpp
+++ b/include/msgpack/v1/adaptor/cpp11/unique_ptr.hpp
@@ -13,6 +13,7 @@
 
 #include "msgpack/versioning.hpp"
 #include "msgpack/adaptor/adaptor_base.hpp"
+#include "msgpack/object.hpp"
 #include "msgpack/adaptor/check_container_size.hpp"
 
 #include <memory>

--- a/include/msgpack/v1/adaptor/cpp11/unordered_map.hpp
+++ b/include/msgpack/v1/adaptor/cpp11/unordered_map.hpp
@@ -12,6 +12,7 @@
 
 #include "msgpack/versioning.hpp"
 #include "msgpack/adaptor/adaptor_base.hpp"
+#include "msgpack/object.hpp"
 #include "msgpack/adaptor/check_container_size.hpp"
 
 #include <unordered_map>

--- a/include/msgpack/v1/adaptor/cpp11/unordered_set.hpp
+++ b/include/msgpack/v1/adaptor/cpp11/unordered_set.hpp
@@ -12,6 +12,7 @@
 
 #include "msgpack/versioning.hpp"
 #include "msgpack/adaptor/adaptor_base.hpp"
+#include "msgpack/object.hpp"
 #include "msgpack/adaptor/check_container_size.hpp"
 
 #include <unordered_set>

--- a/include/msgpack/v1/adaptor/cpp17/array_byte.hpp
+++ b/include/msgpack/v1/adaptor/cpp17/array_byte.hpp
@@ -16,6 +16,7 @@
 
 #include "msgpack/versioning.hpp"
 #include "msgpack/adaptor/adaptor_base.hpp"
+#include "msgpack/object.hpp"
 #include "msgpack/adaptor/check_container_size.hpp"
 
 #include <array>

--- a/include/msgpack/v1/adaptor/cpp17/byte.hpp
+++ b/include/msgpack/v1/adaptor/cpp17/byte.hpp
@@ -16,6 +16,7 @@
 
 #include "msgpack/versioning.hpp"
 #include "msgpack/adaptor/adaptor_base.hpp"
+#include "msgpack/object.hpp"
 #include "msgpack/adaptor/adaptor_base.hpp"
 #include "msgpack/adaptor/int_decl.hpp"
 #include "msgpack/object.hpp"

--- a/include/msgpack/v1/adaptor/cpp17/carray_byte.hpp
+++ b/include/msgpack/v1/adaptor/cpp17/carray_byte.hpp
@@ -16,6 +16,7 @@
 
 #include "msgpack/versioning.hpp"
 #include "msgpack/adaptor/adaptor_base.hpp"
+#include "msgpack/object.hpp"
 #include "msgpack/adaptor/check_container_size.hpp"
 
 #include <cstring>

--- a/include/msgpack/v1/adaptor/cpp17/optional.hpp
+++ b/include/msgpack/v1/adaptor/cpp17/optional.hpp
@@ -16,6 +16,7 @@
 
 #include "msgpack/versioning.hpp"
 #include "msgpack/adaptor/adaptor_base.hpp"
+#include "msgpack/object.hpp"
 #include "msgpack/adaptor/check_container_size.hpp"
 
 #include <optional>

--- a/include/msgpack/v1/adaptor/cpp17/string_view.hpp
+++ b/include/msgpack/v1/adaptor/cpp17/string_view.hpp
@@ -16,6 +16,7 @@
 
 #include "msgpack/versioning.hpp"
 #include "msgpack/adaptor/adaptor_base.hpp"
+#include "msgpack/object.hpp"
 #include "msgpack/adaptor/check_container_size.hpp"
 
 #include <string_view>

--- a/include/msgpack/v1/adaptor/cpp17/vector_byte.hpp
+++ b/include/msgpack/v1/adaptor/cpp17/vector_byte.hpp
@@ -16,6 +16,7 @@
 
 #include "msgpack/versioning.hpp"
 #include "msgpack/adaptor/adaptor_base.hpp"
+#include "msgpack/object.hpp"
 #include "msgpack/adaptor/check_container_size.hpp"
 
 #include <vector>

--- a/include/msgpack/v1/adaptor/cpp20/span.hpp
+++ b/include/msgpack/v1/adaptor/cpp20/span.hpp
@@ -18,6 +18,7 @@
 
 #include "msgpack/versioning.hpp"
 #include "msgpack/adaptor/adaptor_base.hpp"
+#include "msgpack/object.hpp"
 #include "msgpack/adaptor/check_container_size.hpp"
 #include "msgpack/meta.hpp"
 

--- a/include/msgpack/v1/adaptor/deque.hpp
+++ b/include/msgpack/v1/adaptor/deque.hpp
@@ -12,6 +12,7 @@
 
 #include "msgpack/versioning.hpp"
 #include "msgpack/adaptor/adaptor_base.hpp"
+#include "msgpack/object.hpp"
 #include "msgpack/adaptor/check_container_size.hpp"
 
 #include <deque>

--- a/include/msgpack/v1/adaptor/detail/cpp11_define_array_decl.hpp
+++ b/include/msgpack/v1/adaptor/detail/cpp11_define_array_decl.hpp
@@ -12,6 +12,7 @@
 
 #include "msgpack/versioning.hpp"
 #include "msgpack/adaptor/adaptor_base.hpp"
+#include "msgpack/object.hpp"
 
 namespace msgpack {
 /// @cond

--- a/include/msgpack/v1/adaptor/detail/cpp11_define_map_decl.hpp
+++ b/include/msgpack/v1/adaptor/detail/cpp11_define_map_decl.hpp
@@ -12,6 +12,7 @@
 
 #include "msgpack/versioning.hpp"
 #include "msgpack/adaptor/adaptor_base.hpp"
+#include "msgpack/object.hpp"
 
 namespace msgpack {
 /// @cond

--- a/include/msgpack/v1/adaptor/ext_decl.hpp
+++ b/include/msgpack/v1/adaptor/ext_decl.hpp
@@ -12,6 +12,7 @@
 
 #include "msgpack/versioning.hpp"
 #include "msgpack/adaptor/adaptor_base.hpp"
+#include "msgpack/object.hpp"
 #include <cstring>
 #include <string>
 

--- a/include/msgpack/v1/adaptor/fixint_decl.hpp
+++ b/include/msgpack/v1/adaptor/fixint_decl.hpp
@@ -12,6 +12,7 @@
 
 #include "msgpack/versioning.hpp"
 #include "msgpack/adaptor/adaptor_base.hpp"
+#include "msgpack/object.hpp"
 #include "msgpack/adaptor/int.hpp"
 
 namespace msgpack {

--- a/include/msgpack/v1/adaptor/int_decl.hpp
+++ b/include/msgpack/v1/adaptor/int_decl.hpp
@@ -12,6 +12,7 @@
 
 #include "msgpack/versioning.hpp"
 #include "msgpack/adaptor/adaptor_base.hpp"
+#include "msgpack/object.hpp"
 #include <limits>
 
 namespace msgpack {

--- a/include/msgpack/v1/adaptor/list.hpp
+++ b/include/msgpack/v1/adaptor/list.hpp
@@ -12,6 +12,7 @@
 
 #include "msgpack/versioning.hpp"
 #include "msgpack/adaptor/adaptor_base.hpp"
+#include "msgpack/object.hpp"
 #include "msgpack/adaptor/check_container_size.hpp"
 
 #include <list>

--- a/include/msgpack/v1/adaptor/nil_decl.hpp
+++ b/include/msgpack/v1/adaptor/nil_decl.hpp
@@ -12,6 +12,7 @@
 
 #include "msgpack/versioning.hpp"
 #include "msgpack/adaptor/adaptor_base.hpp"
+#include "msgpack/object.hpp"
 
 namespace msgpack {
 

--- a/include/msgpack/v1/adaptor/pair.hpp
+++ b/include/msgpack/v1/adaptor/pair.hpp
@@ -12,6 +12,7 @@
 
 #include "msgpack/versioning.hpp"
 #include "msgpack/adaptor/adaptor_base.hpp"
+#include "msgpack/object.hpp"
 #include "msgpack/meta.hpp"
 
 #include <utility>

--- a/include/msgpack/v1/adaptor/raw_decl.hpp
+++ b/include/msgpack/v1/adaptor/raw_decl.hpp
@@ -12,6 +12,7 @@
 
 #include "msgpack/versioning.hpp"
 #include "msgpack/adaptor/adaptor_base.hpp"
+#include "msgpack/object.hpp"
 #include <cstring>
 #include <string>
 

--- a/include/msgpack/v1/adaptor/size_equal_only_decl.hpp
+++ b/include/msgpack/v1/adaptor/size_equal_only_decl.hpp
@@ -12,6 +12,7 @@
 
 #include "msgpack/versioning.hpp"
 #include "msgpack/adaptor/adaptor_base.hpp"
+#include "msgpack/object.hpp"
 #include "msgpack/adaptor/msgpack_tuple.hpp"
 
 namespace msgpack {

--- a/include/msgpack/v1/adaptor/string.hpp
+++ b/include/msgpack/v1/adaptor/string.hpp
@@ -12,6 +12,7 @@
 
 #include "msgpack/versioning.hpp"
 #include "msgpack/adaptor/adaptor_base.hpp"
+#include "msgpack/object.hpp"
 #include "msgpack/adaptor/check_container_size.hpp"
 
 #include <string>

--- a/include/msgpack/v1/adaptor/tr1/unordered_map.hpp
+++ b/include/msgpack/v1/adaptor/tr1/unordered_map.hpp
@@ -12,6 +12,7 @@
 
 #include "msgpack/versioning.hpp"
 #include "msgpack/adaptor/adaptor_base.hpp"
+#include "msgpack/object.hpp"
 #include "msgpack/adaptor/check_container_size.hpp"
 
 #if defined(_LIBCPP_VERSION) || (_MSC_VER >= 1700)

--- a/include/msgpack/v1/adaptor/tr1/unordered_set.hpp
+++ b/include/msgpack/v1/adaptor/tr1/unordered_set.hpp
@@ -12,6 +12,7 @@
 
 #include "msgpack/versioning.hpp"
 #include "msgpack/adaptor/adaptor_base.hpp"
+#include "msgpack/object.hpp"
 #include "msgpack/adaptor/check_container_size.hpp"
 
 #if defined(_LIBCPP_VERSION) || (_MSC_VER >= 1700)

--- a/include/msgpack/v1/adaptor/v4raw_decl.hpp
+++ b/include/msgpack/v1/adaptor/v4raw_decl.hpp
@@ -12,6 +12,7 @@
 
 #include "msgpack/versioning.hpp"
 #include "msgpack/adaptor/adaptor_base.hpp"
+#include "msgpack/object.hpp"
 
 namespace msgpack {
 

--- a/include/msgpack/v1/adaptor/vector.hpp
+++ b/include/msgpack/v1/adaptor/vector.hpp
@@ -12,6 +12,7 @@
 
 #include "msgpack/versioning.hpp"
 #include "msgpack/adaptor/adaptor_base.hpp"
+#include "msgpack/object.hpp"
 #include "msgpack/adaptor/check_container_size.hpp"
 
 #include <vector>

--- a/include/msgpack/v1/adaptor/vector_char.hpp
+++ b/include/msgpack/v1/adaptor/vector_char.hpp
@@ -12,6 +12,7 @@
 
 #include "msgpack/versioning.hpp"
 #include "msgpack/adaptor/adaptor_base.hpp"
+#include "msgpack/object.hpp"
 #include "msgpack/adaptor/check_container_size.hpp"
 
 #include <vector>

--- a/include/msgpack/v1/adaptor/vector_unsigned_char.hpp
+++ b/include/msgpack/v1/adaptor/vector_unsigned_char.hpp
@@ -12,6 +12,7 @@
 
 #include "msgpack/versioning.hpp"
 #include "msgpack/adaptor/adaptor_base.hpp"
+#include "msgpack/object.hpp"
 #include "msgpack/adaptor/check_container_size.hpp"
 
 #include <vector>

--- a/include/msgpack/v1/adaptor/wstring.hpp
+++ b/include/msgpack/v1/adaptor/wstring.hpp
@@ -12,6 +12,7 @@
 
 #include "msgpack/versioning.hpp"
 #include "msgpack/adaptor/adaptor_base.hpp"
+#include "msgpack/object.hpp"
 #include "msgpack/adaptor/check_container_size.hpp"
 
 #include <vector>

--- a/include/msgpack/v1/sbuffer.hpp
+++ b/include/msgpack/v1/sbuffer.hpp
@@ -10,6 +10,7 @@
 #ifndef MSGPACK_V1_SBUFFER_HPP
 #define MSGPACK_V1_SBUFFER_HPP
 
+#include "msgpack/v1/cpp_config_decl.hpp"
 #include "msgpack/v1/sbuffer_decl.hpp"
 #include "msgpack/assert.hpp"
 

--- a/include/msgpack/v2/adaptor/v4raw_decl.hpp
+++ b/include/msgpack/v2/adaptor/v4raw_decl.hpp
@@ -12,6 +12,7 @@
 
 #include "msgpack/versioning.hpp"
 #include "msgpack/adaptor/adaptor_base.hpp"
+#include "msgpack/object.hpp"
 
 namespace msgpack {
 

--- a/include/msgpack/v3/adaptor/v4raw_decl.hpp
+++ b/include/msgpack/v3/adaptor/v4raw_decl.hpp
@@ -12,6 +12,7 @@
 
 #include "msgpack/versioning.hpp"
 #include "msgpack/adaptor/adaptor_base.hpp"
+#include "msgpack/object.hpp"
 
 namespace msgpack {
 


### PR DESCRIPTION
some headers are not self-contained, as they depend on
symbols from headers which aren't included