### PR TITLE
Optimization of msgpack::zone size on the stack and deferred memory allocation

### DIFF
--- a/erb/v1/cpp03_zone.hpp.erb
+++ b/erb/v1/cpp03_zone.hpp.erb
@@ -45,7 +45,7 @@ class zone {
 
         void clear() {
             finalizer* fin = m_head;
-            finalizer* tmp = nullptr;
+            finalizer* tmp = MSGPACK_NULLPTR;
             while(fin) {
                 (*fin)();
                 tmp = fin;

--- a/erb/v1/cpp03_zone.hpp.erb
+++ b/erb/v1/cpp03_zone.hpp.erb
@@ -60,7 +60,7 @@ class zone {
         }
 
         void pop() {
-            auto n = m_head->m_next;
+            finalizer* n = m_head->m_next;
             delete m_head;
             m_head = n;
         }
@@ -196,7 +196,7 @@ inline char* zone::get_aligned(char* ptr, size_t align) {
 
 inline zone::chunk_list& zone::get_chank_lst() {
     if (!m_chunk_list) {
-        auto ptr = ::malloc(sizeof(chunk_list) + m_chunk_size);
+        void* ptr = ::malloc(sizeof(chunk_list) + m_chunk_size);
         if (!ptr)
             throw std::bad_alloc();
         m_chunk_list = new (ptr) chunk_list(m_chunk_size, reinterpret_cast<char*>(ptr) + sizeof(chunk_list));
@@ -277,7 +277,7 @@ inline void zone::swap(zone& o) {
     using std::swap;
     swap(m_chunk_size, o.m_chunk_size);
     swap(m_chunk_list, o.m_chunk_list);
-    swap(m_finalizer_array, o.m_finalizer_array);
+    swap(m_finalizer_array.m_head, o.m_finalizer_array.m_head);
 }
 
 template <typename T>

--- a/erb/v1/cpp03_zone.hpp.erb
+++ b/erb/v1/cpp03_zone.hpp.erb
@@ -29,120 +29,100 @@ MSGPACK_API_VERSION_NAMESPACE(v1) {
 
 class zone {
     struct finalizer {
-        finalizer(void (*func)(void*), void* data):m_func(func), m_data(data) {}
+        finalizer(void (*func)(void*), void* data, finalizer* next): m_func(func), m_data(data), m_next(next) {}
         void operator()() { m_func(m_data); }
         void (*m_func)(void*);
         void* m_data;
+        finalizer* m_next;
     };
+
     struct finalizer_array {
-        finalizer_array():m_tail(MSGPACK_NULLPTR), m_end(MSGPACK_NULLPTR), m_array(MSGPACK_NULLPTR) {}
-        void call() {
-            finalizer* fin = m_tail;
-            for(; fin != m_array; --fin) (*(fin-1))();
-        }
+        finalizer_array(): m_head(MSGPACK_NULLPTR) {}
+
         ~finalizer_array() {
-            call();
-            ::free(m_array);
+            clear();
         }
+
         void clear() {
-            call();
-            m_tail = m_array;
-        }
-        void push(void (*func)(void* data), void* data)
-        {
-            finalizer* fin = m_tail;
-
-            if(fin == m_end) {
-                push_expand(func, data);
-                return;
+            finalizer* fin = m_head;
+            finalizer* tmp = nullptr;
+            while(fin) {
+                (*fin)();
+                tmp = fin;
+                fin = fin->m_next;
+                delete tmp;
             }
-
-            fin->m_func = func;
-            fin->m_data = data;
-
-            ++m_tail;
+            m_head = MSGPACK_NULLPTR;
         }
-        void push_expand(void (*func)(void*), void* data) {
-            const size_t nused = static_cast<size_t>(m_end - m_array);
-            size_t nnext;
-            if(nused == 0) {
-                nnext = (sizeof(finalizer) < 72/2) ?
-                    72 / sizeof(finalizer) : 8;
-            } else {
-                nnext = nused * 2;
-            }
-            finalizer* tmp =
-                static_cast<finalizer*>(::realloc(m_array, sizeof(finalizer) * nnext));
-            if(!tmp) {
-                throw std::bad_alloc();
-            }
-            m_array     = tmp;
-            m_end   = tmp + nnext;
-            m_tail  = tmp + nused;
-            new (m_tail) finalizer(func, data);
 
-            ++m_tail;
+        void push(void (*func)(void* data), void* data) {
+            m_head = new finalizer(func, data, m_head);
         }
-        finalizer* m_tail;
-        finalizer* m_end;
-        finalizer* m_array;
+
+        void pop() {
+            auto n = m_head->m_next;
+            delete m_head;
+            m_head = n;
+        }
+
+        finalizer* m_head;
+    private:
+        finalizer_array(const finalizer_array&);
+        finalizer_array& operator=(const finalizer_array&);
     };
+
     struct chunk {
         chunk* m_next;
     };
-    struct chunk_list {
-        chunk_list(size_t chunk_size)
-        {
-            chunk* c = static_cast<chunk*>(::malloc(sizeof(chunk) + chunk_size));
-            if(!c) {
-                throw std::bad_alloc();
-            }
 
-            m_head = c;
-            m_free = chunk_size;
-            m_ptr  = reinterpret_cast<char*>(c) + sizeof(chunk);
-            c->m_next = MSGPACK_NULLPTR;
-        }
-        ~chunk_list()
-        {
+    struct chunk_list {
+        chunk_list(size_t chunk_size, char* ptr): m_free(chunk_size), m_ptr(ptr), m_head(MSGPACK_NULLPTR) {}
+        ~chunk_list() {
             chunk* c = m_head;
             while(c) {
                 chunk* n = c->m_next;
                 ::free(c);
                 c = n;
             }
+            m_head = MSGPACK_NULLPTR;
         }
-        void clear(size_t chunk_size)
-        {
+
+        void clear(size_t chunk_size, char* ptr) {
             chunk* c = m_head;
-            while(true) {
+            while(c) {
                 chunk* n = c->m_next;
-                if(n) {
-                    ::free(c);
-                    c = n;
-                } else {
-                    m_head = c;
-                    break;
-                }
+                ::free(c);
+                c = n;
             }
-            m_head->m_next = MSGPACK_NULLPTR;
+            m_head = MSGPACK_NULLPTR;
             m_free = chunk_size;
-            m_ptr  = reinterpret_cast<char*>(m_head) + sizeof(chunk);
+            m_ptr  = ptr;
         }
+
         size_t m_free;
         char* m_ptr;
         chunk* m_head;
+
+    private:
+        chunk_list(const chunk_list&);
+        chunk_list& operator=(const chunk_list&);
     };
+
     size_t m_chunk_size;
-    chunk_list m_chunk_list;
+    chunk_list* m_chunk_list;
     finalizer_array m_finalizer_array;
 
 public:
     zone(size_t chunk_size = MSGPACK_ZONE_CHUNK_SIZE);
+    ~zone();
 
-public:
     void* allocate_align(size_t size, size_t align = MSGPACK_ZONE_ALIGN);
+
     void* allocate_no_align(size_t size);
+
+    bool allocated() { 
+        return m_chunk_list != MSGPACK_NULLPTR; 
+    }
 
     void push_finalizer(void (*func)(void*), void* data);
 
@@ -152,24 +132,23 @@ public:
     void clear();
 
     void swap(zone& o);
-    static void* operator new(std::size_t size)
-    {
+
+    static void* operator new(std::size_t size) {
         void* p = ::malloc(size);
         if (!p) throw std::bad_alloc();
         return p;
     }
-    static void operator delete(void *p) /* throw() */
-    {
+
+    static void operator delete(void *p) /* throw() */ {
         ::free(p);
     }
-    static void* operator new(std::size_t size, void* place) /* throw() */
-    {
-        return ::operator new(size, place);
+
+    static void* operator new(std::size_t /*size*/, void* mem) /* throw() */ {
+        return mem;
     }
-    static void operator delete(void* p, void* place) /* throw() */
-    {
-        ::operator delete(p, place);
-    }
+
+    static void operator delete(void * /*p*/, void* /*mem*/) /* throw() */ {}
+
     /// @cond
     <%0.upto(GENERATION_LIMIT) {|i|%>
     template <typename T<%1.upto(i) {|j|%>, typename A<%=j%><%}%>>
@@ -188,18 +167,26 @@ private:
 
     static char* get_aligned(char* ptr, size_t align);
 
+    chunk_list& get_chank_lst();
+
     char* allocate_expand(size_t size);
 private:
     zone(const zone&);
     zone& operator=(const zone&);
 };
 
-inline zone::zone(size_t chunk_size):m_chunk_size(chunk_size), m_chunk_list(m_chunk_size)
-{
+inline zone::zone(size_t chunk_size):m_chunk_size(chunk_size), m_chunk_list(MSGPACK_NULLPTR) {}
+
+inline zone::~zone() {
+    m_finalizer_array.~finalizer_array();
+    if(m_chunk_list) {
+        m_chunk_list->~chunk_list();
+        ::free(m_chunk_list);
+        m_chunk_list = MSGPACK_NULLPTR;
+    }
 }
 
-inline char* zone::get_aligned(char* ptr, size_t align)
-{
+inline char* zone::get_aligned(char* ptr, size_t align) {
     MSGPACK_ASSERT(align != 0 && (align & (align - 1)) == 0); // align must be 2^n (n >= 0)
     return
         reinterpret_cast<char*>(
@@ -207,37 +194,45 @@ inline char* zone::get_aligned(char* ptr, size_t align)
         );
 }
 
-inline void* zone::allocate_align(size_t size, size_t align)
-{
-    char* aligned = get_aligned(m_chunk_list.m_ptr, align);
-    size_t adjusted_size = size + static_cast<size_t>(aligned - m_chunk_list.m_ptr);
-    if (m_chunk_list.m_free < adjusted_size) {
+inline zone::chunk_list& zone::get_chank_lst() {
+    if (!m_chunk_list) {
+        auto ptr = ::malloc(sizeof(chunk_list) + m_chunk_size);
+        if (!ptr)
+            throw std::bad_alloc();
+        m_chunk_list = new (ptr) chunk_list(m_chunk_size, reinterpret_cast<char*>(ptr) + sizeof(chunk_list));
+    }
+    return *m_chunk_list;
+}
+
+inline void* zone::allocate_align(size_t size, size_t align) {
+    chunk_list& chank_lst = get_chank_lst();
+    char* aligned = get_aligned(chank_lst.m_ptr, align);
+    size_t adjusted_size = size + static_cast<size_t>(aligned - chank_lst.m_ptr);
+    if (chank_lst.m_free < adjusted_size) {
         size_t enough_size = size + align - 1;
         char* ptr = allocate_expand(enough_size);
         aligned = get_aligned(ptr, align);
-        adjusted_size = size + static_cast<size_t>(aligned - m_chunk_list.m_ptr);
+        adjusted_size = size + static_cast<size_t>(aligned - chank_lst.m_ptr);
     }
-    m_chunk_list.m_free -= adjusted_size;
-    m_chunk_list.m_ptr  += adjusted_size;
+    chank_lst.m_free -= adjusted_size;
+    chank_lst.m_ptr += adjusted_size;
     return aligned;
 }
 
-inline void* zone::allocate_no_align(size_t size)
-{
-    char* ptr = m_chunk_list.m_ptr;
-    if(m_chunk_list.m_free < size) {
+inline void* zone::allocate_no_align(size_t size) {
+    chunk_list& chank_lst = get_chank_lst();
+    char* ptr = chank_lst.m_ptr;
+    if(chank_lst.m_free < size) {
         ptr = allocate_expand(size);
     }
-    m_chunk_list.m_free -= size;
-    m_chunk_list.m_ptr  += size;
+    chank_lst.m_free -= size;
+    chank_lst.m_ptr  += size;
 
     return ptr;
 }
 
-inline char* zone::allocate_expand(size_t size)
-{
-    chunk_list* const cl = &m_chunk_list;
-
+inline char* zone::allocate_expand(size_t size) {
+    chunk_list& cl = get_chank_lst();
     size_t sz = m_chunk_size;
 
     while(sz < size) {
@@ -254,33 +249,31 @@ inline char* zone::allocate_expand(size_t size)
 
     char* ptr = reinterpret_cast<char*>(c) + sizeof(chunk);
 
-    c->m_next  = cl->m_head;
-    cl->m_head = c;
-    cl->m_free = sz;
-    cl->m_ptr  = ptr;
+    c->m_next = cl.m_head;
+    cl.m_head = c;
+    cl.m_free = sz;
+    cl.m_ptr  = ptr;
 
     return ptr;
 }
 
-inline void zone::push_finalizer(void (*func)(void*), void* data)
-{
+inline void zone::push_finalizer(void (*func)(void*), void* data) {
     m_finalizer_array.push(func, data);
 }
 
 template <typename T>
-inline void zone::push_finalizer(msgpack::unique_ptr<T> obj)
-{
+inline void zone::push_finalizer(msgpack::unique_ptr<T> obj) {
     m_finalizer_array.push(&zone::object_delete<T>, obj.release());
 }
 
-inline void zone::clear()
-{
+inline void zone::clear() {
     m_finalizer_array.clear();
-    m_chunk_list.clear(m_chunk_size);
+    if (m_chunk_list) {
+        m_chunk_list->clear(m_chunk_size, reinterpret_cast<char*>(m_chunk_list) + sizeof(chunk_list));
+    }
 }
 
-inline void zone::swap(zone& o)
-{
+inline void zone::swap(zone& o) {
     using std::swap;
     swap(m_chunk_size, o.m_chunk_size);
     swap(m_chunk_list, o.m_chunk_list);
@@ -288,26 +281,22 @@ inline void zone::swap(zone& o)
 }
 
 template <typename T>
-void zone::object_destruct(void* obj)
-{
-    static_cast<T*>(obj)->~T();
-}
-
-template <typename T>
-void zone::object_delete(void* obj)
-{
+void zone::object_delete(void* obj) {
     delete static_cast<T*>(obj);
 }
 
-inline void zone::undo_allocate(size_t size)
-{
-    m_chunk_list.m_ptr  -= size;
-    m_chunk_list.m_free += size;
+template <typename T>
+void zone::object_destruct(void* obj) {
+    static_cast<T*>(obj)->~T();
 }
 
-inline std::size_t aligned_size(
-    std::size_t size,
-    std::size_t align) {
+inline void zone::undo_allocate(size_t size) {
+    chunk_list& cl = get_chank_lst();
+    cl.m_ptr  -= size;
+    cl.m_free += size;
+}
+
+inline std::size_t aligned_size(std::size_t size, std::size_t align) {
     return (size + align - 1) / align * align;
 }
 
@@ -326,7 +315,7 @@ T* zone::allocate(<%=(1..i).map{|j|"A#{j} a#{j}"}.join(', ')%>)
     try {
         return new (x) T(<%=(1..i).map{|j|"a#{j}"}.join(', ')%>);
     } catch (...) {
-        --m_finalizer_array.m_tail;
+        m_finalizer_array.pop();
         undo_allocate(sizeof(T));
         throw;
     }

--- a/include/msgpack/v1/detail/cpp03_zone.hpp
+++ b/include/msgpack/v1/detail/cpp03_zone.hpp
@@ -60,7 +60,7 @@ class zone {
         }
 
         void pop() {
-            auto n = m_head->m_next;
+            finalizer* n = m_head->m_next;
             delete m_head;
             m_head = n;
         }
@@ -241,7 +241,7 @@ inline char* zone::get_aligned(char* ptr, size_t align) {
 
 inline zone::chunk_list& zone::get_chank_lst() {
     if (!m_chunk_list) {
-        auto ptr = ::malloc(sizeof(chunk_list) + m_chunk_size);
+        void* ptr = ::malloc(sizeof(chunk_list) + m_chunk_size);
         if (!ptr)
             throw std::bad_alloc();
         m_chunk_list = new (ptr) chunk_list(m_chunk_size, reinterpret_cast<char*>(ptr) + sizeof(chunk_list));
@@ -322,7 +322,7 @@ inline void zone::swap(zone& o) {
     using std::swap;
     swap(m_chunk_size, o.m_chunk_size);
     swap(m_chunk_list, o.m_chunk_list);
-    swap(m_finalizer_array, o.m_finalizer_array);
+    swap(m_finalizer_array.m_head, o.m_finalizer_array.m_head);
 }
 
 template <typename T>

--- a/include/msgpack/v1/detail/cpp03_zone.hpp
+++ b/include/msgpack/v1/detail/cpp03_zone.hpp
@@ -29,120 +29,100 @@ MSGPACK_API_VERSION_NAMESPACE(v1) {
 
 class zone {
     struct finalizer {
-        finalizer(void (*func)(void*), void* data):m_func(func), m_data(data) {}
+        finalizer(void (*func)(void*), void* data, finalizer* next): m_func(func), m_data(data), m_next(next) {}
         void operator()() { m_func(m_data); }
         void (*m_func)(void*);
         void* m_data;
+        finalizer* m_next;
     };
+
     struct finalizer_array {
-        finalizer_array():m_tail(MSGPACK_NULLPTR), m_end(MSGPACK_NULLPTR), m_array(MSGPACK_NULLPTR) {}
-        void call() {
-            finalizer* fin = m_tail;
-            for(; fin != m_array; --fin) (*(fin-1))();
-        }
+        finalizer_array(): m_head(MSGPACK_NULLPTR) {}
+
         ~finalizer_array() {
-            call();
-            ::free(m_array);
+            clear();
         }
+
         void clear() {
-            call();
-            m_tail = m_array;
-        }
-        void push(void (*func)(void* data), void* data)
-        {
-            finalizer* fin = m_tail;
-
-            if(fin == m_end) {
-                push_expand(func, data);
-                return;
+            finalizer* fin = m_head;
+            finalizer* tmp = nullptr;
+            while(fin) {
+                (*fin)();
+                tmp = fin;
+                fin = fin->m_next;
+                delete tmp;
             }
-
-            fin->m_func = func;
-            fin->m_data = data;
-
-            ++m_tail;
+            m_head = MSGPACK_NULLPTR;
         }
-        void push_expand(void (*func)(void*), void* data) {
-            const size_t nused = static_cast<size_t>(m_end - m_array);
-            size_t nnext;
-            if(nused == 0) {
-                nnext = (sizeof(finalizer) < 72/2) ?
-                    72 / sizeof(finalizer) : 8;
-            } else {
-                nnext = nused * 2;
-            }
-            finalizer* tmp =
-                static_cast<finalizer*>(::realloc(m_array, sizeof(finalizer) * nnext));
-            if(!tmp) {
-                throw std::bad_alloc();
-            }
-            m_array     = tmp;
-            m_end   = tmp + nnext;
-            m_tail  = tmp + nused;
-            new (m_tail) finalizer(func, data);
 
-            ++m_tail;
+        void push(void (*func)(void* data), void* data) {
+            m_head = new finalizer(func, data, m_head);
         }
-        finalizer* m_tail;
-        finalizer* m_end;
-        finalizer* m_array;
+
+        void pop() {
+            auto n = m_head->m_next;
+            delete m_head;
+            m_head = n;
+        }
+
+        finalizer* m_head;
+    private:
+        finalizer_array(const finalizer_array&);
+        finalizer_array& operator=(const finalizer_array&);
     };
+
     struct chunk {
         chunk* m_next;
     };
-    struct chunk_list {
-        chunk_list(size_t chunk_size)
-        {
-            chunk* c = static_cast<chunk*>(::malloc(sizeof(chunk) + chunk_size));
-            if(!c) {
-                throw std::bad_alloc();
-            }
 
-            m_head = c;
-            m_free = chunk_size;
-            m_ptr  = reinterpret_cast<char*>(c) + sizeof(chunk);
-            c->m_next = MSGPACK_NULLPTR;
-        }
-        ~chunk_list()
-        {
+    struct chunk_list {
+        chunk_list(size_t chunk_size, char* ptr): m_free(chunk_size), m_ptr(ptr), m_head(MSGPACK_NULLPTR) {}
+        ~chunk_list() {
             chunk* c = m_head;
             while(c) {
                 chunk* n = c->m_next;
                 ::free(c);
                 c = n;
             }
+            m_head = MSGPACK_NULLPTR;
         }
-        void clear(size_t chunk_size)
-        {
+
+        void clear(size_t chunk_size, char* ptr) {
             chunk* c = m_head;
-            while(true) {
+            while(c) {
                 chunk* n = c->m_next;
-                if(n) {
-                    ::free(c);
-                    c = n;
-                } else {
-                    m_head = c;
-                    break;
-                }
+                ::free(c);
+                c = n;
             }
-            m_head->m_next = MSGPACK_NULLPTR;
+            m_head = MSGPACK_NULLPTR;
             m_free = chunk_size;
-            m_ptr  = reinterpret_cast<char*>(m_head) + sizeof(chunk);
+            m_ptr  = ptr;
         }
+
         size_t m_free;
         char* m_ptr;
         chunk* m_head;
+
+    private:
+        chunk_list(const chunk_list&);
+        chunk_list& operator=(const chunk_list&);
     };
+
     size_t m_chunk_size;
-    chunk_list m_chunk_list;
+    chunk_list* m_chunk_list;
     finalizer_array m_finalizer_array;
 
 public:
     zone(size_t chunk_size = MSGPACK_ZONE_CHUNK_SIZE);
+    ~zone();
 
-public:
     void* allocate_align(size_t size, size_t align = MSGPACK_ZONE_ALIGN);
+
     void* allocate_no_align(size_t size);
+
+    bool allocated() { 
+        return m_chunk_list != MSGPACK_NULLPTR; 
+    }
 
     void push_finalizer(void (*func)(void*), void* data);
 
@@ -152,24 +132,23 @@ public:
     void clear();
 
     void swap(zone& o);
-    static void* operator new(std::size_t size)
-    {
+
+    static void* operator new(std::size_t size) {
         void* p = ::malloc(size);
         if (!p) throw std::bad_alloc();
         return p;
     }
-    static void operator delete(void *p) /* throw() */
-    {
+
+    static void operator delete(void *p) /* throw() */ {
         ::free(p);
     }
-    static void* operator new(std::size_t size, void* place) /* throw() */
-    {
-        return ::operator new(size, place);
+
+    static void* operator new(std::size_t /*size*/, void* mem) /* throw() */ {
+        return mem;
     }
-    static void operator delete(void* p, void* place) /* throw() */
-    {
-        ::operator delete(p, place);
-    }
+
+    static void operator delete(void * /*p*/, void* /*mem*/) /* throw() */ {}
+
     /// @cond
     
     template <typename T>
@@ -233,18 +212,26 @@ private:
 
     static char* get_aligned(char* ptr, size_t align);
 
+    chunk_list& get_chank_lst();
+
     char* allocate_expand(size_t size);
 private:
     zone(const zone&);
     zone& operator=(const zone&);
 };
 
-inline zone::zone(size_t chunk_size):m_chunk_size(chunk_size), m_chunk_list(m_chunk_size)
-{
+inline zone::zone(size_t chunk_size):m_chunk_size(chunk_size), m_chunk_list(MSGPACK_NULLPTR) {}
+
+inline zone::~zone() {
+    m_finalizer_array.~finalizer_array();
+    if(m_chunk_list) {
+        m_chunk_list->~chunk_list();
+        ::free(m_chunk_list);
+        m_chunk_list = MSGPACK_NULLPTR;
+    }
 }
 
-inline char* zone::get_aligned(char* ptr, size_t align)
-{
+inline char* zone::get_aligned(char* ptr, size_t align) {
     MSGPACK_ASSERT(align != 0 && (align & (align - 1)) == 0); // align must be 2^n (n >= 0)
     return
         reinterpret_cast<char*>(
@@ -252,37 +239,45 @@ inline char* zone::get_aligned(char* ptr, size_t align)
         );
 }
 
-inline void* zone::allocate_align(size_t size, size_t align)
-{
-    char* aligned = get_aligned(m_chunk_list.m_ptr, align);
-    size_t adjusted_size = size + static_cast<size_t>(aligned - m_chunk_list.m_ptr);
-    if (m_chunk_list.m_free < adjusted_size) {
+inline zone::chunk_list& zone::get_chank_lst() {
+    if (!m_chunk_list) {
+        auto ptr = ::malloc(sizeof(chunk_list) + m_chunk_size);
+        if (!ptr)
+            throw std::bad_alloc();
+        m_chunk_list = new (ptr) chunk_list(m_chunk_size, reinterpret_cast<char*>(ptr) + sizeof(chunk_list));
+    }
+    return *m_chunk_list;
+}
+
+inline void* zone::allocate_align(size_t size, size_t align) {
+    chunk_list& chank_lst = get_chank_lst();
+    char* aligned = get_aligned(chank_lst.m_ptr, align);
+    size_t adjusted_size = size + static_cast<size_t>(aligned - chank_lst.m_ptr);
+    if (chank_lst.m_free < adjusted_size) {
         size_t enough_size = size + align - 1;
         char* ptr = allocate_expand(enough_size);
         aligned = get_aligned(ptr, align);
-        adjusted_size = size + static_cast<size_t>(aligned - m_chunk_list.m_ptr);
+        adjusted_size = size + static_cast<size_t>(aligned - chank_lst.m_ptr);
     }
-    m_chunk_list.m_free -= adjusted_size;
-    m_chunk_list.m_ptr  += adjusted_size;
+    chank_lst.m_free -= adjusted_size;
+    chank_lst.m_ptr += adjusted_size;
     return aligned;
 }
 
-inline void* zone::allocate_no_align(size_t size)
-{
-    char* ptr = m_chunk_list.m_ptr;
-    if(m_chunk_list.m_free < size) {
+inline void* zone::allocate_no_align(size_t size) {
+    chunk_list& chank_lst = get_chank_lst();
+    char* ptr = chank_lst.m_ptr;
+    if(chank_lst.m_free < size) {
         ptr = allocate_expand(size);
     }
-    m_chunk_list.m_free -= size;
-    m_chunk_list.m_ptr  += size;
+    chank_lst.m_free -= size;
+    chank_lst.m_ptr  += size;
 
     return ptr;
 }
 
-inline char* zone::allocate_expand(size_t size)
-{
-    chunk_list* const cl = &m_chunk_list;
-
+inline char* zone::allocate_expand(size_t size) {
+    chunk_list& cl = get_chank_lst();
     size_t sz = m_chunk_size;
 
     while(sz < size) {
@@ -299,33 +294,31 @@ inline char* zone::allocate_expand(size_t size)
 
     char* ptr = reinterpret_cast<char*>(c) + sizeof(chunk);
 
-    c->m_next  = cl->m_head;
-    cl->m_head = c;
-    cl->m_free = sz;
-    cl->m_ptr  = ptr;
+    c->m_next = cl.m_head;
+    cl.m_head = c;
+    cl.m_free = sz;
+    cl.m_ptr  = ptr;
 
     return ptr;
 }
 
-inline void zone::push_finalizer(void (*func)(void*), void* data)
-{
+inline void zone::push_finalizer(void (*func)(void*), void* data) {
     m_finalizer_array.push(func, data);
 }
 
 template <typename T>
-inline void zone::push_finalizer(msgpack::unique_ptr<T> obj)
-{
+inline void zone::push_finalizer(msgpack::unique_ptr<T> obj) {
     m_finalizer_array.push(&zone::object_delete<T>, obj.release());
 }
 
-inline void zone::clear()
-{
+inline void zone::clear() {
     m_finalizer_array.clear();
-    m_chunk_list.clear(m_chunk_size);
+    if (m_chunk_list) {
+        m_chunk_list->clear(m_chunk_size, reinterpret_cast<char*>(m_chunk_list) + sizeof(chunk_list));
+    }
 }
 
-inline void zone::swap(zone& o)
-{
+inline void zone::swap(zone& o) {
     using std::swap;
     swap(m_chunk_size, o.m_chunk_size);
     swap(m_chunk_list, o.m_chunk_list);
@@ -333,26 +326,22 @@ inline void zone::swap(zone& o)
 }
 
 template <typename T>
-void zone::object_destruct(void* obj)
-{
-    static_cast<T*>(obj)->~T();
-}
-
-template <typename T>
-void zone::object_delete(void* obj)
-{
+void zone::object_delete(void* obj) {
     delete static_cast<T*>(obj);
 }
 
-inline void zone::undo_allocate(size_t size)
-{
-    m_chunk_list.m_ptr  -= size;
-    m_chunk_list.m_free += size;
+template <typename T>
+void zone::object_destruct(void* obj) {
+    static_cast<T*>(obj)->~T();
 }
 
-inline std::size_t aligned_size(
-    std::size_t size,
-    std::size_t align) {
+inline void zone::undo_allocate(size_t size) {
+    chunk_list& cl = get_chank_lst();
+    cl.m_ptr  -= size;
+    cl.m_free += size;
+}
+
+inline std::size_t aligned_size(std::size_t size, std::size_t align) {
     return (size + align - 1) / align * align;
 }
 
@@ -371,7 +360,7 @@ T* zone::allocate()
     try {
         return new (x) T();
     } catch (...) {
-        --m_finalizer_array.m_tail;
+        m_finalizer_array.pop();
         undo_allocate(sizeof(T));
         throw;
     }
@@ -390,7 +379,7 @@ T* zone::allocate(A1 a1)
     try {
         return new (x) T(a1);
     } catch (...) {
-        --m_finalizer_array.m_tail;
+        m_finalizer_array.pop();
         undo_allocate(sizeof(T));
         throw;
     }
@@ -409,7 +398,7 @@ T* zone::allocate(A1 a1, A2 a2)
     try {
         return new (x) T(a1, a2);
     } catch (...) {
-        --m_finalizer_array.m_tail;
+        m_finalizer_array.pop();
         undo_allocate(sizeof(T));
         throw;
     }
@@ -428,7 +417,7 @@ T* zone::allocate(A1 a1, A2 a2, A3 a3)
     try {
         return new (x) T(a1, a2, a3);
     } catch (...) {
-        --m_finalizer_array.m_tail;
+        m_finalizer_array.pop();
         undo_allocate(sizeof(T));
         throw;
     }
@@ -447,7 +436,7 @@ T* zone::allocate(A1 a1, A2 a2, A3 a3, A4 a4)
     try {
         return new (x) T(a1, a2, a3, a4);
     } catch (...) {
-        --m_finalizer_array.m_tail;
+        m_finalizer_array.pop();
         undo_allocate(sizeof(T));
         throw;
     }
@@ -466,7 +455,7 @@ T* zone::allocate(A1 a1, A2 a2, A3 a3, A4 a4, A5 a5)
     try {
         return new (x) T(a1, a2, a3, a4, a5);
     } catch (...) {
-        --m_finalizer_array.m_tail;
+        m_finalizer_array.pop();
         undo_allocate(sizeof(T));
         throw;
     }
@@ -485,7 +474,7 @@ T* zone::allocate(A1 a1, A2 a2, A3 a3, A4 a4, A5 a5, A6 a6)
     try {
         return new (x) T(a1, a2, a3, a4, a5, a6);
     } catch (...) {
-        --m_finalizer_array.m_tail;
+        m_finalizer_array.pop();
         undo_allocate(sizeof(T));
         throw;
     }
@@ -504,7 +493,7 @@ T* zone::allocate(A1 a1, A2 a2, A3 a3, A4 a4, A5 a5, A6 a6, A7 a7)
     try {
         return new (x) T(a1, a2, a3, a4, a5, a6, a7);
     } catch (...) {
-        --m_finalizer_array.m_tail;
+        m_finalizer_array.pop();
         undo_allocate(sizeof(T));
         throw;
     }
@@ -523,7 +512,7 @@ T* zone::allocate(A1 a1, A2 a2, A3 a3, A4 a4, A5 a5, A6 a6, A7 a7, A8 a8)
     try {
         return new (x) T(a1, a2, a3, a4, a5, a6, a7, a8);
     } catch (...) {
-        --m_finalizer_array.m_tail;
+        m_finalizer_array.pop();
         undo_allocate(sizeof(T));
         throw;
     }
@@ -542,7 +531,7 @@ T* zone::allocate(A1 a1, A2 a2, A3 a3, A4 a4, A5 a5, A6 a6, A7 a7, A8 a8, A9 a9)
     try {
         return new (x) T(a1, a2, a3, a4, a5, a6, a7, a8, a9);
     } catch (...) {
-        --m_finalizer_array.m_tail;
+        m_finalizer_array.pop();
         undo_allocate(sizeof(T));
         throw;
     }
@@ -561,7 +550,7 @@ T* zone::allocate(A1 a1, A2 a2, A3 a3, A4 a4, A5 a5, A6 a6, A7 a7, A8 a8, A9 a9,
     try {
         return new (x) T(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10);
     } catch (...) {
-        --m_finalizer_array.m_tail;
+        m_finalizer_array.pop();
         undo_allocate(sizeof(T));
         throw;
     }
@@ -580,7 +569,7 @@ T* zone::allocate(A1 a1, A2 a2, A3 a3, A4 a4, A5 a5, A6 a6, A7 a7, A8 a8, A9 a9,
     try {
         return new (x) T(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11);
     } catch (...) {
-        --m_finalizer_array.m_tail;
+        m_finalizer_array.pop();
         undo_allocate(sizeof(T));
         throw;
     }
@@ -599,7 +588,7 @@ T* zone::allocate(A1 a1, A2 a2, A3 a3, A4 a4, A5 a5, A6 a6, A7 a7, A8 a8, A9 a9,
     try {
         return new (x) T(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12);
     } catch (...) {
-        --m_finalizer_array.m_tail;
+        m_finalizer_array.pop();
         undo_allocate(sizeof(T));
         throw;
     }
@@ -618,7 +607,7 @@ T* zone::allocate(A1 a1, A2 a2, A3 a3, A4 a4, A5 a5, A6 a6, A7 a7, A8 a8, A9 a9,
     try {
         return new (x) T(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13);
     } catch (...) {
-        --m_finalizer_array.m_tail;
+        m_finalizer_array.pop();
         undo_allocate(sizeof(T));
         throw;
     }
@@ -637,7 +626,7 @@ T* zone::allocate(A1 a1, A2 a2, A3 a3, A4 a4, A5 a5, A6 a6, A7 a7, A8 a8, A9 a9,
     try {
         return new (x) T(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14);
     } catch (...) {
-        --m_finalizer_array.m_tail;
+        m_finalizer_array.pop();
         undo_allocate(sizeof(T));
         throw;
     }
@@ -656,7 +645,7 @@ T* zone::allocate(A1 a1, A2 a2, A3 a3, A4 a4, A5 a5, A6 a6, A7 a7, A8 a8, A9 a9,
     try {
         return new (x) T(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15);
     } catch (...) {
-        --m_finalizer_array.m_tail;
+        m_finalizer_array.pop();
         undo_allocate(sizeof(T));
         throw;
     }

--- a/include/msgpack/v1/detail/cpp03_zone.hpp
+++ b/include/msgpack/v1/detail/cpp03_zone.hpp
@@ -45,7 +45,7 @@ class zone {
 
         void clear() {
             finalizer* fin = m_head;
-            finalizer* tmp = nullptr;
+            finalizer* tmp = MSGPACK_NULLPTR;
             while(fin) {
                 (*fin)();
                 tmp = fin;

--- a/include/msgpack/v1/detail/cpp11_zone.hpp
+++ b/include/msgpack/v1/detail/cpp11_zone.hpp
@@ -78,9 +78,9 @@ private:
             other.m_head = MSGPACK_NULLPTR;
             return *this;
         }
-        finalizer* m_head;
 
     private:
+        finalizer* m_head;
         finalizer_array(const finalizer_array&);
         finalizer_array& operator=(const finalizer_array&);
     };
@@ -106,7 +106,7 @@ private:
                 ::free(c);
                 c = n;
             }
-            m_head->m_next = MSGPACK_NULLPTR;
+            m_head = MSGPACK_NULLPTR;
             m_free = chunk_size;
             m_ptr  = ptr;
         }

--- a/include/msgpack/v1/detail/cpp11_zone.hpp
+++ b/include/msgpack/v1/detail/cpp11_zone.hpp
@@ -45,7 +45,7 @@ private:
 
         void clear() {
             finalizer* fin = m_head;
-            finalizer* tmp = nullptr;
+            finalizer* tmp = MSGPACK_NULLPTR;
             while(fin) {
                 (*fin)();
                 tmp = fin;

--- a/process.rb
+++ b/process.rb
@@ -1,0 +1,17 @@
+require 'erb'
+
+files = {
+    "erb/v1/cpp03_msgpack_tuple_decl.hpp" => "include/msgpack/v1/adaptor/detail/cpp03_msgpack_tuple_decl.hpp",
+    "erb/v1/cpp03_msgpack_tuple.hpp" => "include/msgpack/v1/adaptor/detail/cpp03_msgpack_tuple.hpp",
+    "erb/v1/cpp03_define_array_decl.hpp" => "include/msgpack/v1/adaptor/detail/cpp03_define_array_decl.hpp",
+    "erb/v1/cpp03_define_array.hpp" => "include/msgpack/v1/adaptor/detail/cpp03_define_array.hpp",
+    "erb/v1/cpp03_define_map_decl.hpp" => "include/msgpack/v1/adaptor/detail/cpp03_define_map_decl.hpp",
+    "erb/v1/cpp03_define_map.hpp" => "include/msgpack/v1/adaptor/detail/cpp03_define_map.hpp",
+    "erb/v1/cpp03_zone_decl.hpp" => "include/msgpack/v1/detail/cpp03_zone_decl.hpp",
+    "erb/v1/cpp03_zone.hpp" => "include/msgpack/v1/detail/cpp03_zone.hpp"
+}
+
+files.map { |erb, hpp|
+    res = ERB.new(File.open(erb+".erb").read).result
+    File.write(hpp, res)
+}


### PR DESCRIPTION
Reduced zone size from 54 to 24 bytes for x64 and added delayed allocation of the first chunk as needed.
In case when there are a lot of non-large objects that require serialization in msgpack::objects it is very expensive to allocate memory just to create a zone to use the adapter
``` cpp
template<>
struct msgpack::adaptor::object_with_zone<T> {
    void operator()(msgpack::object::with_zone& o, T v) const {
        o << v;
    }
};
```