### PR TITLE
Use GNUInstallDirs to set installation directories

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,10 +27,11 @@ SET (VERSION_REVISION ${CMAKE_MATCH_1})
 SET (VERSION ${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_REVISION})
 
 LIST (APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake/")
+include(GNUInstallDirs)
 SET (prefix ${CMAKE_INSTALL_PREFIX})
-SET (exec_prefix "\${prefix}")
-SET (libdir "\${exec_prefix}/lib")
-SET (includedir "\${prefix}/include")
+SET (exec_prefix ${CMAKE_INSTALL_PREFIX})
+SET (libdir ${CMAKE_INSTALL_LIBDIR})
+SET (includedir ${CMAKE_INSTALL_INCLUDEDIR})
 
 OPTION (MSGPACK_32BIT "32bit compile" OFF)
 


### PR DESCRIPTION
Allow the user to override directories via typical options if necessary, otherwise use the GNU defaults.

Only change in behaviour is to install into `${prefix}/lib64` on systems where the [following conditions](https://gitlab.kitware.com/cmake/cmake/-/blob/v3.29.0-rc3/Modules/GNUInstallDirs.cmake?ref_type=tags#L231-236) are met.
```
  #  - we are on Linux system but NOT cross-compiling
  #  - we are NOT on debian
  #  - we are NOT building for conda
  #  - we are on a 64 bits system
```

Resolves #981