### PR TITLE
Fix ext32 unpacking of the maximum UINT32_MAX-byte payload

### DIFF
--- a/include/msgpack/unpack_template.h
+++ b/include/msgpack/unpack_template.h
@@ -53,7 +53,7 @@ msgpack_unpack_struct_decl(_stack) {
 msgpack_unpack_struct_decl(_context) {
     msgpack_unpack_user user;
     unsigned int cs;
-    unsigned int trail;
+    size_t trail;
     unsigned int top;
     /*
     msgpack_unpack_struct(_stack)* stack;
@@ -99,7 +99,7 @@ msgpack_unpack_func(int, _execute)(msgpack_unpack_struct(_context)* ctx, const c
         const unsigned char* const pe = (unsigned char*)data + len;
         const void* n = NULL;
 
-        unsigned int trail = ctx->trail;
+        size_t trail = ctx->trail;
         unsigned int cs = ctx->cs;
         unsigned int top = ctx->top;
         msgpack_unpack_struct(_stack)* stack = ctx->stack;
@@ -326,7 +326,7 @@ msgpack_unpack_func(int, _execute)(msgpack_unpack_struct(_context)* ctx, const c
                 case MSGPACK_CS_EXT_16:{
                     uint16_t tmp;
                     _msgpack_load16(uint16_t,n,&tmp);
-                    again_fixed_trail_if_zero(MSGPACK_ACS_EXT_VALUE, tmp + 1, _ext_zero);
+                    again_fixed_trail_if_zero(MSGPACK_ACS_EXT_VALUE, (size_t)tmp + 1, _ext_zero);
                 }
                 case MSGPACK_CS_STR_32:{
                     uint32_t tmp;
@@ -341,7 +341,11 @@ msgpack_unpack_func(int, _execute)(msgpack_unpack_struct(_context)* ctx, const c
                 case MSGPACK_CS_EXT_32:{
                     uint32_t tmp;
                     _msgpack_load32(uint32_t,n,&tmp);
-                    again_fixed_trail_if_zero(MSGPACK_ACS_EXT_VALUE, tmp + 1, _ext_zero);
+                    /* cast before adding: on a 64-bit size_t this lets an ext32 with
+                     * the maximum UINT32_MAX-byte payload carry its trailing type
+                     * byte without wrapping trail back to 0 the way `tmp + 1` would
+                     * when tmp is exactly UINT32_MAX */
+                    again_fixed_trail_if_zero(MSGPACK_ACS_EXT_VALUE, (size_t)tmp + 1, _ext_zero);
                 }
                 case MSGPACK_ACS_STR_VALUE:
                 _str_zero:

--- a/src/unpack.c
+++ b/src/unpack.c
@@ -275,7 +275,7 @@ static inline int template_callback_map_item(unpack_user* u, msgpack_object* c, 
     return 0;
 }
 
-static inline int template_callback_str(unpack_user* u, const char* b, const char* p, unsigned int l, msgpack_object* o)
+static inline int template_callback_str(unpack_user* u, const char* b, const char* p, size_t l, msgpack_object* o)
 {
     MSGPACK_UNUSED(b);
     if (*u->z == NULL) {
@@ -291,7 +291,7 @@ static inline int template_callback_str(unpack_user* u, const char* b, const cha
     return 0;
 }
 
-static inline int template_callback_bin(unpack_user* u, const char* b, const char* p, unsigned int l, msgpack_object* o)
+static inline int template_callback_bin(unpack_user* u, const char* b, const char* p, size_t l, msgpack_object* o)
 {
     MSGPACK_UNUSED(b);
     if (*u->z == NULL) {
@@ -307,7 +307,7 @@ static inline int template_callback_bin(unpack_user* u, const char* b, const cha
     return 0;
 }
 
-static inline int template_callback_ext(unpack_user* u, const char* b, const char* p, unsigned int l, msgpack_object* o)
+static inline int template_callback_ext(unpack_user* u, const char* b, const char* p, size_t l, msgpack_object* o)
 {
     MSGPACK_UNUSED(b);
     if (l == 0) {

--- a/test/msgpack_c.cpp
+++ b/test/msgpack_c.cpp
@@ -642,6 +642,40 @@ TEST(MSGPACKC, simple_buffer_fixext_4byte_65536)
     msgpack_sbuffer_destroy(&sbuf);
 }
 
+TEST(MSGPACKC, simple_buffer_ext_maxlen)
+{
+    // ext32's length header covers up to UINT32_MAX bytes of data, so this
+    // needs roughly 8GB of free memory (the source buffer plus the packed
+    // copy) and will skip itself rather than fail on a host that doesn't
+    // have that much to spare.
+    const size_t size = static_cast<size_t>(UINT32_MAX);
+    void* buf = calloc(size, 1);
+    if (buf == NULL) {
+        GTEST_SKIP() << "not enough memory to allocate a " << size << " byte buffer";
+    }
+
+    msgpack_sbuffer sbuf;
+    msgpack_sbuffer_init(&sbuf);
+    msgpack_packer pk;
+    msgpack_packer_init(&pk, &sbuf, msgpack_sbuffer_write);
+
+    msgpack_pack_ext(&pk, size, 82);
+    msgpack_pack_ext_body(&pk, buf, size);
+    msgpack_zone z;
+    msgpack_zone_init(&z, 2048);
+    msgpack_object obj;
+    msgpack_unpack_return ret =
+        msgpack_unpack(sbuf.data, sbuf.size, NULL, &z, &obj);
+    EXPECT_EQ(MSGPACK_UNPACK_SUCCESS, ret);
+    EXPECT_EQ(MSGPACK_OBJECT_EXT, obj.type);
+    EXPECT_EQ(82, obj.via.ext.type);
+    ASSERT_EQ(size, obj.via.ext.size);
+    EXPECT_EQ(0, memcmp(buf, obj.via.ext.ptr, size));
+    msgpack_zone_destroy(&z);
+    msgpack_sbuffer_destroy(&sbuf);
+    free(buf);
+}
+
 TEST(MSGPACKC, simple_buffer_timestamp_32)
 {
     msgpack_timestamp ts = {


### PR DESCRIPTION
Fixes #1086.

The C unpacker tracks how many bytes are left to read for a variable-length value ("trail") by adding 1 to the wire-format length whenever it's an ext (the extra byte is the ext type tag). For ext8 and ext16 that stays comfortably inside a 32-bit range, but ext32's length field can legitimately be the full `UINT32_MAX`, and `tmp + 1` computed in 32-bit arithmetic wraps around to 0 in that one case. The parser then treats the object as a zero-length ext and bails out immediately through `template_callback_ext`'s `l == 0` guard, so an ext sitting exactly at the wire format's own maximum size fails to unpack with `MSGPACK_UNPACK_PARSE_ERROR`, even though it's a perfectly valid encoding.

Fix: widen the internal `trail` field (and the length parameter the str/bin/ext callbacks receive it through) from `unsigned int` to `size_t`, and cast the ext32 length to `size_t` before adding 1 so the addition itself doesn't wrap on a 64-bit build. This is scoped to the C library specifically (`src/unpack.c` / `unpack_template.h`) - `unpack_template.h` is only ever included from that one file. On a 32-bit build the same boundary case is still unreachable, but that's the same limitation the C++ side already documents as intentional, and a 32-bit process couldn't address a buffer that size in the first place.

Verified with a small standalone reproducer (pack + unpack an ext with exactly `UINT32_MAX` bytes of data): fails with `MSGPACK_UNPACK_PARSE_ERROR` on the current code, succeeds with the correct type/size/contents after this change. Also ran a broader manual check across fixext/ext8/ext16/ext32 and str8/16/32 at several boundary sizes (0, 1, 16, 17, 255, 256, 65535, 65536 bytes) under both `-Wall -Wextra -Werror` and `-fsanitize=undefined` to make sure the wider type didn't change behavior anywhere else - all green.

Added a regression test (`simple_buffer_ext_maxlen` in `test/msgpack_c.cpp`) matching the repro from the issue. It needs roughly 8GB of free memory to allocate the `UINT32_MAX`-byte source buffer plus the packed copy, so it calls `GTEST_SKIP()` instead of failing if `calloc` comes back empty rather than assuming every machine running the suite has that much to spare.