### PR TITLE
Revert "Merge pull request #1018 from GeorgFritze/cpp_master"

### DIFF
--- a/include/msgpack/v1/pack.hpp
+++ b/include/msgpack/v1/pack.hpp
@@ -1138,17 +1138,6 @@ inline packer<Stream>& packer<Stream>::pack_unsigned_long_long(unsigned long lon
 template <typename Stream>
 inline packer<Stream>& packer<Stream>::pack_float(float d)
 {
-    if(d == d) { // check for nan
-        // compare d to limits to avoid undefined behaviour
-        if(d >= 0 && d <= float(std::numeric_limits<uint64_t>::max()) && d == float(uint64_t(d))) {
-            pack_imp_uint64(uint64_t(d));
-            return *this;
-        } else if(d < 0 && d >= float(std::numeric_limits<int64_t>::min()) && d == float(int64_t(d))) {
-            pack_imp_int64(int64_t(d));
-            return *this;
-        }
-    }
-
     union { float f; uint32_t i; } mem;
     mem.f = d;
     char buf[5];
@@ -1160,17 +1149,6 @@ inline packer<Stream>& packer<Stream>::pack_float(float d)
 template <typename Stream>
 inline packer<Stream>& packer<Stream>::pack_double(double d)
 {
-    if(d == d) { // check for nan
-        // compare d to limits to avoid undefined behaviour
-        if(d >= 0 && d <= double(std::numeric_limits<uint64_t>::max()) && d == double(uint64_t(d))) {
-            pack_imp_uint64(uint64_t(d));
-            return *this;
-        } else if(d < 0 && d >= double(std::numeric_limits<int64_t>::min()) && d == double(int64_t(d))) {
-            pack_imp_int64(int64_t(d));
-            return *this;
-        }
-    }
-
     union { double f; uint64_t i; } mem;
     mem.f = d;
     char buf[9];

--- a/test/msgpack_basic.cpp
+++ b/test/msgpack_basic.cpp
@@ -154,8 +154,6 @@ BOOST_AUTO_TEST_CASE(simple_buffer_float)
     v.push_back(-0.0);
     v.push_back(1.0);
     v.push_back(-1.0);
-    v.push_back(1.1f);
-    v.push_back(-1.1f);
     v.push_back(numeric_limits<float>::min());
     v.push_back(numeric_limits<float>::max());
     v.push_back(nanf("tag"));
@@ -188,12 +186,6 @@ BOOST_AUTO_TEST_CASE(simple_buffer_float)
             BOOST_CHECK(std::isinf(val2));
         else
             BOOST_CHECK(fabs(val2 - val1) <= kEPS);
-
-        // check for compact storing of float
-        if (val1 == val1 && val1 >= float(std::numeric_limits<int64_t>::min()) && val1 <= float(std::numeric_limits<int64_t>::max()) && val1 == float(int64_t(val1)))
-            BOOST_REQUIRE_EQUAL(sbuf.size(),1);
-        else
-            BOOST_REQUIRE_EQUAL(sbuf.data()[0],char(0xca));
     }
 }
 
@@ -244,8 +236,6 @@ BOOST_AUTO_TEST_CASE(simple_buffer_double)
     v.push_back(-0.0);
     v.push_back(1.0);
     v.push_back(-1.0);
-    v.push_back(1.1);
-    v.push_back(-1.1);
     v.push_back(numeric_limits<double>::min());
     v.push_back(numeric_limits<double>::max());
     v.push_back(nanf("tag"));
@@ -282,12 +272,6 @@ BOOST_AUTO_TEST_CASE(simple_buffer_double)
             BOOST_CHECK(std::isinf(val2));
         else
             BOOST_CHECK(fabs(val2 - val1) <= kEPS);
-
-        // check for compact storing of double
-        if (val1 == val1 && val1 >= double(std::numeric_limits<int64_t>::min()) && val1 <= double(std::numeric_limits<int64_t>::max()) && val1 == double(int64_t(val1)))
-            BOOST_REQUIRE_EQUAL(sbuf.size(),1);
-        else
-            BOOST_REQUIRE_EQUAL(uint8_t(sbuf.data()[0]),uint8_t(0xcb));
     }
 }
 


### PR DESCRIPTION
This reverts #1018, which introduces a "feature" to pack some floats as integers. I think this is a horrible idea for several reasons:

### 1. It is slow

msgpack should be small, but also fast. If I want to pack a large array of floats, I don't want that every single float is checked for NaN, or checked if it can possibility cast to an integer without precision loss (in total 4-7 checks for a single float).

### 2. It is unexpected

When I pack a float with `pack_float`, I also expect to unpack a float. For example, I pack a vector of floats somewhere and and want to unpack it to a vector of floats. I don't expect any other object than float in the msgpack array. Just looking at how often #1018 what referenced in other public projects on GitHub, this seemed to be an issue. It is even more unexpected when other msgpack implementations, such as Python, won't do this.

### 3. It is just bad design

When I code in C++ I want maximum speed, not 7 checks to save 3 bytes in maybe 0.1% of the cases. If I know I can get a large quantities of just zeros or integer-like values, I can implement zero-suppression or just cast it to an integer directly with my own logic.

If anything, a type change should _only_ be behind an option like `MSGPACK_COMPACT_FLOATS`, but I actually think that removing it is much better. If you prefer making this optional, even default, let me know, I will add it.
