### PR TITLE
Change CMake package name of C library to msgpackc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ IF ((CMAKE_VERSION VERSION_GREATER 3.1) OR
     CMAKE_POLICY(SET CMP0054 NEW)
 ENDIF ()
 
-PROJECT (msgpack)
+PROJECT (msgpackc)
 
 FILE (READ ${CMAKE_CURRENT_SOURCE_DIR}/include/msgpack/version_master.h contents)
 STRING (REGEX MATCH "#define MSGPACK_VERSION_MAJOR *([0-9a-zA-Z_]*)" NULL_OUT ${contents})
@@ -254,7 +254,7 @@ IF (MSGPACK_ENABLE_SHARED AND MSGPACK_ENABLE_STATIC)
     LIST (APPEND MSGPACK_INSTALLTARGETS msgpackc-static)
 ENDIF ()
 
-INSTALL (TARGETS ${MSGPACK_INSTALLTARGETS} EXPORT msgpack-targets
+INSTALL (TARGETS ${MSGPACK_INSTALLTARGETS} EXPORT msgpackc-targets
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
@@ -298,36 +298,36 @@ ENDIF ()
 
 INCLUDE (CMakePackageConfigHelpers)
 
-SET (CMAKE_INSTALL_CMAKEDIR "${CMAKE_INSTALL_LIBDIR}/cmake/msgpack")
+SET (CMAKE_INSTALL_CMAKEDIR "${CMAKE_INSTALL_LIBDIR}/cmake/msgpackc")
 
 WRITE_BASIC_PACKAGE_VERSION_FILE (
-    msgpack-config-version.cmake
+    msgpackc-config-version.cmake
     VERSION ${VERSION}
     COMPATIBILITY SameMajorVersion
 )
 
 IF (NOT CMAKE_VERSION VERSION_LESS 3.0)
-    EXPORT (EXPORT msgpack-targets
-        FILE "${CMAKE_CURRENT_BINARY_DIR}/msgpack-targets.cmake"
+    EXPORT (EXPORT msgpackc-targets
+        FILE "${CMAKE_CURRENT_BINARY_DIR}/msgpackc-targets.cmake"
     )
 ENDIF ()
 
-CONFIGURE_PACKAGE_CONFIG_FILE (msgpack-config.cmake.in
-    msgpack-config.cmake
+CONFIGURE_PACKAGE_CONFIG_FILE (msgpackc-config.cmake.in
+    msgpackc-config.cmake
     INSTALL_DESTINATION "${CMAKE_INSTALL_CMAKEDIR}"
 )
 
-INSTALL (EXPORT msgpack-targets
+INSTALL (EXPORT msgpackc-targets
     FILE
-        msgpack-targets.cmake
+        msgpackc-targets.cmake
     DESTINATION
         "${CMAKE_INSTALL_CMAKEDIR}"
 )
 
 INSTALL (
     FILES
-        "${CMAKE_CURRENT_BINARY_DIR}/msgpack-config.cmake"
-        "${CMAKE_CURRENT_BINARY_DIR}/msgpack-config-version.cmake"
+        "${CMAKE_CURRENT_BINARY_DIR}/msgpackc-config.cmake"
+        "${CMAKE_CURRENT_BINARY_DIR}/msgpackc-config-version.cmake"
     DESTINATION
         "${CMAKE_INSTALL_CMAKEDIR}"
 )

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,10 +22,10 @@ build_script:
 - cmake --build . --config Release
 - cd ..
 - cd ..
-- appveyor DownloadFile http://zlib.net/zlib-1.2.12.tar.gz -FileName zlib-1.2.12.tar.gz
-- 7z x zlib-1.2.12.tar.gz > NUL
-- 7z x zlib-1.2.12.tar > NUL
-- cd zlib-1.2.12
+- appveyor DownloadFile http://zlib.net/zlib-1.2.13.tar.gz -FileName zlib-1.2.13.tar.gz
+- 7z x zlib-1.2.13.tar.gz > NUL
+- 7z x zlib-1.2.13.tar > NUL
+- cd zlib-1.2.13
 - md build
 - cd build
 - cmake -G %msvc% ..

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,9 +35,9 @@ build_script:
 - cd ..
 - md build
 - cd build
-- cmake -G %msvc% -DGTEST_LIBRARY=%APPVEYOR_BUILD_FOLDER%\googletest-release-1.7.0\build\Release\gtest.lib -DGTEST_MAIN_LIBRARY=%APPVEYOR_BUILD_FOLDER%\googletest-release-1.7.0\build\Release\gtest_main.lib -DGTEST_INCLUDE_DIR=%APPVEYOR_BUILD_FOLDER%\googletest-release-1.7.0\include -DZLIB_LIBRARY=%APPVEYOR_BUILD_FOLDER%\zlib-1.2.12\build\Release\zlib.lib -DZLIB_INCLUDE_DIR=%APPVEYOR_BUILD_FOLDER%\zlib-1.2.12 -DCMAKE_CXX_FLAGS='"/D_VARIADIC_MAX=10 /EHsc"' ..
+- cmake -G %msvc% -DGTEST_LIBRARY=%APPVEYOR_BUILD_FOLDER%\googletest-release-1.7.0\build\Release\gtest.lib -DGTEST_MAIN_LIBRARY=%APPVEYOR_BUILD_FOLDER%\googletest-release-1.7.0\build\Release\gtest_main.lib -DGTEST_INCLUDE_DIR=%APPVEYOR_BUILD_FOLDER%\googletest-release-1.7.0\include -DZLIB_LIBRARY=%APPVEYOR_BUILD_FOLDER%\zlib-1.2.13\build\Release\zlib.lib -DZLIB_INCLUDE_DIR=%APPVEYOR_BUILD_FOLDER%\zlib-1.2.13 -DCMAKE_CXX_FLAGS='"/D_VARIADIC_MAX=10 /EHsc"' ..
 - cmake --build . --config Release -v
 
 test_script:
-- set PATH=%PATH%;%APPVEYOR_BUILD_FOLDER%\googletest-release-1.7.0\build\Release;%APPVEYOR_BUILD_FOLDER%\zlib-1.2.12\build\Release;%APPVEYOR_BUILD_FOLDER%\build\release
+- set PATH=%PATH%;%APPVEYOR_BUILD_FOLDER%\googletest-release-1.7.0\build\Release;%APPVEYOR_BUILD_FOLDER%\zlib-1.2.13\build\Release;%APPVEYOR_BUILD_FOLDER%\build\release
 - ctest -V

--- a/example/cmake/CMakeLists.txt
+++ b/example/cmake/CMakeLists.txt
@@ -3,7 +3,7 @@ project (example)
 
 if(EXAMPLE_MSGPACK_EMBEDDED)
     add_subdirectory(msgpack-c)
-    set(msgpack_DIR ${CMAKE_CURRENT_BINARY_DIR}/msgpack-c)
+    set(msgpackc_DIR ${CMAKE_CURRENT_BINARY_DIR}/msgpack-c)
 endif()
 
 find_package(msgpackc REQUIRED)

--- a/example/cmake/CMakeLists.txt
+++ b/example/cmake/CMakeLists.txt
@@ -6,7 +6,7 @@ if(EXAMPLE_MSGPACK_EMBEDDED)
     set(msgpack_DIR ${CMAKE_CURRENT_BINARY_DIR}/msgpack-c)
 endif()
 
-find_package(msgpack REQUIRED)
+find_package(msgpackc REQUIRED)
 
 add_executable (${PROJECT_NAME} ${CMAKE_CURRENT_LIST_DIR}/../simple_c.c)
 target_link_libraries(${PROJECT_NAME} msgpackc)

--- a/msgpackc-config.cmake.in
+++ b/msgpackc-config.cmake.in
@@ -15,5 +15,5 @@
 include(CMakeFindDependencyMacro)
 
 if(NOT TARGET msgpackc AND NOT TARGET msgpackc-static)
-  include("${CMAKE_CURRENT_LIST_DIR}/msgpack-targets.cmake")
+  include("${CMAKE_CURRENT_LIST_DIR}/msgpackc-targets.cmake")
 endif()


### PR DESCRIPTION
Change the CMake package name to msgpackc, as requested in https://github.com/msgpack/msgpack-c/issues/1043#issuecomment-1372169699 . After this change, to find the C library in the system, it is necessary to call:
~~~cmake
find_package(msgpackc REQUIRED)
~~~
instead of the previously used:
~~~cmake
find_package(msgpack REQUIRED)
~~~

Fix https://github.com/msgpack/msgpack-c/issues/1043 .