### PR TITLE
Fixed #1029.

### DIFF
--- a/erb/v1/cpp03_zone.hpp.erb
+++ b/erb/v1/cpp03_zone.hpp.erb
@@ -138,7 +138,7 @@ class zone {
     finalizer_array m_finalizer_array;
 
 public:
-    zone(size_t chunk_size = MSGPACK_ZONE_CHUNK_SIZE) /* throw() */;
+    zone(size_t chunk_size = MSGPACK_ZONE_CHUNK_SIZE);
 
 public:
     void* allocate_align(size_t size, size_t align = MSGPACK_ZONE_ALIGN);
@@ -194,7 +194,7 @@ private:
     zone& operator=(const zone&);
 };
 
-inline zone::zone(size_t chunk_size) /* throw() */ :m_chunk_size(chunk_size), m_chunk_list(m_chunk_size)
+inline zone::zone(size_t chunk_size):m_chunk_size(chunk_size), m_chunk_list(m_chunk_size)
 {
 }
 

--- a/include/msgpack/v1/detail/cpp03_zone.hpp
+++ b/include/msgpack/v1/detail/cpp03_zone.hpp
@@ -138,7 +138,7 @@ class zone {
     finalizer_array m_finalizer_array;
 
 public:
-    zone(size_t chunk_size = MSGPACK_ZONE_CHUNK_SIZE) /* throw() */;
+    zone(size_t chunk_size = MSGPACK_ZONE_CHUNK_SIZE);
 
 public:
     void* allocate_align(size_t size, size_t align = MSGPACK_ZONE_ALIGN);
@@ -239,7 +239,7 @@ private:
     zone& operator=(const zone&);
 };
 
-inline zone::zone(size_t chunk_size) /* throw() */ :m_chunk_size(chunk_size), m_chunk_list(m_chunk_size)
+inline zone::zone(size_t chunk_size):m_chunk_size(chunk_size), m_chunk_list(m_chunk_size)
 {
 }
 

--- a/include/msgpack/v1/detail/cpp11_zone.hpp
+++ b/include/msgpack/v1/detail/cpp11_zone.hpp
@@ -171,7 +171,7 @@ private:
     finalizer_array m_finalizer_array;
 
 public:
-    zone(size_t chunk_size = MSGPACK_ZONE_CHUNK_SIZE) noexcept;
+    zone(size_t chunk_size = MSGPACK_ZONE_CHUNK_SIZE);
 
 public:
     void* allocate_align(size_t size, size_t align = MSGPACK_ZONE_ALIGN);
@@ -226,7 +226,7 @@ private:
     char* allocate_expand(size_t size);
 };
 
-inline zone::zone(size_t chunk_size) noexcept:m_chunk_size(chunk_size), m_chunk_list(m_chunk_size)
+inline zone::zone(size_t chunk_size):m_chunk_size(chunk_size), m_chunk_list(m_chunk_size)
 {
 }
 


### PR DESCRIPTION
Removed invalid `noexcept` from zone's constructor.