### PR TITLE
Specify that the project uses only C

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ IF ((CMAKE_VERSION VERSION_GREATER 3.1) OR
     CMAKE_POLICY(SET CMP0054 NEW)
 ENDIF ()
 
-PROJECT (msgpack)
+PROJECT (msgpack C)
 
 FILE (READ ${CMAKE_CURRENT_SOURCE_DIR}/include/msgpack/version_master.h contents)
 STRING (REGEX MATCH "#define MSGPACK_VERSION_MAJOR *([0-9a-zA-Z_]*)" NULL_OUT ${contents})


### PR DESCRIPTION
In rare cases, such as using the clang-cl compiler on Windows, the build assumes that the project is both C and C++ based and will give an error if the variable CMAKE_CXX_COMPILER isn't defined. Explicitly stating it's a C project prevents this situation.