### PR TITLE
Fixed processing of empty data in fbuffer class.

### DIFF
--- a/include/msgpack/v1/fbuffer.hpp
+++ b/include/msgpack/v1/fbuffer.hpp
@@ -31,6 +31,7 @@ public:
     {
         MSGPACK_ASSERT(buf || len == 0);
         if (!buf) return;
+        if (len == 0) return;
         if (1 != fwrite(buf, len, 1, m_file)) {
             throw std::runtime_error("fwrite() failed");
         }

--- a/test/buffer.cpp
+++ b/test/buffer.cpp
@@ -90,6 +90,7 @@ BOOST_AUTO_TEST_CASE(fbuffer)
     fbuf.write("a", 1);
     fbuf.write("a", 1);
     fbuf.write("a", 1);
+    fbuf.write("", 0);
 
     fflush(file);
     rewind(file);


### PR DESCRIPTION
This pull request fixes https://github.com/msgpack/msgpack-c/issues/1164 and adds a unit test for the fix.