### PR TITLE
Prevents the looking for boost if built without it for dependents

### DIFF
--- a/msgpack-config.cmake.in
+++ b/msgpack-config.cmake.in
@@ -2,7 +2,9 @@
 
 include(CMakeFindDependencyMacro)
 
-find_dependency(Boost REQUIRED)
+IF (@MSGPACK_USE_BOOST@)
+    find_dependency(Boost REQUIRED)
+ENDIF ()
 
 include("${CMAKE_CURRENT_LIST_DIR}/msgpackc-cxx-targets.cmake")
 


### PR DESCRIPTION
The library is still using Boost for the dependents and will fail to build if the dependents do not have BOOST installed.

By adding the following to the configured file, we will fix the usage with either looking or not for Boost. (`@MSGPACK_USE_BOOST@` will be translated to `ON` or `OFF` at configure time)
```cmake
IF (@MSGPACK_USE_BOOST@)
    find_dependency(Boost REQUIRED)
ENDIF ()

```