### PR TITLE
Fix to avoid common function name's (`has_as::check`) ambiguity/conflict with other libraries' macros

### DIFF
--- a/include/msgpack/v1/object_fwd.hpp
+++ b/include/msgpack/v1/object_fwd.hpp
@@ -53,16 +53,16 @@ template <typename T>
 struct has_as {
 private:
     template <typename U>
-    static auto check(U*) ->
+    static auto check_(U*) ->
         // Check v1 specialization
         typename std::is_same<
             decltype(adaptor::as<U>()(std::declval<msgpack::object>())),
             T
         >::type;
     template <typename...>
-    static std::false_type check(...);
+    static std::false_type check_(...);
 public:
-    using type = decltype(check<T>(MSGPACK_NULLPTR));
+    using type = decltype(check_<T>(MSGPACK_NULLPTR));
     static constexpr bool value = type::value;
 };
 

--- a/include/msgpack/v2/object_fwd.hpp
+++ b/include/msgpack/v2/object_fwd.hpp
@@ -79,7 +79,7 @@ template <typename T>
 struct has_as {
 private:
     template <typename U>
-    static auto check(U*) ->
+    static auto check_(U*) ->
         typename std::enable_if<
             // check v2 specialization
             std::is_same<
@@ -92,9 +92,9 @@ private:
             std::true_type
         >::type;
     template <typename...>
-    static std::false_type check(...);
+    static std::false_type check_(...);
 public:
-    using type = decltype(check<T>(MSGPACK_NULLPTR));
+    using type = decltype(check_<T>(MSGPACK_NULLPTR));
     static constexpr bool value = type::value;
 };
 

--- a/include/msgpack/v3/object_fwd.hpp
+++ b/include/msgpack/v3/object_fwd.hpp
@@ -36,7 +36,7 @@ template <typename T>
 struct has_as {
 private:
     template <typename U>
-    static auto check(U*) ->
+    static auto check_(U*) ->
         typename std::enable_if<
             // check v3 specialization
             std::is_same<
@@ -52,9 +52,9 @@ private:
             std::true_type
         >::type;
     template <typename...>
-    static std::false_type check(...);
+    static std::false_type check_(...);
 public:
-    using type = decltype(check<T>(MSGPACK_NULLPTR));
+    using type = decltype(check_<T>(MSGPACK_NULLPTR));
     static constexpr bool value = type::value;
 };
 


### PR DESCRIPTION
This is a minor change of a private function name, which can have a big impact for Unreal Engine's users to be able to use msgpack-cxx library as unfortunately some libraries, specially, Unreal Engine use badly named generic/common macro definitions (UE uses since v4.0) and no effort to modify their macro names to something more unique to their engine. 

This issue fixes #1050 and was also raised and discussed in #626 in more depth.