### PR TITLE
fix detection of linux based os

### DIFF
--- a/.github/depends/zlib.sh
+++ b/.github/depends/zlib.sh
@@ -27,9 +27,9 @@ while getopts "b:t:p:" c; do
 done
 
 mkdir $prefix || exit 1
-wget https://zlib.net/zlib-1.2.11.tar.gz || exit 1
-tar -xf zlib-1.2.11.tar.gz || exit 1
-cd zlib-1.2.11
+wget https://zlib.net/zlib-1.2.12.tar.gz || exit 1
+tar -xf zlib-1.2.12.tar.gz || exit 1
+cd zlib-1.2.12
 
 build()
 {

--- a/.github/workflows/gha.yml
+++ b/.github/workflows/gha.yml
@@ -36,7 +36,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ~/zlib-prefix/
-        key: ${{ runner.os }}-zlib-1-2-11-2021-08-09
+        key: ${{ runner.os }}-zlib-1-2-12-2021-08-09
 
     - name: Build zlib
       if: steps.cache-zlib.outputs.cache-hit != 'true'
@@ -111,7 +111,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ~/zlib-prefix/
-        key: ${{ runner.os }}-zlib-1-2-11-2021-08-09
+        key: ${{ runner.os }}-zlib-1-2-12-2021-08-09
 
     - name: Build zlib
       if: steps.cache-zlib.outputs.cache-hit != 'true'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,10 +23,10 @@ environment:
       boost_subdir: lib32-msvc-14.0
 build_script:
   - ps: |
-      appveyor DownloadFile http://zlib.net/zlib-1.2.11.tar.gz -FileName zlib-1.2.11.tar.gz
-      7z x zlib-1.2.11.tar.gz 2> $null
-      7z x zlib-1.2.11.tar 2> $null
-      cd zlib-1.2.11
+      appveyor DownloadFile http://zlib.net/zlib-1.2.12.tar.gz -FileName zlib-1.2.12.tar.gz
+      7z x zlib-1.2.12.tar.gz 2> $null
+      7z x zlib-1.2.12.tar 2> $null
+      cd zlib-1.2.12
 
       md build
       md prefix
@@ -34,7 +34,7 @@ build_script:
 
       cmake `
           -G $env:msvc `
-          -D CMAKE_INSTALL_PREFIX="$env:APPVEYOR_BUILD_FOLDER\zlib-1.2.11\prefix" `
+          -D CMAKE_INSTALL_PREFIX="$env:APPVEYOR_BUILD_FOLDER\zlib-1.2.12\prefix" `
           ..
       if ($LastExitCode -ne 0) { exit $LastExitCode }
 
@@ -52,7 +52,7 @@ build_script:
           -D MSGPACK_BUILD_EXAMPLES=ON `
           -D MSGPACK_BUILD_TESTS=ON `
           -D CMAKE_EXE_LINKER_FLAGS=/LIBPATH:"$env:boost_prefix\$env:boost_subdir" `
-          -D CMAKE_PREFIX_PATH="$env:boost_prefix;$env:APPVEYOR_BUILD_FOLDER\zlib-1.2.11\prefix" `
+          -D CMAKE_PREFIX_PATH="$env:boost_prefix;$env:APPVEYOR_BUILD_FOLDER\zlib-1.2.12\prefix" `
           -D CMAKE_INSTALL_PREFIX="$env:APPVEYOR_BUILD_FOLDER\prefix" `
           -D CMAKE_CXX_FLAGS="/D_VARIADIC_MAX=10 /EHsc /DBOOST_ALL_DYN_LINK" `
           ..
@@ -62,5 +62,5 @@ build_script:
       if ($LastExitCode -ne 0) { exit $LastExitCode }
 
 test_script:
-- set PATH=%PATH%;%APPVEYOR_BUILD_FOLDER%\zlib-1.2.11\build\Release;%APPVEYOR_BUILD_FOLDER%\build\release;%boost_prefix%\%boost_subdir%
+- set PATH=%PATH%;%APPVEYOR_BUILD_FOLDER%\zlib-1.2.12\build\Release;%APPVEYOR_BUILD_FOLDER%\build\release;%boost_prefix%\%boost_subdir%
 - ctest -VV -C Release

--- a/include/msgpack/predef/os/linux.h
+++ b/include/msgpack/predef/os/linux.h
@@ -27,7 +27,7 @@ http://www.boost.org/LICENSE_1_0.txt)
 #define MSGPACK_OS_LINUX MSGPACK_VERSION_NUMBER_NOT_AVAILABLE
 
 #if !defined(MSGPACK_PREDEF_DETAIL_OS_DETECTED) && ( \
-    defined(linux) || defined(__linux) \
+    defined(linux) || defined(__linux) || defined(__linux__) \
     )
 #   undef MSGPACK_OS_LINUX
 #   define MSGPACK_OS_LINUX MSGPACK_VERSION_NUMBER_AVAILABLE

--- a/include/msgpack/sysdep.hpp
+++ b/include/msgpack/sysdep.hpp
@@ -88,7 +88,7 @@
 #elif defined(unix) || defined(__unix) || defined(__APPLE__) || defined(__OpenBSD__)
 
 #include <arpa/inet.h>  /* __BYTE_ORDER */
-#   if defined(linux)
+#   if defined(linux) || defined(__linux__)
 #       include <byteswap.h>
 #   endif
 


### PR DESCRIPTION
According to [one](https://sourceforge.net/p/predef/wiki/OperatingSystems/) and [two](http://www.faqs.org/docs/Linux-HOWTO/GCC-HOWTO.html#INDEX.25) `linux` macro is obsolete, `__linux__` should be used instead. Quoting [two](http://www.faqs.org/docs/Linux-HOWTO/GCC-HOWTO.html#INDEX.25):

> If you are writing code that uses Linux-specific features, it is a good idea to enclose the nonportable bits in
#ifdef \_\_linux__
/* ... funky stuff ... */
#endif /* linux */
Use \_\_linux__ for this purpose, not linux. Although the latter is defined, it is not POSIX compliant.

It turns out that `linux` macro undefined when compiling project with `-std=c++xy` family of compilation flags, e.g. with `-std=c++11`