### PR TITLE
Add msgpack obj init for complex types

### DIFF
--- a/include/msgpack/object.h
+++ b/include/msgpack/object.h
@@ -97,6 +97,9 @@ typedef struct msgpack_object_kv {
     msgpack_object val;
 } msgpack_object_kv;
 
+MSGPACK_DLLEXPORT
+bool msgpack_object_init(msgpack_object* d, int type, void* data, size_t size);
+
 #if !defined(_KERNEL_MODE)
 MSGPACK_DLLEXPORT
 void msgpack_object_print(FILE* out, msgpack_object o);

--- a/src/objectc.c
+++ b/src/objectc.c
@@ -125,9 +125,8 @@ int msgpack_pack_object(msgpack_packer* pk, msgpack_object d)
     }
 }
 
-int msgpack_object_init(msgpack_object* d, void *data, size_t size, int type)
+bool msgpack_object_init(msgpack_object* d, int type, void* data, size_t size)
 {
-    d->type = type;
     switch (type) {
     case MSGPACK_OBJECT_STR:
         {
@@ -149,19 +148,18 @@ int msgpack_object_init(msgpack_object* d, void *data, size_t size, int type)
         }
     case MSGPACK_OBJECT_MAP:
         {
-            d->via.map.ptr = (msgpack_object_kv *) data;
+            d->via.map.ptr = (msgpack_object_kv *)data;
             d->via.map.size = size;
             break;
         }
     default:
         {
             // Other types are not supported and need to be initialized manually.
-            d->type = MSGPACK_OBJECT_NIL;
-            return -1;
+            return false;
         }
     }
-    return 0;
-
+    d->type = type;
+    return true;
 }
 
 #if !defined(_KERNEL_MODE)

--- a/src/objectc.c
+++ b/src/objectc.c
@@ -137,7 +137,6 @@ int msgpack_object_init(msgpack_object* d, void *data, size_t size, int type)
         }
     case MSGPACK_OBJECT_BIN:
         {
-            d->type = type;
             d->via.bin.ptr = (char *)data;
             d->via.bin.size = size;
             break;

--- a/src/objectc.c
+++ b/src/objectc.c
@@ -125,6 +125,46 @@ int msgpack_pack_object(msgpack_packer* pk, msgpack_object d)
     }
 }
 
+int msgpack_object_init(msgpack_object* d, void *data, size_t size, int type)
+{
+    d->type = type;
+    switch (type) {
+    case MSGPACK_OBJECT_STR:
+        {
+            d->via.str.ptr = (char *)data;
+            d->via.str.size = size;
+            break;
+        }
+    case MSGPACK_OBJECT_BIN:
+        {
+            d->type = type;
+            d->via.bin.ptr = (char *)data;
+            d->via.bin.size = size;
+            break;
+        }
+    case MSGPACK_OBJECT_ARRAY:
+        {
+            d->via.array.ptr = (msgpack_object *)data;
+            d->via.array.size = size;
+            break;
+        }
+    case MSGPACK_OBJECT_MAP:
+        {
+            d->via.map.ptr = (msgpack_object_kv *) data;
+            d->via.map.size = size;
+            break;
+        }
+    default:
+        {
+            // Other types are not supported and need to be initialized manually.
+            d->type = MSGPACK_OBJECT_NIL;
+            return -1;
+        }
+    }
+    return 0;
+
+}
+
 #if !defined(_KERNEL_MODE)
 
 static void msgpack_object_bin_print(FILE* out, const char *ptr, size_t size)

--- a/test/msgpack_c.cpp
+++ b/test/msgpack_c.cpp
@@ -1612,6 +1612,51 @@ TEST(MSGPACKC, object_bin_print_buffer_overflow) {
   EXPECT_STREQ("\"test\"", buffer);
 }
 
+TEST(MSGPACKC, init_msgpack_obj_string) {
+    msgpack_object obj;
+    char buffer[] = "test";
+    msgpack_object_init(&obj, MSGPACK_OBJECT_STR, (void *)buffer, strlen(buffer));
+    EXPECT_EQ(MSGPACK_OBJECT_STR, obj.type);
+    EXPECT_STREQ(buffer, obj.via.str.ptr);
+}
+
+TEST(MSGPACKC, init_msgpack_obj_bin) {
+    msgpack_object obj;
+    char buffer[] = "test";
+    msgpack_object_init(&obj, MSGPACK_OBJECT_BIN, (void *)buffer, strlen(buffer));
+    EXPECT_EQ(MSGPACK_OBJECT_BIN, obj.type);
+    EXPECT_STREQ(buffer, obj.via.bin.ptr);
+}
+
+TEST(MSGPACKC, init_msgpack_obj_array) {
+    msgpack_object obj;
+    char buffer[][7] = {"test_1", "test_2", "test_3", "test_4"};
+    size_t buffer_size = 4;
+    msgpack_object array[buffer_size];
+    for(size_t i = 0; i < buffer_size; i++) {
+        msgpack_object_init(&array[i], MSGPACK_OBJECT_STR, (void *)buffer[i], strlen(buffer[i]));
+    }
+    msgpack_object_init(&obj, MSGPACK_OBJECT_ARRAY, (void *)array, buffer_size);
+    EXPECT_EQ(MSGPACK_OBJECT_ARRAY, obj.type);
+    for(size_t i = 0; i < buffer_size; i++) {
+        EXPECT_STREQ(buffer[i], obj.via.array.ptr[i].via.str.ptr);
+    }
+}
+
+TEST(MSGPACKC, init_msgpack_obj_map) {
+    msgpack_object obj;
+    char key_str[] = "test_key";
+    char value_str[] = "test_value";
+    msgpack_object key,value;
+    msgpack_object_init(&key, MSGPACK_OBJECT_STR, (void *)key_str, strlen(key_str));
+    msgpack_object_init(&value, MSGPACK_OBJECT_STR, (void *)value_str, strlen(value_str));
+    msgpack_object_kv map = { key, value };
+    msgpack_object_init(&obj, MSGPACK_OBJECT_MAP, (void *)&map, 1);
+    EXPECT_EQ(MSGPACK_OBJECT_MAP, obj.type);
+    EXPECT_STREQ(key_str, obj.via.map.ptr->key.via.str.ptr);
+    EXPECT_STREQ(value_str, obj.via.map.ptr->val.via.str.ptr);
+}
+
 /* test for vrefbuffer */
 #define GEN_TEST_VREFBUFFER_PREPARE(...)                       \
     msgpack_vrefbuffer vbuf;                                   \


### PR DESCRIPTION
This PR addresses the feature request to initialise msgpack objects such as string, bin, array and map
Closes #1134 