### PR TITLE
ci: Use ubuntu-latest for CI on Linux

### DIFF
--- a/.github/workflows/gha.yml
+++ b/.github/workflows/gha.yml
@@ -66,7 +66,7 @@ jobs:
         CMAKE_CXX_COMPILER="${CXX}" CMAKE_C_COMPILER="${CC}" GTEST_ROOT="${BASE}/usr" CFLAGS="-Werror -g -fsanitize=undefined  -fno-sanitize-recover=all" CXXFLAGS="-Werror -g -ggdb3 -fsanitize=undefined  -fno-sanitize-recover=all" ${ACTION}
 
   linux:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
@@ -76,7 +76,7 @@ jobs:
     - name: install build depends
       run: |
         sudo apt-get update
-        sudo apt-get install g++-multilib clang-8 valgrind
+        sudo apt-get install g++-multilib clang valgrind
     - name: build and test
       shell: bash
       run: |
@@ -161,17 +161,12 @@ jobs:
         fi
 
         # install gtest
-        wget https://github.com/google/googletest/archive/release-1.7.0.zip -O googletest-release-1.7.0.zip
-        unzip -q googletest-release-1.7.0.zip
-        cd googletest-release-1.7.0
-        $CXX -m${ARCH} src/gtest-all.cc -I. -Iinclude -c -fPIC
-        $CXX -m${ARCH} src/gtest_main.cc -I. -Iinclude -c -fPIC
-        ar -rv libgtest.a gtest-all.o
-        ar -rv libgtest_main.a gtest_main.o
-        mkdir -p ${BASE}/usr/include
-        cp -r include/gtest ${BASE}/usr/include
-        mkdir -p ${BASE}/usr/lib
-        mv *.a ${BASE}/usr/lib
+        wget https://github.com/google/googletest/archive/v1.13.0.zip -O googletest-1.13.0.zip
+        unzip -q googletest-1.13.0.zip
+        cd googletest-1.13.0
+        cmake -S . -DCMAKE_CXX_FLAGS="-m$ARCH" --install-prefix="$BASE/usr"
+        cmake --build .  --verbose
+        cmake --install . --verbose
         cd ..
 
         # install zlib
@@ -180,7 +175,7 @@ jobs:
         fi
 
         # build and test
-        CMAKE_CXX_COMPILER="${CXX}" CMAKE_C_COMPILER="${CC}" GTEST_ROOT="${BASE}/usr" CFLAGS="-Werror -g -fsanitize=undefined  -fno-sanitize-recover=all" CXXFLAGS="-Werror -g -ggdb3 -fsanitize=undefined  -fno-sanitize-recover=all" ${ACTION}
+        CMAKE_CXX_COMPILER="${CXX}" CMAKE_C_COMPILER="${CC}" GTEST_ROOT="${BASE}/usr" CFLAGS="-Werror -g -gdwarf-4 -fsanitize=undefined  -fno-sanitize-recover=all" CXXFLAGS="-Werror -g -ggdb3 -gdwarf-4 -fsanitize=undefined  -fno-sanitize-recover=all" ${ACTION}
 
   windows:
     runs-on: windows-2019

--- a/ci/build_cmake.sh
+++ b/ci/build_cmake.sh
@@ -33,7 +33,7 @@ then
     exit $ret
 fi
 
-make
+make VERBOSE=1
 
 ret=$?
 if [ $ret -ne 0 ]
@@ -60,17 +60,8 @@ fi
 
 if [ "${ARCH}" != "32" ] && [ `uname` = "Linux" ]
 then
-    ctest -T memcheck | tee memcheck.log
-
-    ret=${PIPESTATUS[0]}
-    if [ $ret -ne 0 ]
-    then
-        exit $ret
-    fi
-    cat memcheck.log | grep "Memory Leak" > /dev/null
-    ret=$?
-    if [ $ret -eq 0 ]
-    then
+    if ! ctest -T memcheck; then
+        find Testing/Temporary -name "MemoryChecker.*.log" -exec cat {} +
         exit 1
     fi
 fi


### PR DESCRIPTION
Ubuntu 18.04 is deprecated on GitHub Actions. Additionally:

- Install 'clang' to get the latest clang toolchain.
    - Use -gdwarf-4 so Valgrind understands the debug information.
- Install latest version of gtest (v1.13.0).
- Show compile and link commands when building.
- `cat` Valgrind output on error.