### PR TITLE
Work around MSVC C++20 modules error for nested msgpack::object::with_zone

### DIFF
--- a/include/msgpack/v1/object.hpp
+++ b/include/msgpack/v1/object.hpp
@@ -32,11 +32,11 @@ struct object_kv {
     msgpack::object val;
 };
 
-struct object::with_zone : msgpack::object {
-    with_zone(msgpack::zone& z) : zone(z) { }
+struct object_with_zone_type : msgpack::object {
+    object_with_zone_type(msgpack::zone& z) : zone(z) { }
     msgpack::zone& zone;
 private:
-    with_zone();
+    object_with_zone_type();
 };
 
 

--- a/include/msgpack/v1/object_fwd.hpp
+++ b/include/msgpack/v1/object_fwd.hpp
@@ -68,6 +68,8 @@ public:
 
 #endif // !defined(MSGPACK_USE_CPP03)
 
+struct object_with_zone_type;
+
 /// Object class that corresponding to MessagePack format object
 /**
  * See https://github.com/msgpack/msgpack-c/wiki/v1_1_cpp_object
@@ -219,7 +221,8 @@ struct object {
     template <typename T>
     object& operator=(const T& v);
 
-    struct with_zone;
+    // Not a nested struct (i.e. 'struct with_zone;') to work around MSVC C++20 modules error C2504
+    typedef object_with_zone_type with_zone;
 
 protected:
     struct implicit_type;


### PR DESCRIPTION
When packaging msgpack into a C++20 module (by #include of msgpack in the global module fragment and then `export using ...;` for relevant names), MSVC (VS 17.13.5) reports the following:

```
error C2504: 'msgpack::v2::object': base class undefined
```

This is apparently due to with_zone being a nested type of msgpack::object; in order to work around this problem, with_zone is replaced with an alias to a struct defined outside of msgpack::object.