### PR TITLE
Include type_traits before use of std:: members

### DIFF
--- a/include/msgpack/v1/cpp_config_decl.hpp
+++ b/include/msgpack/v1/cpp_config_decl.hpp
@@ -87,6 +87,7 @@ struct is_pointer;
 
 #include <memory>
 #include <tuple>
+#include <type_traits>
 
 namespace msgpack {
 /// @cond


### PR DESCRIPTION
msgpack-cpp relies on its users to include, directly or indirectly, the <type_traits> header before including msgpack headers. If they don't, it can't compile, because std::remove_volatile will not be declared. This fixes the issue by including it from msgpack, which should be fine now that msgpack-cpp requires C++11.