### PR TITLE
Fix config for new MSVC preprocessor

### DIFF
--- a/.github/workflows/gha.yml
+++ b/.github/workflows/gha.yml
@@ -195,6 +195,7 @@ jobs:
       matrix:
         # MSVC2019 only supports /std:c++14, /std:c++17 and /std:c++latest
         cxx: [14, 17, 20]
+        pp_flag: ["/Zc:preprocessor-", "/Zc:preprocessor"]
     steps:
     - uses: actions/checkout@v2
 
@@ -225,7 +226,7 @@ jobs:
             -D CMAKE_TOOLCHAIN_FILE="C:/vcpkg/scripts/buildsystems/vcpkg.cmake" `
             -D MSGPACK_BUILD_TESTS=ON `
             -D $CPPVER `
-            -D CMAKE_CXX_FLAGS="/D_VARIADIC_MAX=10 /EHsc /D_SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING /D_SILENCE_CXX17_ALLOCATOR_VOID_DEPRECATION_WARNING /D_SILENCE_CXX17_OLD_ALLOCATOR_MEMBERS_DEPRECATION_WARNING /W3 /WX" `
+            -D CMAKE_CXX_FLAGS="${{ matrix.pp_flag }} /D_VARIADIC_MAX=10 /EHsc /D_SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING /D_SILENCE_CXX17_ALLOCATOR_VOID_DEPRECATION_WARNING /D_SILENCE_CXX17_OLD_ALLOCATOR_MEMBERS_DEPRECATION_WARNING /W3 /WX" `
             -B build `
             -S .
         if ($LastExitCode -ne 0) { exit $LastExitCode }

--- a/include/msgpack/preprocessor/config/config.hpp
+++ b/include/msgpack/preprocessor/config/config.hpp
@@ -24,16 +24,22 @@
 # define MSGPACK_PP_CONFIG_EDG() 0x0020
 # define MSGPACK_PP_CONFIG_DMC() 0x0040
 #
+# if !defined(__clang__) && (!defined(_MSVC_TRADITIONAL) || _MSVC_TRADITIONAL)
+#    define MSGPACK_TRADITIONAL_MSVC 1
+# else
+#    define MSGPACK_TRADITIONAL_MSVC 0
+# endif
+#
 # ifndef MSGPACK_PP_CONFIG_FLAGS
 #    if defined(__GCCXML__) || defined(__WAVE__) || defined(__MWERKS__) && __MWERKS__ >= 0x3200
 #        define MSGPACK_PP_CONFIG_FLAGS() (MSGPACK_PP_CONFIG_STRICT())
 #    elif defined(__EDG__) || defined(__EDG_VERSION__)
-#        if defined(_MSC_VER) && !defined(__clang__) && (defined(__INTELLISENSE__) || __EDG_VERSION__ >= 308)
+#        if defined(_MSC_VER) && MSGPACK_TRADITIONAL_MSVC && (defined(__INTELLISENSE__) || __EDG_VERSION__ >= 308)
 #            define MSGPACK_PP_CONFIG_FLAGS() (MSGPACK_PP_CONFIG_MSVC())
 #        else
 #            define MSGPACK_PP_CONFIG_FLAGS() (MSGPACK_PP_CONFIG_EDG() | MSGPACK_PP_CONFIG_STRICT())
 #        endif
-#    elif defined(_MSC_VER) && defined(__clang__)
+#    elif defined(_MSC_VER) && !MSGPACK_TRADITIONAL_MSVC
 #        define MSGPACK_PP_CONFIG_FLAGS() (MSGPACK_PP_CONFIG_STRICT())
 #    elif defined(__MWERKS__)
 #        define MSGPACK_PP_CONFIG_FLAGS() (MSGPACK_PP_CONFIG_MWCC())
@@ -75,7 +81,7 @@
 #        define MSGPACK_PP_VARIADICS 0
 #    elif defined(__CUDACC__)
 #        define MSGPACK_PP_VARIADICS 1
-#    elif defined(_MSC_VER) && defined(__clang__)
+#    elif defined(_MSC_VER) && !MSGPACK_TRADITIONAL_MSVC
 #        define MSGPACK_PP_VARIADICS 1
 #    /* VC++ (C/C++) and Intel C++ Compiler >= 17.0 with MSVC */
 #    elif defined _MSC_VER && _MSC_VER >= 1400 && (!defined __EDG__ || defined(__INTELLISENSE__) || defined(__INTEL_COMPILER) && __INTEL_COMPILER >= 1700)
@@ -94,7 +100,7 @@
 # elif !MSGPACK_PP_VARIADICS + 1 < 2
 #    undef MSGPACK_PP_VARIADICS
 #    define MSGPACK_PP_VARIADICS 1
-#    if defined _MSC_VER && _MSC_VER >= 1400 && !defined(__clang__) && (defined(__INTELLISENSE__) || (defined(__INTEL_COMPILER) && __INTEL_COMPILER >= 1700) || !(defined __EDG__ || defined __GCCXML__ || defined __CUDACC__ || defined __PATHSCALE__ || defined __DMC__ || defined __CODEGEARC__ || defined __BORLANDC__ || defined __MWERKS__ || defined __SUNPRO_CC || defined __HP_aCC || defined __MRC__ || defined __SC__ || defined __IBMCPP__ || defined __PGI))
+#    if defined _MSC_VER && _MSC_VER >= 1400 && MSGPACK_TRADITIONAL_MSVC && (defined(__INTELLISENSE__) || (defined(__INTEL_COMPILER) && __INTEL_COMPILER >= 1700) || !(defined __EDG__ || defined __GCCXML__ || defined __CUDACC__ || defined __PATHSCALE__ || defined __DMC__ || defined __CODEGEARC__ || defined __BORLANDC__ || defined __MWERKS__ || defined __SUNPRO_CC || defined __HP_aCC || defined __MRC__ || defined __SC__ || defined __IBMCPP__ || defined __PGI))
 #        undef MSGPACK_PP_VARIADICS_MSVC
 #        define MSGPACK_PP_VARIADICS_MSVC 1
 #    endif


### PR DESCRIPTION
The [new MSVC preprocessor](https://devblogs.microsoft.com/cppblog/announcing-full-support-for-a-c-c-conformant-preprocessor-in-msvc) is now standard-conformant. It should use the standard (strict) macro definition if `/Zc:preprocessor` is specified.