### PR TITLE
adaptor: better diagnostic for converter

### DIFF
--- a/include/msgpack/v1/cpp_config.hpp
+++ b/include/msgpack/v1/cpp_config.hpp
@@ -138,4 +138,24 @@ template<class T> struct is_pointer : detail::is_pointer_helper<typename remove_
 #define MSGPACK_DEPRECATED(msg)
 #endif // MSGPACK_CPP_VERSION >= 201402L
 
+
+#if !defined(MSGPACK_USE_CPP03) && MSGPACK_CPP_VERSION < 201703L
+
+namespace msgpack {
+
+/// @cond
+MSGPACK_API_VERSION_NAMESPACE(v1) {
+/// @endcond
+
+template<typename...> using void_t = void;
+
+/// @cond
+}  // MSGPACK_API_VERSION_NAMESPACE(v1)
+/// @endcond
+
+}  // namespace msgpack
+
+#endif
+
+
 #endif // MSGPACK_V1_CPP_CONFIG_HPP

--- a/include/msgpack/v1/cpp_config_decl.hpp
+++ b/include/msgpack/v1/cpp_config_decl.hpp
@@ -87,6 +87,7 @@ struct is_pointer;
 
 #include <memory>
 #include <tuple>
+#include <type_traits>
 
 namespace msgpack {
 /// @cond
@@ -123,5 +124,24 @@ MSGPACK_API_VERSION_NAMESPACE(v1) {
 #else  // defined(__has_include)
 #define MSGPACK_HAS_INCLUDE(header) 0
 #endif // defined(__has_include)
+
+#if MSGPACK_CPP_VERSION >= 201703L
+
+namespace msgpack {
+/// @cond
+MSGPACK_API_VERSION_NAMESPACE(v1) {
+/// @endcond
+
+    // type_traits
+    using std::void_t;
+
+/// @cond
+}  // MSGPACK_API_VERSION_NAMESPACE(v1)
+/// @endcond
+}  // namespace msgpack
+
+
+#endif
+
 
 #endif // MSGPACK_V1_CPP_CONFIG_DECL_HPP

--- a/include/msgpack/v1/object.hpp
+++ b/include/msgpack/v1/object.hpp
@@ -640,10 +640,17 @@ struct packer_serializer {
 } // namespace detail
 
 // Adaptor functors' member functions definitions.
+#ifdef MSGPACK_USE_CPP03
 template <typename T, typename Enabler>
 inline
 msgpack::object const&
 adaptor::convert<T, Enabler>::operator()(msgpack::object const& o, T& v) const {
+#else
+template <typename T>
+inline
+msgpack::object const&
+adaptor::convert<T, typename std::enable_if<adaptor::impl::has_msgpack_unpack<T>::value>::type>::operator()(msgpack::object const& o, T& v) const {
+#endif
     v.msgpack_unpack(o.convert());
     return o;
 }

--- a/test/object.cpp
+++ b/test/object.cpp
@@ -562,3 +562,18 @@ BOOST_AUTO_TEST_CASE(array_unsigned_char)
 }
 
 #endif // MSGPACK_CPP_VERSION >= 201703
+
+#ifndef MSGPACK_USE_CPP03
+
+struct struct_without_adaptor
+{
+    int foo;
+};
+
+BOOST_AUTO_TEST_CASE(has_msgpack_unpack)
+{
+    static_assert(msgpack::v1::adaptor::impl::has_msgpack_unpack<struct_without_adaptor>::value == false, "");
+    static_assert(msgpack::v1::adaptor::impl::has_msgpack_unpack<myclass>::value, "");
+}
+
+#endif


### PR DESCRIPTION
we only use the default `convert` implementation, if a `msgpack_unpack` method actually exists. if that's not the case we get an `undefined template` error.